### PR TITLE
Search results retrieval and cache

### DIFF
--- a/src/api/http-common.ts
+++ b/src/api/http-common.ts
@@ -31,10 +31,10 @@ class ApiClient {
       });
   }
 
-  post(url: string, values: any, config = {}) {
+  post<T>(url: string, values: any, config = {}) {
     // console.log(`POST: ${this.baseUrl}${url}`);
     return this.axiosClient
-      .post(`${this.baseUrl}${url}`, values, config)
+      .post<T>(`${this.baseUrl}${url}`, values, config)
       .then((res) => res)
       .catch((err) => {
         console.log(err);

--- a/src/components/forms/SearchForm.tsx
+++ b/src/components/forms/SearchForm.tsx
@@ -42,7 +42,7 @@ const SearchForm = ({ input, placeholder, handleSearchInput, handleSuggestion }:
   };
 
   useEffect(() => {
-    if (input) setTerm(input);
+    if (input || input === "") setTerm(input);
   }, [input]);
 
   useEffect(() => {

--- a/src/constants/cache.ts
+++ b/src/constants/cache.ts
@@ -1,0 +1,3 @@
+export const CACHE_NAME = "CPR_search_cache";
+export const CACHE_LIMIT = 100;
+export const CACHE_EXPIRY = 1000 * 60 * 60 * 24 * 7; // 7 days

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "react";
 import { ApiClient, getEnvFromServer } from "../api/http-common";
 import { initialSearchCriteria } from "../constants/searchCriteria";
-import { TSearch } from "../types";
+import { getCachedSearch, updateCacheSearch, TCacheResult } from "@utils/searchCache";
+import { TFamily, TSearch, TSearchCriteria } from "../types";
 
 type TConfig = {
   headers: {
@@ -24,3 +26,55 @@ export async function getSearch(query = initialSearchCriteria) {
   const results = await client.post<TSearch>(`/searches`, query, config);
   return results;
 }
+
+const useSearch = (query: TSearchCriteria) => {
+  const [status, setStatus] = useState<"fetched" | "loading" | "idle">("idle");
+  const [families, setFamilies] = useState<TFamily[]>([]);
+  const [hits, setHits] = useState<number>(null);
+
+  useEffect(() => {
+    setStatus("loading");
+
+    // Check if we have a cached result before calling the API
+    const cacheId = {
+      query_string: query.query_string,
+      exact_match: query.exact_match,
+      keyword_filters: query.keyword_filters,
+      year_range: query.year_range,
+      sort_field: query.sort_field,
+      sort_order: query.sort_order,
+      offset: query.offset,
+    };
+
+    const cachedResult = getCachedSearch(cacheId);
+
+    if (cachedResult) {
+      setFamilies(cachedResult?.families || []);
+      setHits(cachedResult.hits);
+      setStatus("fetched");
+      return;
+    }
+
+    const resultsQuery = getSearch(query);
+
+    resultsQuery.then((res) => {
+      if (res.status === 200) {
+        setFamilies(res.data.families);
+        setHits(res.data.hits);
+
+        const searchToCache: TCacheResult = {
+          ...cacheId,
+          families: res.data.families,
+          hits: res.data.hits,
+          timestamp: new Date().getTime(),
+        };
+        updateCacheSearch(searchToCache);
+      }
+      setStatus("fetched");
+    });
+  }, [query]);
+
+  return { status, families, hits };
+};
+
+export default useSearch;

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,11 +1,6 @@
-import { useQuery } from "react-query";
 import { ApiClient, getEnvFromServer } from "../api/http-common";
 import { initialSearchCriteria } from "../constants/searchCriteria";
 import { TSearch } from "../types";
-
-type TSearchReturned = {
-  data: TSearch;
-};
 
 type TConfig = {
   headers: {
@@ -14,7 +9,7 @@ type TConfig = {
   };
 };
 
-async function getResults(query = initialSearchCriteria) {
+export async function getSearch(query = initialSearchCriteria) {
   const config: TConfig = {
     headers: {
       accept: "application/json",
@@ -24,23 +19,8 @@ async function getResults(query = initialSearchCriteria) {
 
   const { data } = await getEnvFromServer();
   const client = new ApiClient(data?.env?.api_url);
-  // TODO: remove this as/when the API returns families as default
+  // TODO: remove this attribute as/when the API returns families as default
   query.group_documents = true;
-  const results = await client.post(`/searches`, query, config);
+  const results = await client.post<TSearch>(`/searches`, query, config);
   return results;
-}
-
-export default function useSearch(id: string, query = initialSearchCriteria) {
-  return useQuery<TSearchReturned>(
-    id,
-    async () => {
-      return getResults(query);
-    },
-    {
-      // refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      cacheTime: 1000 * 60 * 60 * 24,
-      staleTime: 1000 * 60 * 60 * 24,
-    }
-  );
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -7,31 +7,40 @@ type TSearchReturned = {
   data: TSearch;
 };
 
-export default function useSearch(id: string, query = initialSearchCriteria) {
-  const config = {
+type TConfig = {
+  headers: {
+    accept: string;
+    "Content-Type": string;
+  };
+};
+
+async function getResults(query = initialSearchCriteria) {
+  const config: TConfig = {
     headers: {
       accept: "application/json",
       "Content-Type": "application/json",
     },
   };
 
-  const getResults = async () => {
-    const { data } = await getEnvFromServer();
-    const client = new ApiClient(data?.env?.api_url);
-    // TODO: remove this as/when the API returns families as default
-    query.group_documents = true;
-    const results = await client.post(`/searches`, query, config);
-    return results;
-  };
+  const { data } = await getEnvFromServer();
+  const client = new ApiClient(data?.env?.api_url);
+  // TODO: remove this as/when the API returns families as default
+  query.group_documents = true;
+  const results = await client.post(`/searches`, query, config);
+  return results;
+}
 
+export default function useSearch(id: string, query = initialSearchCriteria) {
   return useQuery<TSearchReturned>(
     id,
     async () => {
-      return getResults();
+      return getResults(query);
     },
     {
+      // refetchOnMount: false,
       refetchOnWindowFocus: false,
       cacheTime: 1000 * 60 * 60 * 24,
+      staleTime: 1000 * 60 * 60 * 24,
     }
   );
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, ChangeEvent, useMemo } from "react";
+import { useEffect, useState, useRef, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { TDocument } from "@types";
@@ -27,7 +27,6 @@ import SearchResultList from "@components/blocks/SearchResultList";
 import { ExternalLink } from "@components/ExternalLink";
 import Tooltip from "@components/tooltip";
 import { calculatePageCount } from "@utils/paging";
-import buildSearchQuery from "@utils/buildSearchQuery";
 import { PER_PAGE } from "@constants/paging";
 import { DOCUMENT_CATEGORIES } from "@constants/documentCategories";
 import { QUERY_PARAMS } from "@constants/queryParams";
@@ -55,11 +54,7 @@ const Search = () => {
     setShowSlideout(false);
   });
 
-  const searchQuery = useMemo(() => {
-    return buildSearchQuery({ ...router.query });
-  }, [router.query]);
-
-  const { status, families, hits } = useSearch(searchQuery);
+  const { status, families, hits, searchQuery } = useSearch(router.query);
 
   const configQuery = useConfig("config");
   const { data: { document_types = [], sectors = [], regions = [], countries = [] } = {} } = configQuery;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -273,6 +273,7 @@ const Search = () => {
           ...cacheId,
           families: res.data.families,
           hits: res.data.hits,
+          timestamp: new Date().getTime(),
         };
         updateCacheSearch(searchToCache);
       }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -42,7 +42,7 @@ const Search = () => {
   const [showPDF, setShowPDF] = useState(false);
   const [passageIndex, setPassageIndex] = useState(null);
   const [pageCount, setPageCount] = useState(1);
-  const [offset, setOffset] = useState(null);
+  // const [offset, setOffset] = useState(null);
 
   const updateDocument = useUpdateDocument();
   const updateCountries = useUpdateCountries();
@@ -85,8 +85,10 @@ const Search = () => {
   };
 
   const handlePageChange = (page: number) => {
-    setOffset((page - 1) * PER_PAGE);
     setShowSlideout(false);
+    const offSet = (page - 1) * PER_PAGE;
+    router.query[QUERY_PARAMS.offset] = offSet.toString();
+    router.push({ query: router.query });
   };
 
   const handleRegionChange = (type: string, regionName: string) => {
@@ -228,13 +230,6 @@ const Search = () => {
     const offSet = isNaN(parseInt(router.query[QUERY_PARAMS.offset]?.toString())) ? 0 : parseInt(router.query[QUERY_PARAMS.offset]?.toString());
     return offSet / PER_PAGE + 1;
   };
-
-  useEffect(() => {
-    if (offset === null) return;
-    router.query[QUERY_PARAMS.offset] = offset;
-    router.push({ query: router.query });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [offset]);
 
   useEffect(() => {
     if (hits !== undefined) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, ChangeEvent, useMemo } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
-import { TDocument } from "@types";
-import useSearch from "@hooks/useSearch";
+import { TDocument, TFamily } from "@types";
+import { getSearch } from "@hooks/useSearch";
 import useDocument from "@hooks/useDocument";
 import useUpdateDocument from "@hooks/useUpdateDocument";
 import useUpdateCountries from "@hooks/useUpdateCountries";
@@ -31,6 +31,7 @@ import buildSearchQuery from "@utils/buildSearchQuery";
 import { PER_PAGE } from "@constants/paging";
 import { DOCUMENT_CATEGORIES } from "@constants/documentCategories";
 import { QUERY_PARAMS } from "@constants/queryParams";
+import { getCachedSearch, updateCacheSearch, TCacheResult } from "@utils/searchCache";
 
 const Search = () => {
   const router = useRouter();
@@ -42,7 +43,9 @@ const Search = () => {
   const [showPDF, setShowPDF] = useState(false);
   const [passageIndex, setPassageIndex] = useState(null);
   const [pageCount, setPageCount] = useState(1);
-  // const [offset, setOffset] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [families, setFamilies] = useState<TFamily[]>([]);
+  const [hits, setHits] = useState<number>(null);
 
   const updateDocument = useUpdateDocument();
   const updateCountries = useUpdateCountries();
@@ -66,9 +69,12 @@ const Search = () => {
 
   const isBrowsing = !qQueryString || qQueryString?.toString().trim() === "";
 
-  const resultsQuery = useSearch("searches", searchQuery);
-  const families = resultsQuery?.data?.data?.families ?? [];
-  const hits = resultsQuery?.data?.data?.hits ?? 0;
+  // FIXME: remove this
+  // const resultsQuery = useSearch("searches", searchQuery);
+  // const families = resultsQuery?.data?.data?.families ?? [];
+  // const hits = resultsQuery?.data?.data?.hits ?? 0;
+  // const families = [];
+  // const hits = 0;
 
   const { data: document }: { data: TDocument } = ({} = useDocument());
 
@@ -238,9 +244,41 @@ const Search = () => {
   }, [hits]);
 
   useEffect(() => {
-    resultsQuery.refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.query]);
+    setIsLoading(true);
+    // Check if we have a cached result before calling the API
+    const cacheId = {
+      query_string: searchQuery.query_string,
+      exact_match: searchQuery.exact_match,
+      keyword_filters: searchQuery.keyword_filters,
+      year_range: searchQuery.year_range,
+      sort_field: searchQuery.sort_field,
+      sort_order: searchQuery.sort_order,
+      offset: searchQuery.offset,
+    };
+    const cachedResult = getCachedSearch(cacheId);
+    if (cachedResult) {
+      setFamilies(cachedResult?.families || []);
+      setHits(cachedResult.hits);
+      setIsLoading(false);
+      return;
+    }
+
+    const resultsQuery = getSearch(searchQuery);
+    resultsQuery.then((res) => {
+      if (res.status === 200) {
+        setFamilies(res.data.families);
+        setHits(res.data.hits);
+
+        const searchToCache: TCacheResult = {
+          ...cacheId,
+          families: res.data.families,
+          hits: res.data.hits,
+        };
+        updateCacheSearch(searchToCache);
+      }
+      setIsLoading(false);
+    });
+  }, [searchQuery]);
 
   const renderNoOfResults = () => {
     let resultsMsg = `Showing`;
@@ -342,7 +380,7 @@ const Search = () => {
                 <div className="md:w-3/4">
                   <div className="md:pl-8">
                     <div className="lg:flex justify-between">
-                      <div className="text-sm my-4 md:my-0 md:flex">{!resultsQuery.isFetching && renderNoOfResults()}</div>
+                      <div className="text-sm my-4 md:my-0 md:flex">{!isLoading && renderNoOfResults()}</div>
                       <ExternalLink
                         url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform"
                         className="text-sm text-blue-600 mt-4 md:mt-0 hover:underline"
@@ -361,7 +399,7 @@ const Search = () => {
                   </div>
 
                   <div className="search-results md:pl-8 md:mt-12 relative">
-                    {resultsQuery.isFetching ? (
+                    {isLoading ? (
                       <div className="w-full flex justify-center h-96">
                         <Loader />
                       </div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -177,7 +177,7 @@ export type TFamily = {
   family_description_match: boolean;
   family_documents: TFamilyDocument[];
   family_geography: string;
-  family_metadata: {};
+  family_metadata: {}; // TODO: type this
   family_name: string;
   family_slug: string;
   family_source: string;

--- a/src/utils/arrayEquality.ts
+++ b/src/utils/arrayEquality.ts
@@ -1,0 +1,11 @@
+export const arrayOfStringdMatch = (a?: string[], b?: string[]) => {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a.length !== b.length) return false;
+  a.sort();
+  b.sort();
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -2,7 +2,7 @@ import { initialSearchCriteria } from "@constants/searchCriteria";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { TSearchCriteria, TSearchKeywordFilters } from "@types";
 
-type TRouterQuery = {
+export type TRouterQuery = {
   [key: string]: string | string[];
 };
 

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -13,7 +13,7 @@ export function getCookie(cname: string) {
   return "";
 }
 
-export function setCookie(cname: string, cvalue: string) {
+export function setCookie(cname: string, cvalue: string, exdays?: number) {
   const d = new Date();
   let y = d.getFullYear() + 1;
   d.setFullYear(y);

--- a/src/utils/daysBetween.ts
+++ b/src/utils/daysBetween.ts
@@ -1,0 +1,10 @@
+export const daysBetween = function (date1: number, date2: number) {
+  // 1 day in milliseconds
+  var one_day = 1000 * 60 * 60 * 24;
+
+  // calculate the difference in milliseconds
+  var difference_ms = date2 - date1;
+
+  // convert back to nearest days and return
+  return Math.round(difference_ms / one_day);
+};

--- a/src/utils/searchCache.ts
+++ b/src/utils/searchCache.ts
@@ -1,5 +1,6 @@
 import { TFamily, TSearchKeywordFilters } from "@types";
 import { arrayOfStringdMatch } from "./arrayEquality";
+import { CACHE_NAME, CACHE_LIMIT } from "@constants/cache";
 
 export type TCacheIdentifier = {
   query_string: string;
@@ -21,15 +22,13 @@ type TCacheSearch = {
   cache: TCacheResult[];
 };
 
-const LS_CACHE_NAME = "CPR_search_cache";
-
 const getCache = (): TCacheSearch => {
-  const cachedSearch = window.localStorage.getItem(LS_CACHE_NAME);
+  const cachedSearch = window.localStorage.getItem(CACHE_NAME);
   return cachedSearch === null || undefined ? { cache: [] } : JSON.parse(cachedSearch);
 };
 
 const saveCache = (newCache: TCacheSearch) => {
-  window.localStorage.setItem(LS_CACHE_NAME, JSON.stringify(newCache));
+  window.localStorage.setItem(CACHE_NAME, JSON.stringify(newCache));
 };
 
 export const getCachedSearch = (cacheId: TCacheIdentifier) => {
@@ -54,8 +53,11 @@ export const getCachedSearch = (cacheId: TCacheIdentifier) => {
 export const updateCacheSearch = (search: TCacheResult) => {
   if (getCachedSearch(search) !== undefined) return;
   const cache = getCache();
+  if (cache.cache.length > CACHE_LIMIT) {
+    cache.cache.pop();
+  }
   const newCache = {
-    cache: [...cache.cache, search],
+    cache: [search, ...cache.cache],
   };
   saveCache(newCache);
 };

--- a/src/utils/searchCache.ts
+++ b/src/utils/searchCache.ts
@@ -1,0 +1,61 @@
+import { TFamily, TSearchKeywordFilters } from "@types";
+import { arrayOfStringdMatch } from "./arrayEquality";
+
+export type TCacheIdentifier = {
+  query_string: string;
+  exact_match: boolean;
+  keyword_filters?: TSearchKeywordFilters;
+  year_range: [number, number];
+  sort_field: string | null;
+  sort_order: string;
+  offset: number;
+};
+
+export type TCacheResult = TCacheIdentifier & {
+  families: TFamily[];
+  hits: number;
+};
+
+type TCacheSearch = {
+  cache: TCacheResult[];
+};
+
+const LS_CACHE_NAME = "CPR_search_cache";
+
+// Handle all search caching in local storage
+const getCache = (): TCacheSearch => {
+  const cachedSearch = window.localStorage.getItem(LS_CACHE_NAME);
+  return cachedSearch === null || undefined ? { cache: [] } : JSON.parse(cachedSearch);
+};
+
+const saveCache = (newCache: TCacheSearch) => {
+  window.localStorage.setItem(LS_CACHE_NAME, JSON.stringify(newCache));
+};
+
+export const getCachedSearch = (cacheId: TCacheIdentifier) => {
+  const cache = getCache();
+  const { query_string, exact_match, keyword_filters, year_range, sort_field, sort_order, offset } = cacheId;
+  const cachedSearch = cache.cache.find(
+    (search) =>
+      search.query_string === query_string &&
+      search.exact_match === exact_match &&
+      arrayOfStringdMatch(search.keyword_filters?.categories, keyword_filters?.categories) &&
+      arrayOfStringdMatch(search.keyword_filters?.countries, keyword_filters?.countries) &&
+      arrayOfStringdMatch(search.keyword_filters?.regions, keyword_filters?.regions) &&
+      search.year_range[0] === year_range[0] &&
+      search.year_range[1] === year_range[1] &&
+      search.sort_field === sort_field &&
+      search.sort_order === sort_order &&
+      search.offset === offset
+  );
+  return cachedSearch;
+};
+
+export const updateCacheSearch = (search: TCacheResult) => {
+  if (getCachedSearch(search) !== undefined) return;
+  const cache = getCache();
+  const newCache = {
+    cache: [...cache.cache, search],
+  };
+  saveCache(newCache);
+};

--- a/src/utils/searchCache.ts
+++ b/src/utils/searchCache.ts
@@ -14,6 +14,7 @@ export type TCacheIdentifier = {
 export type TCacheResult = TCacheIdentifier & {
   families: TFamily[];
   hits: number;
+  timestamp: number;
 };
 
 type TCacheSearch = {
@@ -22,7 +23,6 @@ type TCacheSearch = {
 
 const LS_CACHE_NAME = "CPR_search_cache";
 
-// Handle all search caching in local storage
 const getCache = (): TCacheSearch => {
   const cachedSearch = window.localStorage.getItem(LS_CACHE_NAME);
   return cachedSearch === null || undefined ? { cache: [] } : JSON.parse(cachedSearch);


### PR DESCRIPTION
Needed to overhaul the search function within the app, key highlights:
- useSearch now manages responsibility of caching, the search query and any API calls
- Search is now cached in local storage - see the utility file

I'm reluctant to separate the code out further until there is need for more abstraction required.