### PR TITLE
Ensure that other geographies don't receive links

### DIFF
--- a/e2e/cypress/e2e/cclw/pages/geography.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/geography.cy.js
@@ -53,4 +53,16 @@ describe("Geography Page", () => {
     // Without resetting the page Cypress and Next may get stuck in a GET loop
     cy.visit(geoUrl);
   });
+
+  it("should return a 404 if 'no geography'", () => {
+    cy.request({ url: "/geographies/xaa", failOnStatusCode: false }).its("status").should("equal", 404);
+    // Without resetting the page Cypress and Next may get stuck in a GET loop
+    cy.visit(geoUrl);
+  }); 
+
+  it("should return a 404 if 'international'", () => {
+    cy.request({ url: "/geographies/xab", failOnStatusCode: false }).its("status").should("equal", 404);
+    // Without resetting the page Cypress and Next may get stuck in a GET loop
+    cy.visit(geoUrl);
+  }); 
 });

--- a/next.config.js
+++ b/next.config.js
@@ -41,16 +41,6 @@ const defaultRedirects = [
     permanent: true,
   },
   {
-    source: "/geographies/xaa",
-    destination: "/not-found",
-    permanent: true,
-  },
-  {
-    source: "/geographies/xab",
-    destination: "/not-found",
-    permanent: true,
-  },
-  {
     source: "/cclow",
     destination: "/",
     permanent: true,

--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,16 @@ const defaultRedirects = [
     permanent: true,
   },
   {
+    source: "/geographies/xaa",
+    destination: "/not-found",
+    permanent: true,
+  },
+  {
+    source: "/geographies/xab",
+    destination: "/not-found",
+    permanent: true,
+  },
+  {
     source: "/cclow",
     destination: "/",
     permanent: true,

--- a/src/components/CountryLink.tsx
+++ b/src/components/CountryLink.tsx
@@ -10,6 +10,11 @@ type TCountryLink = {
   children?: ReactNode;
 };
 
+const nonLinkableSlugs = [
+  "xaa", // No Geography
+  "xab" // International
+];
+
 export const CountryLink: FC<TCountryLink> = ({ countryCode, className = "", emptyContentFallback, children }) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
@@ -18,6 +23,8 @@ export const CountryLink: FC<TCountryLink> = ({ countryCode, className = "", emp
   // Force render without any empty content fallback the children without a link
   if (!slug && emptyContentFallback) return <>{emptyContentFallback}</>;
   if (!slug && !emptyContentFallback) return <>{children}</>;
+  if (nonLinkableSlugs.includes(slug)) return <>{children}</>;
+
   return (
     <LinkWithQuery href={`/geographies/${slug}`} className={`flex items-center underline ${className}`} passHref cypress="country-link">
       {children}

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -278,8 +278,19 @@ export default CountryPage;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
-
   const id = context.params.id;
+
+  const ignoredSlugs = [
+    "xaa", // No Geography
+    "xab" // International
+  ];
+
+  if (ignoredSlugs.includes(id as string)) {
+    return {
+      notFound: true,
+    };
+  }
+
   const client = new ApiClient();
 
   let geographyData: TGeographyStats;


### PR DESCRIPTION
Not been able to test as there are no documents in the databse with these geographies on yet.

But here is the database table so you can test by inspection:
```
 id  | display_value | value |          type          | parent_id | slug 
-----+---------------+-------+------------------------+-----------+------
 216 | No Geography  | XAA   | ISO-3166 CPR Extension |       215 | xaa
 217 | International | XAB   | ISO-3166 CPR Extension |       215 | xab
```