### PR TITLE
Don't set 'All' as the category as it is invalid

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -76,7 +76,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
     const newQuery = {};
     newQuery[QUERY_PARAMS.country] = geography.geography_slug;
     const documentCategory = categoryByIndex[selectedCategoryIndex] ?? null;
-    if (documentCategory) {
+    if (documentCategory && documentCategory !== "All") {
       newQuery[QUERY_PARAMS.category] = documentCategory;
     }
     router.push({ pathname: "/search", query: { ...newQuery } });


### PR DESCRIPTION
Bug was:
- Incorrectly setting the category in the query string to 'All' this was then passing null in the API which was returning a 422