### PR TITLE
Remove www from CCLW url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,11 @@
 const defaultRedirects = [
+  // Remove www from all URLs
+  {
+    source: "/:path*",
+    has: [{ type: "host", value: "www.climate-laws.org" }],
+    destination: "https://climate-laws.org/:path*",
+    permanent: true,
+  },
   {
     source: "/auth/:id*",
     destination: "/",

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@ const defaultRedirects = [
   // Remove www from all URLs
   {
     source: "/:path*",
-    has: [{ type: "host", value: "www.climate-laws.org" }],
+    has: [{ type: "header", key: "host", value: "www.climate-laws.org" }],
     destination: "https://climate-laws.org/:path*",
     permanent: true,
   },


### PR DESCRIPTION
Key note: only for the domain `www.climate-laws.org`