### PR TITLE
PDCT 198 - display matches html non english

### DIFF
--- a/e2e/cypress/e2e/cclw/pages/document.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/document.cy.js
@@ -40,7 +40,7 @@ describe("Document Page", () => {
   });
 
   it("should display the matches heading", () => {
-    cy.contains("h3", "Document matches for").should("be.visible");
+    cy.get("[data-cy='document-matches-description']").should("be.visible").should("contain", "Sorted by search relevance");
   });
 
   it("should contain at least 1 passage match", () => {

--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -1,13 +1,16 @@
-import { TPassage } from "@types";
+import { MAX_PASSAGE_LENGTH } from "@constants/document";
 import Loader from "./Loader";
+import { truncateString } from "@helpers/index";
+import { TPassage } from "@types";
 
 type TProps = {
   passages: TPassage[];
   onClick: (index: number) => void;
   activeIndex?: number;
+  showPageNumbers?: boolean;
 };
 
-const PassageMatches = ({ passages, onClick, activeIndex }: TProps) => {
+const PassageMatches = ({ passages, onClick, activeIndex, showPageNumbers = true }: TProps) => {
   return (
     <>
       {!passages ? (
@@ -26,10 +29,12 @@ const PassageMatches = ({ passages, onClick, activeIndex }: TProps) => {
                   onClick(index);
                 }}
               >
-                <div className="text-sm text-blue-500">
-                  <span className="font-bold">Page {item.text_block_page}</span>
-                </div>
-                <p className="mt-2 text-indigo-400 font-light">{item.text}</p>
+                {showPageNumbers && (
+                  <div className="text-sm text-blue-500">
+                    <span className="font-bold">Page {item.text_block_page}</span>
+                  </div>
+                )}
+                <p className="mt-2 text-indigo-400 font-light">{truncateString(item.text, MAX_PASSAGE_LENGTH)}</p>
               </div>
             </div>
           ))}

--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -15,20 +15,19 @@ const PassageMatches = ({ passages, onClick, activeIndex }: TProps) => {
           <Loader />
         </div>
       ) : (
-        <div className="divide-lineBorder divide-y passage-matches-list" id="passage-matches">
+        <div className="my-4" id="passage-matches">
           {passages.map((item, index: number) => (
-            <div key={item.text_block_id} data-analytics-passage={index + 1} id={`passage-${index}`}>
+            <div key={item.text_block_id} data-analytics-passage={index + 1} id={`passage-${index}`} className="mb-4">
               <div
-                className={`p-4 cursor-pointer border-x hover:bg-offwhite ${
-                  activeIndex === index ? "border-lineBorder bg-grey-200" : "border-transparent"
+                className={`p-4 cursor-pointer border border-white rounded-md bg-white hover:border-blue-300 ${
+                  activeIndex === index ? "border-blue-300 bg-blue-100" : ""
                 }`}
                 onClick={() => {
                   onClick(index);
                 }}
               >
-                <div className="text-s text-blue-500">
-                  <span className="font-bold">Page {item.text_block_page} | &nbsp;</span>
-                  <span>go to page &gt;</span>
+                <div className="text-sm text-blue-500">
+                  <span className="font-bold">Page {item.text_block_page}</span>
                 </div>
                 <p className="mt-2 text-indigo-400 font-light">{item.text}</p>
               </div>

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -40,7 +40,7 @@ const Button = ({
       break;
     case "clear":
       conditionalClasses = !disabled
-        ? "clear bg-white border hover:border-blue-400 text-blue-400 disabled:border-indigo-300 disabled:text-indigo-300 disabled:hover:bg-white"
+        ? "clear bg-white border border-gray-300 hover:border-blue-400 text-blue-400 disabled:border-indigo-300 disabled:text-indigo-300 disabled:hover:bg-white"
         : "";
       break;
   }

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -40,7 +40,7 @@ const Button = ({
       break;
     case "clear":
       conditionalClasses = !disabled
-        ? "clear bg-white border hover:border-indigo-600 text-indigo-600 disabled:border-indigo-300 disabled:text-indigo-300 disabled:hover:bg-white"
+        ? "clear bg-white border hover:border-blue-400 text-blue-400 disabled:border-indigo-300 disabled:text-indigo-300 disabled:hover:bg-white"
         : "";
       break;
   }
@@ -60,7 +60,7 @@ const Button = ({
       type={type}
       disabled={disabled}
       data-cy={props["data-cy"]}
-      className={`button transition duration-300 px-4 rounded-sm pointer-events-auto w-full font-bold ${conditionalClasses}`}
+      className={`button transition duration-300 px-4 rounded-full pointer-events-auto w-full font-bold ${conditionalClasses}`}
       {...props}
     >
       {children}

--- a/src/components/document/DocumentHead.tsx
+++ b/src/components/document/DocumentHead.tsx
@@ -7,7 +7,7 @@ import { isSystemGeo } from "@utils/isSystemGeo";
 import { TDocumentFamily, TDocumentPage } from "@types";
 import Button from "@components/buttons/Button";
 import { LinkWithQuery } from "@components/LinkWithQuery";
-import { ExternalLinkIcon } from "@components/svg/Icons";
+import { ExternalLinkIcon, AlertCircleIcon } from "@components/svg/Icons";
 
 type TProps = {
   document: TDocumentPage;
@@ -21,7 +21,10 @@ const containsNonEnglish = (languages: string[]) => {
 const Alert = () => (
   <div className="flex">
     <div className="w-[6px] h-full bg-blue-400 rounded-l-lg"></div>
-    <div className="bg-white p-2 border border-gray-200 border-l-0 rounded-r-lg" role="alert">
+    <div className="bg-white p-2 border border-gray-200 border-l-0 rounded-r-lg flex items-center" role="alert">
+      <div className="mr-1 text-blue-400">
+        <AlertCircleIcon height="16" width="16" />
+      </div>
       <p className="text-sm">
         English translations of this document have been provided by Google Cloud Translate. They may not be 100% accurate. Read our{" "}
         <LinkWithQuery href="/terms-of-use" className="underline">

--- a/src/components/document/DocumentHead.tsx
+++ b/src/components/document/DocumentHead.tsx
@@ -1,24 +1,21 @@
-import useConfig from "@hooks/useConfig";
-import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { CountryLink } from "@components/CountryLink";
 import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { TDocumentPage } from "@types";
+import useConfig from "@hooks/useConfig";
+import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
+import { getLanguage } from "@helpers/getLanguage";
 import { isSystemGeo } from "@utils/isSystemGeo";
+import { TDocumentFamily, TDocumentPage } from "@types";
 
 type TProps = {
   document: TDocumentPage;
-  family: {
-    title: string;
-    slug: string;
-  };
-  geography: string;
+  family: TDocumentFamily;
 };
 
-export const DocumentHead = ({ document, family, geography }: TProps) => {
+export const DocumentHead = ({ document, family }: TProps) => {
   const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
-  const geoName = getCountryName(geography, countries);
-  const geoSlug = getCountrySlug(geography, countries);
+  const { data: { countries = [], languages = {} } = {} } = configQuery;
+  const geoName = getCountryName(family.geography, countries);
+  const geoSlug = getCountrySlug(family.geography, countries);
   const isMain = document.document_role.toLowerCase().includes("main");
   const breadcrumbGeography = { label: geoName, href: `/geographies/${geoSlug}` };
   const breadcrumbFamily = { label: family.title, href: `/document/${family.slug}` };
@@ -26,7 +23,7 @@ export const DocumentHead = ({ document, family, geography }: TProps) => {
   const breadcrumbCategory = { label: "Search results", href: "/search" };
 
   return (
-    <div className="bg-offwhite border-solid border-lineBorder border-b">
+    <div className="bg-white border-solid border-lineBorder border-b">
       <div className="container">
         <BreadCrumbs
           geography={breadcrumbGeography}
@@ -37,18 +34,32 @@ export const DocumentHead = ({ document, family, geography }: TProps) => {
         <div className="flex flex-col md:flex-row">
           <div className="flex-1 my-4">
             <h1 className="text-3xl lg:smaller">{document.title}</h1>
-            <div className="flex text-base text-grey-700 mt-4 items-center w-full font-medium divide-x gap-2 divide-grey-700">
-              {!isSystemGeo(geography) && (
-                <CountryLink countryCode={geography} className="text-primary-400 hover:text-indigo-600 duration-300">
+            <div className="flex text-base text-grey-700 mt-4 items-center w-full font-medium gap-2">
+              {!isSystemGeo(family.geography) && (
+                <CountryLink countryCode={family.geography} className="text-primary-400 hover:text-indigo-600 duration-300">
                   <span>{geoName}</span>
                 </CountryLink>
               )}
-              {!isMain && <span className="pl-2 capitalize">{document.document_role.toLowerCase()}</span>}
+              {!isMain && (
+                <>
+                  <span>&middot;</span>
+                  <span className="capitalize">{document.document_role.toLowerCase()}</span>
+                </>
+              )}
+              {family.category && (
+                <>
+                  <span>&middot;</span>
+                  <span className="capitalize">{family.category}</span>
+                </>
+              )}
               {!!document.language && (
-                <span className="pl-2">
-                  {document.language.toUpperCase()}
-                  {!!document.variant && ` (${document.variant})`}
-                </span>
+                <>
+                  <span>&middot;</span>
+                  <span>
+                    {getLanguage(document.language, languages)}
+                    {!!document.variant && ` (${document.variant})`}
+                  </span>
+                </>
               )}
             </div>
           </div>

--- a/src/components/document/DocumentHead.tsx
+++ b/src/components/document/DocumentHead.tsx
@@ -5,6 +5,7 @@ import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { getLanguage } from "@helpers/getLanguage";
 import { isSystemGeo } from "@utils/isSystemGeo";
 import { TDocumentFamily, TDocumentPage } from "@types";
+import Button from "@components/buttons/Button";
 
 type TProps = {
   document: TDocumentPage;
@@ -22,6 +23,13 @@ export const DocumentHead = ({ document, family }: TProps) => {
   const breadcrumbLabel = isMain ? "Document" : document.document_role.toLowerCase();
   const breadcrumbCategory = { label: "Search results", href: "/search" };
 
+  const handleViewSourceClick = (e: React.FormEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const url = document.content_type === "application/pdf" ? document.cdn_object : document.source_url;
+    if (!url) return;
+    window.open(url);
+  };
+
   return (
     <div className="bg-white border-solid border-lineBorder border-b">
       <div className="container">
@@ -34,33 +42,40 @@ export const DocumentHead = ({ document, family }: TProps) => {
         <div className="flex flex-col md:flex-row">
           <div className="flex-1 my-4">
             <h1 className="text-3xl lg:smaller">{document.title}</h1>
-            <div className="flex text-base text-grey-700 mt-4 items-center w-full font-medium gap-2">
-              {!isSystemGeo(family.geography) && (
-                <CountryLink countryCode={family.geography} className="text-primary-400 hover:text-indigo-600 duration-300">
-                  <span>{geoName}</span>
-                </CountryLink>
-              )}
-              {!isMain && (
-                <>
-                  <span>&middot;</span>
-                  <span className="capitalize">{document.document_role.toLowerCase()}</span>
-                </>
-              )}
-              {family.category && (
-                <>
-                  <span>&middot;</span>
-                  <span className="capitalize">{family.category}</span>
-                </>
-              )}
-              {!!document.language && (
-                <>
-                  <span>&middot;</span>
-                  <span>
-                    {getLanguage(document.language, languages)}
-                    {!!document.variant && ` (${document.variant})`}
-                  </span>
-                </>
-              )}
+            <div className="mt-4 md:mt-0 md:flex justify-between items-center">
+              <div className="flex text-base text-grey-700 items-center font-medium gap-2">
+                {!isSystemGeo(family.geography) && (
+                  <CountryLink countryCode={family.geography} className="text-primary-400 hover:text-indigo-600 duration-300">
+                    <span>{geoName}</span>
+                  </CountryLink>
+                )}
+                {!isMain && (
+                  <>
+                    <span>&middot;</span>
+                    <span className="capitalize">{document.document_role.toLowerCase()}</span>
+                  </>
+                )}
+                {family.category && (
+                  <>
+                    <span>&middot;</span>
+                    <span className="capitalize">{family.category}</span>
+                  </>
+                )}
+                {!!document.language && (
+                  <>
+                    <span>&middot;</span>
+                    <span>
+                      {getLanguage(document.language, languages)}
+                      {!!document.variant && ` (${document.variant})`}
+                    </span>
+                  </>
+                )}
+              </div>
+              <div className="mt-4 md:mt-0">
+                <Button color="clear" data-cy="view-source" onClick={handleViewSourceClick}>
+                  View source document
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/document/DocumentHead.tsx
+++ b/src/components/document/DocumentHead.tsx
@@ -6,11 +6,32 @@ import { getLanguage } from "@helpers/getLanguage";
 import { isSystemGeo } from "@utils/isSystemGeo";
 import { TDocumentFamily, TDocumentPage } from "@types";
 import Button from "@components/buttons/Button";
+import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLinkIcon } from "@components/svg/Icons";
 
 type TProps = {
   document: TDocumentPage;
   family: TDocumentFamily;
 };
+
+const containsNonEnglish = (languages: string[]) => {
+  return languages.some((lang) => lang !== "eng");
+};
+
+const Alert = () => (
+  <div className="flex">
+    <div className="w-[6px] h-full bg-blue-400 rounded-l-lg"></div>
+    <div className="bg-white p-2 border border-gray-200 border-l-0 rounded-r-lg" role="alert">
+      <p className="text-sm">
+        English translations of this document have been provided by Google Cloud Translate. They may not be 100% accurate. Read our{" "}
+        <LinkWithQuery href="/terms-of-use" className="underline">
+          Terms of Use
+        </LinkWithQuery>{" "}
+        for more information.
+      </p>
+    </div>
+  </div>
+);
 
 export const DocumentHead = ({ document, family }: TProps) => {
   const configQuery = useConfig();
@@ -22,6 +43,7 @@ export const DocumentHead = ({ document, family }: TProps) => {
   const breadcrumbFamily = { label: family.title, href: `/document/${family.slug}` };
   const breadcrumbLabel = isMain ? "Document" : document.document_role.toLowerCase();
   const breadcrumbCategory = { label: "Search results", href: "/search" };
+  const translated = containsNonEnglish(document.languages);
 
   const handleViewSourceClick = (e: React.FormEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -43,7 +65,7 @@ export const DocumentHead = ({ document, family }: TProps) => {
           <div className="flex-1 my-4">
             <h1 className="text-3xl lg:smaller">{document.title}</h1>
             <div className="mt-4 md:mt-0 md:flex justify-between items-center">
-              <div className="flex text-base text-grey-700 items-center font-medium gap-2">
+              <div className="flex text-sm text-grey-700 items-center font-medium gap-2">
                 {!isSystemGeo(family.geography) && (
                   <CountryLink countryCode={family.geography} className="text-primary-400 hover:text-indigo-600 duration-300">
                     <span>{geoName}</span>
@@ -72,11 +94,16 @@ export const DocumentHead = ({ document, family }: TProps) => {
                 )}
               </div>
               <div className="mt-4 md:mt-0">
-                <Button color="clear" data-cy="view-source" onClick={handleViewSourceClick}>
-                  View source document
+                <Button color="clear" data-cy="view-source" onClick={handleViewSourceClick} extraClasses="flex items-center">
+                  <ExternalLinkIcon height="16" width="16" /> <span className="ml-2">View source document</span>
                 </Button>
               </div>
             </div>
+            {translated && (
+              <div className="flex mt-4">
+                <Alert />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -25,7 +25,7 @@ export const FamilyHead = ({ family, geographyName, geographySlug, onCollectionC
           <div className="flex-1 my-4">
             <h1 className="text-3xl lg:smaller">{family.title}</h1>
             {family.collections.length > 0 && (
-              <div className="flex text-base text-indigo-400 mt-4 items-center w-full mb-2 font-medium">
+              <div className="flex text-sm text-indigo-400 mt-4 items-center w-full mb-2 font-medium">
                 <span>Part of the&nbsp;</span>
                 {family.collections.length > 0 &&
                   family.collections.map((collection, i) => (
@@ -42,7 +42,7 @@ export const FamilyHead = ({ family, geographyName, geographySlug, onCollectionC
                   ))}
               </div>
             )}
-            <div className="flex text-base text-grey-700 mt-4 items-center w-full font-medium divide-grey-700">
+            <div className="flex text-sm text-grey-700 mt-4 items-center w-full font-medium divide-grey-700">
               {!isSystemGeo(family.geography) ? (
                 <CountryLink countryCode={family.geography} className="text-primary-400 hover:text-indigo-600 duration-300">
                   <span data-analytics-country={geographyName}>{geographyName}</span>

--- a/src/components/svg/Icons.tsx
+++ b/src/components/svg/Icons.tsx
@@ -506,3 +506,31 @@ export const SpeakerIcon = ({ height = "32", width = "32", color = "currentColor
     </svg>
   );
 };
+
+export const AlertCircleIcon = ({ height = "24", width = "24", color = "currentColor" }: IconProps) => {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: `${width}px`, height: `${height}px` }}>
+      <path
+        d="M12 8V12M12 16H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+        stroke={color}
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export const BookOpenIcon = ({ height = "24", width = "24", color = "currentColor" }: IconProps) => {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: `${width}px`, height: `${height}px` }}>
+      <path
+        d="M12 7C12 5.93913 11.5786 4.92172 10.8284 4.17157C10.0783 3.42143 9.06087 3 8 3H2V18H9C9.79565 18 10.5587 18.3161 11.1213 18.8787C11.6839 19.4413 12 20.2044 12 21M12 7V21M12 7C12 5.93913 12.4214 4.92172 13.1716 4.17157C13.9217 3.42143 14.9391 3 16 3H22V18H15C14.2044 18 13.4413 18.3161 12.8787 18.8787C12.3161 19.4413 12 20.2044 12 21"
+        stroke={color}
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/components/svg/Icons.tsx
+++ b/src/components/svg/Icons.tsx
@@ -513,9 +513,9 @@ export const AlertCircleIcon = ({ height = "24", width = "24", color = "currentC
       <path
         d="M12 8V12M12 16H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
         stroke={color}
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );
@@ -527,9 +527,9 @@ export const BookOpenIcon = ({ height = "24", width = "24", color = "currentColo
       <path
         d="M12 7C12 5.93913 11.5786 4.92172 10.8284 4.17157C10.0783 3.42143 9.06087 3 8 3H2V18H9C9.79565 18 10.5587 18.3161 11.1213 18.8787C11.6839 19.4413 12 20.2044 12 21M12 7V21M12 7C12 5.93913 12.4214 4.92172 13.1716 4.17157C13.9217 3.42143 14.9391 3 16 3H22V18H15C14.2044 18 13.4413 18.3161 12.8787 18.8787C12.3161 19.4413 12 20.2044 12 21"
         stroke={color}
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/src/constants/document.ts
+++ b/src/constants/document.ts
@@ -1,3 +1,5 @@
-export const initialSummaryLength = 1400;
+export const MAX_FAMILY_SUMMARY_LENGTH = 1400;
+
+export const MAX_PASSAGE_LENGTH = 250;
 
 export const PDF_SCROLL_DELAY = 100;

--- a/src/helpers/getLanguage.ts
+++ b/src/helpers/getLanguage.ts
@@ -1,0 +1,5 @@
+import { TLanguages } from "@types";
+
+export const getLanguage = (languageKey: string, dataSet: TLanguages) => {
+  return dataSet[languageKey];
+};

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "react-query";
 import { ApiClient, getEnvFromServer } from "../api/http-common";
 import { extractNestedData } from "@utils/extractNestedData";
-import { TGeography } from "@types";
+import { TGeography, TLanguages } from "@types";
 
 type TDataNode<T> = {
   node: T;
@@ -12,6 +12,7 @@ type TQueryResponse = {
   geographies: TDataNode<TGeography>[];
   regions: TGeography[];
   countries: TGeography[];
+  languages: TLanguages;
 };
 
 export default function useConfig() {
@@ -30,6 +31,7 @@ export default function useConfig() {
         geographies,
         regions,
         countries,
+        languages: query_response.data.languages,
       };
       return resp_end;
     },

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -56,8 +56,8 @@ function generateHighlights(document: TDocumentPage, documentPassageMatches: TPa
 
 export default function usePDFPreview(document: TDocumentPage, documentPassageMatches: TPassage[], adobeKey: string) {
   const viewerConfig = {
-    showDownloadPDF: true,
-    showPrintPDF: true,
+    showDownloadPDF: false,
+    showPrintPDF: false,
     showLeftHandPanel: false,
     enableAnnotationAPIs: true,
     includePDFAnnotations: true,

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -24,7 +24,7 @@ async function getSearch(query = initialSearchCriteria) {
   const client = new ApiClient(data?.env?.api_url);
   // TODO: remove this later when BE is updated
   query["jit_query"] = "disabled";
-  query["include_results"] = ["htmlsNonTranslated"];
+  query["include_results"] = ["htmlsNonTranslated", "pdfsTranslated"];
   const results = await client.post<TSearch>("/searches", query, config);
   return results;
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -24,6 +24,7 @@ async function getSearch(query = initialSearchCriteria) {
   const client = new ApiClient(data?.env?.api_url);
   // TODO: remove this later when BE is updated
   query["jit_query"] = "disabled";
+  query["include_results"] = ["htmlsNonTranslated"];
   const results = await client.post<TSearch>("/searches", query, config);
   return results;
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -24,7 +24,7 @@ async function getSearch(query = initialSearchCriteria) {
   const client = new ApiClient(data?.env?.api_url);
   // TODO: remove this later when BE is updated
   query["jit_query"] = "disabled";
-  query["include_results"] = ["htmlsNonTranslated", "pdfsTranslated"];
+  query["include_results"] = ["htmlsNonTranslated", "pdfsTranslated", "htmlsTranslated"];
   const results = await client.post<TSearch>("/searches", query, config);
   return results;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -37,7 +37,7 @@ function getThemeColours(theme: string): string {
       --color-indigo-600:#2B2F49;
       --color-indigo-700:#2B2F49;
       --color-sky:#fde1e3;
-      --color-blue-100:#e8f3fe;
+      --color-blue-100:#f4e8e9;
       --color-blue-200:#e2aeb2;
       --color-blue-300:#ED3D48;
       --color-blue-400:#ED3D48;

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Script from "next/script";
+import { useRouter } from "next/router";
+import { usePathname } from "next/navigation";
+import axios from "axios";
 import { ApiClient } from "@api/http-common";
 import Layout from "@components/layouts/Main";
 import DocumentInfo from "@components/blocks/DocumentInfo";
@@ -12,26 +15,30 @@ import { ExternalLink } from "@components/ExternalLink";
 import { Targets } from "@components/Targets";
 import { ShowHide } from "@components/controls/ShowHide";
 import { Divider } from "@components/dividers/Divider";
-import { initialSummaryLength } from "@constants/document";
-import { truncateString } from "@helpers/index";
-import { TFamilyPage, TMatchedFamily, TTarget } from "@types";
-import useSearch from "@hooks/useSearch";
-import { useRouter } from "next/router";
-import { usePathname } from "next/navigation";
 import { QUERY_PARAMS } from "@constants/queryParams";
-import axios from "axios";
 import { TargetIcon } from "@components/svg/Icons";
 import Button from "@components/buttons/Button";
 import { LinkWithQuery } from "@components/LinkWithQuery";
+import useSearch from "@hooks/useSearch";
 import useConfig from "@hooks/useConfig";
+import { truncateString } from "@helpers/index";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
-import { sortFilterTargets } from "@utils/sortFilterTargets";
 import { getOrganisationNote } from "@helpers/getOrganisationNote";
+import { sortFilterTargets } from "@utils/sortFilterTargets";
+import { initialSummaryLength } from "@constants/document";
+import { TFamilyPage, TMatchedFamily, TTarget } from "@types";
 
 type TProps = {
   page: TFamilyPage;
   targets: TTarget[];
 };
+
+/*
+  # DEV NOTES
+  - This page displays a single document family and its associated documents, meta data, targets, and events.
+  - Families can contain multiple documents, often referred to as 'physical documents'.
+  - The 'physical document' view is within the folder: src/pages/documents/[id].tsx.
+*/
 
 const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ page, targets = [] }: TProps) => {
   const router = useRouter();

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -25,7 +25,7 @@ import { truncateString } from "@helpers/index";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { getOrganisationNote } from "@helpers/getOrganisationNote";
 import { sortFilterTargets } from "@utils/sortFilterTargets";
-import { initialSummaryLength } from "@constants/document";
+import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { TFamilyPage, TMatchedFamily, TTarget } from "@types";
 
 type TProps = {
@@ -109,7 +109,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
       if (showFullSummary) {
         setSummary(text);
       } else {
-        setSummary(truncateString(text, initialSummaryLength));
+        setSummary(truncateString(text, MAX_FAMILY_SUMMARY_LENGTH));
       }
     }
   }, [page, showFullSummary]);
@@ -135,7 +135,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
             <section className="flex-1 md:w-0">
               <section className="mt-6">
                 <div className="text-content mt-4" dangerouslySetInnerHTML={{ __html: summary }} />
-                {page.summary.length > initialSummaryLength && (
+                {page.summary.length > MAX_FAMILY_SUMMARY_LENGTH && (
                   <div className="mt-6 flex justify-end">
                     {showFullSummary ? (
                       <button onClick={() => setShowFullSummary(false)} className="text-blue-500 font-medium">

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -72,7 +72,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
               <div className="md:flex md:h-[80vh]">
                 {hasPassageMatches && (
                   <div className={`overflow-y-scroll pr-4 max-h-[30vh] md:block md:max-h-full ${passageClasses(document.content_type)}`}>
-                    <div className="my-4">
+                    <div className="my-4" data-cy="document-matches-description">
                       <p className="">
                         {passageMatches.length} matches for "<b>{`${router.query[QUERY_PARAMS.query_string]}`}</b>"
                         {!searchQuery.exact_match && ` and related phrases`}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -12,6 +12,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 import Loader from "@components/Loader";
 import { getDocumentDescription } from "@constants/metaDescriptions";
 import { ExternalLink } from "@components/ExternalLink";
+import { BookOpenIcon } from "@components/svg/Icons";
 
 type TProps = {
   document: TDocumentPage;
@@ -90,7 +91,10 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
                   <div className={`pt-4 flex-1 h-[400px] md:block md:h-full ${hasPassageMatches ? "md:border-l md:border-l-gray-200" : ""}`}>
                     {canPreview && <EmbeddedPDF document={document} documentPassageMatches={passageMatches} passageIndex={passageIndex} />}
                     {!canPreview && (
-                      <div className="flex flex-col justify-center items-center h-full ml-4 border border-gray-300 rounded-lg text-center text-gray-600">
+                      <div className="ml-4 text-center text-gray-600">
+                        <div className="mb-2 flex justify-center">
+                          <BookOpenIcon />
+                        </div>
                         <p className="mb-2">Document Preview</p>
                         <p className="mb-2 text-sm">
                           You’ll soon be able to view the full-text of the document here, along with the English translation.

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -62,7 +62,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       >
         <DocumentHead document={document} family={family} />
         {status !== "success" ? (
-          <div className="w-full flex justify-center flex-1">
+          <div className="w-full flex justify-center flex-1 bg-white">
             <Loader />
           </div>
         ) : (

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -96,7 +96,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
                           You’ll soon be able to view the full-text of the document here, along with the English translation.
                         </p>
                         <p className="text-sm">
-                          <ExternalLink className="underline" url="https://3566c5a7.sibforms.com/serve/MUIEAPkXK4liqQjleE87527EfcD9gDzY26dQhnJOxNeXZK_TvEAjl_Qu7rrkysJS2ODrj1LioiH24HTGbul2vS1sAxYCPHtu7PgnhZrAE9yCfaFrJ7vzmvBc3u87cs_pkC_99nQ2AqBONHtLwErrV7mcVga2qNlO1xetSeqVVWYsrVPRjg6Rc978eQEMasGQc4PFgIfMFza8TJEv">
+                          <ExternalLink className="underline" url="https://forms.gle/yJTRdwTNBdTesexW8">
                             Sign up here
                           </ExternalLink>{" "}
                           to be notified when it’s available.

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -10,8 +10,8 @@ import { TDocumentFamily, TDocumentPage } from "@types";
 import useSearch from "@hooks/useSearch";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import Loader from "@components/Loader";
-import Button from "@components/buttons/SquareButton";
 import { getDocumentDescription } from "@constants/metaDescriptions";
+import { ExternalLink } from "@components/ExternalLink";
 
 type TProps = {
   document: TDocumentPage;
@@ -89,6 +89,20 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
                 {status === "success" && (
                   <div className={`pt-4 flex-1 h-[400px] md:block md:h-full ${hasPassageMatches ? "md:border-l md:border-l-gray-200" : ""}`}>
                     {canPreview && <EmbeddedPDF document={document} documentPassageMatches={passageMatches} passageIndex={passageIndex} />}
+                    {!canPreview && (
+                      <div className="flex flex-col justify-center items-center h-full ml-4 border border-gray-300 rounded-lg text-center text-gray-600">
+                        <p className="mb-2">Document Preview</p>
+                        <p className="mb-2 text-sm">
+                          You’ll soon be able to view the full-text of the document here, along with the English translation.
+                        </p>
+                        <p className="text-sm">
+                          <ExternalLink className="underline" url="https://3566c5a7.sibforms.com/serve/MUIEAPkXK4liqQjleE87527EfcD9gDzY26dQhnJOxNeXZK_TvEAjl_Qu7rrkysJS2ODrj1LioiH24HTGbul2vS1sAxYCPHtu7PgnhZrAE9yCfaFrJ7vzmvBc3u87cs_pkC_99nQ2AqBONHtLwErrV7mcVga2qNlO1xetSeqVVWYsrVPRjg6Rc978eQEMasGQc4PFgIfMFza8TJEv">
+                            Sign up here
+                          </ExternalLink>{" "}
+                          to be notified when it’s available.
+                        </p>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -28,7 +28,7 @@ const passageClasses = (docType: string) => {
 const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ document, family }: TProps) => {
   const [passageIndex, setPassageIndex] = useState(null);
   const router = useRouter();
-  const { status, families } = useSearch(router.query, !!router.query[QUERY_PARAMS.query_string]);
+  const { status, families, searchQuery } = useSearch(router.query, !!router.query[QUERY_PARAMS.query_string]);
 
   const passageMatches = [];
   if (!!router.query[QUERY_PARAMS.query_string]) {
@@ -42,13 +42,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   }
   const hasPassageMatches = passageMatches.length > 0;
   const canPreview = document.content_type === "application/pdf";
-
-  const handleViewSourceClick = (e: React.FormEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    const url = document.content_type === "application/pdf" ? document.cdn_object : document.source_url;
-    if (!url) return;
-    window.open(url);
-  };
 
   const handlePassageClick = (index: number) => {
     setPassageIndex(index);
@@ -74,20 +67,13 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
         ) : (
           <section className="flex-1 flex" id="document-viewer">
             <div className="container flex-1">
-              {/* <div className="flex flex-col md:flex-row justify-between items-center pb-4 border-b border-lineBorder gap-4">
-                {hasPassageMatches && <h3>Document matches for {`'${router.query[QUERY_PARAMS.query_string]}' (${passageMatches.length})`}</h3>}
-                <div className="flex-1 flex justify-end">
-                  <Button data-cy="view-source" onClick={handleViewSourceClick}>
-                    View source document
-                  </Button>
-                </div>
-              </div> */}
               <div className="md:flex md:h-[80vh]">
                 {hasPassageMatches && (
                   <div className={`overflow-y-scroll pr-4 max-h-[30vh] md:block md:max-h-full ${passageClasses(document.content_type)}`}>
                     <div className="my-4">
                       <p className="">
                         {passageMatches.length} matches for "<b>{`${router.query[QUERY_PARAMS.query_string]}`}</b>"
+                        {!searchQuery.exact_match && ` and related phrases`}
                       </p>
                       <p className="text-sm">Sorted by search relevance</p>
                     </div>

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -44,6 +44,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   const canPreview = document.content_type === "application/pdf";
 
   const handlePassageClick = (index: number) => {
+    if (!canPreview) return;
     setPassageIndex(index);
     setTimeout(() => {
       window.document.getElementById("document-viewer").scrollIntoView({ behavior: "smooth" });

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -6,25 +6,16 @@ import { DocumentHead } from "@components/document/DocumentHead";
 import Layout from "@components/layouts/Main";
 import EmbeddedPDF from "@components/EmbeddedPDF";
 import PassageMatches from "@components/PassageMatches";
-import { TDocumentPage } from "@types";
+import { TDocumentFamily, TDocumentPage } from "@types";
 import useSearch from "@hooks/useSearch";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import Loader from "@components/Loader";
 import Button from "@components/buttons/SquareButton";
 import { getDocumentDescription } from "@constants/metaDescriptions";
 
-type TDocFamily = {
-  title: string;
-  import_id: string;
-  geography: string;
-  slug: string;
-  published_date: string;
-  last_updated_date: string;
-};
-
 type TProps = {
   document: TDocumentPage;
-  family: TDocFamily;
+  family: TDocumentFamily;
 };
 
 const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ document, family }: TProps) => {
@@ -60,13 +51,13 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   return (
     <Layout title={`${document.title}`} description={getDocumentDescription(document.title)}>
       <section
-        className="mb-8 flex-1 flex flex-col"
+        className="pb-8 flex-1 flex flex-col bg-gray-100"
         data-analytics-date={family.published_date}
         data-analytics-geography={family.geography}
         data-analytics-variant={document.variant}
         data-analytics-type={document.content_type}
       >
-        <DocumentHead document={document} geography={family.geography} family={{ title: family.title, slug: family.slug }} />
+        <DocumentHead document={document} family={family} />
         {status !== "success" ? (
           <div className="w-full flex justify-center flex-1">
             <Loader />
@@ -115,7 +106,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const client = new ApiClient(process.env.API_URL);
 
   let documentData: TDocumentPage;
-  let familyData: TDocFamily;
+  let familyData: TDocumentFamily;
 
   try {
     const { data: returnedData } = await client.get(`/documents/${id}`, { group_documents: true });

--- a/src/sites/cclw/components/Footer.tsx
+++ b/src/sites/cclw/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
   };
 
   return (
-    <footer className="flex flex-col bg-grey-400 mt-12">
+    <footer className="flex flex-col bg-grey-400">
       <div className="py-12">
         <div className="container">
           <p className="text-lg mb-6 md:text-center" data-cy="report-problem">

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -536,14 +536,6 @@ ul li.selected {
     }
   }
 }
-.passage-matches-list {
-  > *:first-child > * {
-    @apply border-t;
-  }
-  > *:last-child > * {
-    @apply border-b;
-  }
-}
 
 .family-document {
   &:hover {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -242,6 +242,16 @@ export type TDocumentPage = {
   document_role: string;
 };
 
+export type TDocumentFamily = {
+  title: string;
+  import_id: string;
+  geography: string;
+  category: TCategory;
+  slug: string;
+  published_date: string;
+  last_updated_date: string;
+};
+
 export type TCollection = {
   import_id: string;
   title: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -238,6 +238,7 @@ export type TDocumentPage = {
   source_url: string;
   content_type: TDocumentContentType;
   language: string;
+  languages: string[];
   document_type: string;
   document_role: string;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -278,3 +278,7 @@ export type TSearch = {
 };
 
 export type TLoadingStatus = "idle" | "loading" | "success" | "error";
+
+export type TLanguages = {
+  [key: string]: string;
+};


### PR DESCRIPTION
Support matching passages for:
- Non-English PDFs
- HTML documents

Also
- Display actual language name rather than 3-letter system value
- Add styling updates to the document viewer page