### PR TITLE
Add 'Search results' to breadcrumb, limit to 50 chars

### DIFF
--- a/e2e/cypress/e2e/cclw/pages/document.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/document.cy.js
@@ -5,6 +5,14 @@ const URL = "documents/jet-zero-strategy_a6a6?q=2050&l=united-kingdom&y=2022&y=2
 
 const pageSelectors = ["h1", '[data-cy="country-link"]', '[data-cy="view-source"]', "#passage-matches", "#pdf-div"];
 
+const breadcrumbSelectors = [
+  "[data-cy='breadcrumbs']",
+  "[data-cy='breadcrumb home']",
+  "[data-cy='breadcrumb category']",
+  "[data-cy='breadcrumb family']",
+  "[data-cy='breadcrumb current']",
+];
+
 describe("Document Page", () => {
   before(() => {
     cy.visit(URL);
@@ -25,8 +33,10 @@ describe("Document Page", () => {
     });
   });
 
-  it("should contain link back to the family page", () => {
-    cy.contains("a", "View document details").should("be.visible");
+  it("should display the breadcrumbs", () => {
+    breadcrumbSelectors.forEach((selector) => {
+      cy.get(selector).should("be.visible");
+    });
   });
 
   it("should display the matches heading", () => {

--- a/e2e/cypress/e2e/cclw/pages/family.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/family.cy.js
@@ -11,6 +11,13 @@ const pageSelectors = ["h1", '[data-cy="country-link"]', '[data-cy="download-tar
 const pageHeadings = ["Related documents", "Targets", "Timeline", "About this document", "Note"];
 const metaHeadings = ["Category", "Type", "Topics", "Sectors"];
 
+const breadcrumbSelectors = [
+  "[data-cy='breadcrumbs']",
+  "[data-cy='breadcrumb home']",
+  "[data-cy='breadcrumb category']",
+  "[data-cy='breadcrumb current']",
+];
+
 describe("Family Page", () => {
   before(() => {
     cy.visit(URL);
@@ -31,6 +38,12 @@ describe("Family Page", () => {
 
   it("should display the page elements", () => {
     pageSelectors.forEach((selector) => {
+      cy.get(selector).should("be.visible");
+    });
+  });
+
+  it("should display the breadcrumbs", () => {
+    breadcrumbSelectors.forEach((selector) => {
       cy.get(selector).should("be.visible");
     });
   });

--- a/e2e/cypress/e2e/cclw/pages/search.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/search.cy.js
@@ -15,7 +15,16 @@ const selectedCountries = '[data-cy="selected-countries"]';
 const tabbedNavSelector = '[data-cy="tabbed-nav"]';
 const sortSelector = '[data-cy="sort"]';
 
-const pageSelectors = [inputSelector, searchResultsSelector, '[data-cy="download-search-csv"]', '[data-cy="number-of-results"]', tabbedNavSelector, sortSelector];
+const pageSelectors = [
+  inputSelector,
+  searchResultsSelector,
+  '[data-cy="download-search-csv"]',
+  '[data-cy="number-of-results"]',
+  tabbedNavSelector,
+  sortSelector,
+];
+
+const breadcrumbSelectors = ["[data-cy='breadcrumbs']", "[data-cy='breadcrumb home']", "[data-cy='breadcrumb current']"];
 
 describe("Search Page", () => {
   before(() => {
@@ -48,6 +57,12 @@ describe("Search Page", () => {
   it("should display the correct page elements", () => {
     pageSelectors.forEach((selector) => {
       cy.get(selector, { timeout: 10000 }).should("be.visible");
+    });
+  });
+
+  it("should display the breadcrumbs", () => {
+    breadcrumbSelectors.forEach((selector) => {
+      cy.get(selector).should("be.visible");
     });
   });
 

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -5,6 +5,7 @@ type TBreadcrumbLink = {
   label: string | React.ReactNode;
   href?: string;
   last?: boolean;
+  cy?: string;
 };
 
 type TProps = {
@@ -14,13 +15,13 @@ type TProps = {
   label: string | React.ReactNode;
 };
 
-const BreadCrumb = ({ last = false, label, href = null }: TBreadcrumbLink) => {
+const BreadCrumb = ({ last = false, label, href = null, cy = "" }: TBreadcrumbLink) => {
   const labelShort =
     typeof label === "string" && label.toString().length > BREADCRUMB_MAXLENGTH ? `${label.toString().substring(0, BREADCRUMB_MAXLENGTH)}...` : label;
-    
+
   return (
     <>
-      <li>
+      <li data-cy={`breadcrumb ${cy}`}>
         {href ? (
           <LinkWithQuery className="underline" href={href}>
             {labelShort}
@@ -37,12 +38,12 @@ const BreadCrumb = ({ last = false, label, href = null }: TBreadcrumbLink) => {
 
 export const BreadCrumbs = ({ geography = null, category = null, family = null, label }: TProps) => {
   return (
-    <ul className="flex flex-wrap gap-2 pt-4">
-      <BreadCrumb label="Home" href="/" />
-      {geography && <BreadCrumb label={geography.label} href={geography.href} />}
-      {category && <BreadCrumb label={category.label} href={category.href} />}
-      {family && <BreadCrumb label={family.label} href={family.href} />}
-      <BreadCrumb label={label} last />
+    <ul className="flex flex-wrap gap-2 pt-4" data-cy="breadcrumbs">
+      <BreadCrumb label="Home" href="/" cy="home" />
+      {geography && <BreadCrumb label={geography.label} href={geography.href} cy="geography" />}
+      {category && <BreadCrumb label={category.label} href={category.href} cy="category" />}
+      {family && <BreadCrumb label={family.label} href={family.href} cy="family" />}
+      <BreadCrumb label={label} last cy="current" />
     </ul>
   );
 };

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { LinkWithQuery } from "@components/LinkWithQuery";
+const BREADCRUMB_MAXLENGTH = 50;
 
 type TBreadcrumbLink = {
   label: string | React.ReactNode;
@@ -14,7 +15,9 @@ type TProps = {
 };
 
 const BreadCrumb = ({ last = false, label, href = null }: TBreadcrumbLink) => {
-  const labelShort = typeof label === "string" && label.toString().length > 50 ? `${label.toString().substring(0, 50)}...` : label;
+  const labelShort =
+    typeof label === "string" && label.toString().length > BREADCRUMB_MAXLENGTH ? `${label.toString().substring(0, BREADCRUMB_MAXLENGTH)}...` : label;
+    
   return (
     <>
       <li>

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -14,15 +14,16 @@ type TProps = {
 };
 
 const BreadCrumb = ({ last = false, label, href = null }: TBreadcrumbLink) => {
+  const labelShort = typeof label === "string" && label.toString().length > 50 ? `${label.toString().substring(0, 50)}...` : label;
   return (
     <>
       <li>
         {href ? (
           <LinkWithQuery className="underline" href={href}>
-            {label}
+            {labelShort}
           </LinkWithQuery>
         ) : (
-          label
+          labelShort
         )}
       </li>
 

--- a/src/components/document/DocumentHead.tsx
+++ b/src/components/document/DocumentHead.tsx
@@ -12,10 +12,9 @@ type TProps = {
     slug: string;
   };
   geography: string;
-  backLink?: string;
 };
 
-export const DocumentHead = ({ document, family, geography, backLink }: TProps) => {
+export const DocumentHead = ({ document, family, geography }: TProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
   const geoName = getCountryName(geography, countries);
@@ -24,13 +23,14 @@ export const DocumentHead = ({ document, family, geography, backLink }: TProps) 
   const breadcrumbGeography = { label: geoName, href: `/geographies/${geoSlug}` };
   const breadcrumbFamily = { label: family.title, href: `/document/${family.slug}` };
   const breadcrumbLabel = isMain ? "Document" : document.document_role.toLowerCase();
+  const breadcrumbCategory = { label: "Search results", href: "/search" };
 
   return (
     <div className="bg-offwhite border-solid border-lineBorder border-b">
       <div className="container">
         <BreadCrumbs
           geography={breadcrumbGeography}
-          category={null}
+          category={breadcrumbCategory}
           family={breadcrumbFamily}
           label={<span className="capitalize">{breadcrumbLabel}</span>}
         />
@@ -50,13 +50,6 @@ export const DocumentHead = ({ document, family, geography, backLink }: TProps) 
                 </span>
               )}
             </div>
-            {backLink && (
-              <div className="mt-4">
-                <LinkWithQuery href={`/document/${backLink}`} className="text-primary-400 hover:underline">
-                  View document details
-                </LinkWithQuery>
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -13,7 +13,7 @@ type TProps = {
 
 export const FamilyHead = ({ family, geographyName, geographySlug, onCollectionClick }: TProps) => {
   const [year] = family.published_date ? convertDate(family.published_date) : "";
-  const breadcrumbCategory = { label: family.category, href: "/search" };
+  const breadcrumbCategory = { label: "Search results", href: "/search" };
   const breadcrumbGeography = { label: geographyName, href: `/geographies/${geographySlug}` };
 
   return (

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -66,7 +66,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
         data-analytics-variant={document.variant}
         data-analytics-type={document.content_type}
       >
-        <DocumentHead document={document} geography={family.geography} backLink={family.slug} family={{ title: family.title, slug: family.slug }} />
+        <DocumentHead document={document} geography={family.geography} family={{ title: family.title, slug: family.slug }} />
         {status !== "success" ? (
           <div className="w-full flex justify-center flex-1">
             <Loader />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -234,7 +234,7 @@ const Search = () => {
       <div>
         <section>
           <div className="px-4 container">
-            <BreadCrumbs label={t("Search")} />
+            <BreadCrumbs label={"Search results"} />
             <div className="md:pb-8 md:pt-4 md:w-3/4 md:mx-auto">
               <p className="md:hidden mt-4 mb-2">{placeholder}</p>
               <SearchForm


### PR DESCRIPTION
Replacing the document category with a more generic 'Search results' link.

Limit breadcrumbs to 50 characters.

Added e2e tests.