### PR TITLE
Revert "Make family summary clickable (#64)"

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -51,13 +51,11 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
         {!isNaN(year) && <span data-cy="result-year">, {year}</span>}
         {children}
       </div>
-      <LinkWithQuery href={`/document/${family_slug}`} passHref>
-        <p
-          className="text-indigo-400 mt-3 text-content"
-          data-cy="result-description"
-          dangerouslySetInnerHTML={{ __html: truncateString(family_description.replace(/(<([^>]+)>)/gi, ""), 375) }}
-        />
-      </LinkWithQuery>
+      <p
+        className="text-indigo-400 mt-3 text-content"
+        data-cy="result-description"
+        dangerouslySetInnerHTML={{ __html: truncateString(family_description.replace(/(<([^>]+)>)/gi, ""), 375) }}
+      />
     </div>
   );
 };

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -253,9 +253,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
                             >
                               {collFamily.title}
                             </LinkWithQuery>
-                            <LinkWithQuery href={`/document/${collFamily.slug}`}>
-                              <p className="mt-2">{collFamily.description}</p>
-                            </LinkWithQuery>
+                            <p className="mt-2">{collFamily.description}</p>
                           </div>
                         ))}
                       </div>


### PR DESCRIPTION
This reverts commit 0072079d13b465c40032a1ba7e448aef24d8a89e.