### PR TITLE
Remove Case on top_families and handle potential for family to be falsey

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -77,18 +77,24 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
   const renderDocuments = () => {
     // All
     if (selectedCategoryIndex === 0) {
-      const allFamilies = summary.top_families.Executive.concat(summary.top_families.Legislative).concat(summary.top_families.Case);
+      let allFamilies = summary.top_families.Executive.concat(summary.top_families.Legislative);
       if (allFamilies.length === 0) {
         return renderEmpty();
       }
       allFamilies.sort((a, b) => {
         return new Date(b.family_date).getTime() - new Date(a.family_date).getTime();
       });
-      return allFamilies.slice(0, 5).map((family) => (
-        <div key={family.family_slug} className="mt-4 mb-10">
-          <FamilyListItem family={family} />
-        </div>
-      ));
+      if (allFamilies.length > 5) {
+        allFamilies = allFamilies.slice(0, 5);
+      }
+      return allFamilies.map((family) => {
+        if (family)
+          return (
+            <div key={family.family_slug} className="mt-4 mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          );
+      });
     }
     // Legislative
     if (selectedCategoryIndex === 1) {
@@ -272,7 +278,7 @@ export default CountryPage;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
-  
+
   const id = context.params.id;
   const client = new ApiClient();
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -148,7 +148,7 @@ export type TGeographySummary = {
   family_counts: { Legislative: number; Executive: number; Case: number };
   events: TEvent[];
   targets: string[];
-  top_families: { Legislative: TFamily[]; Executive: TFamily[]; Case: TFamily[] };
+  top_families: { Legislative: TFamily[]; Executive: TFamily[]; };
 };
 
 export type TCategory = "Legislative" | "Executive" | "Litigation" | "Policy" | "Law";


### PR DESCRIPTION
Issue was being caused by concatenating an attribute that was missing, i.e null. It adds an `undefined` into the array which was subsequently failing when trying to access a property of family and then render.

I've both removed the `Case` attribute from `top_families` until we implement it and put in an additional existence check on family before rendering.