### PR TITLE
Prevent Adobe embedApi.gotoLocation if no passage matches

### DIFF
--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -100,9 +100,9 @@ export default function usePDFPreview(document: TDocumentPage, documentPassageMa
     if (!embedApi) {
       return;
     }
-    if (passageIndex === null) return;
+    if (passageIndex === null || !documentPassageMatches[passageIndex]) return;
     setTimeout(() => {
-      embedApi.gotoLocation(documentPassageMatches[passageIndex].text_block_page);
+      embedApi.gotoLocation(documentPassageMatches[passageIndex]?.text_block_page);
     }, PDF_SCROLL_DELAY);
   };
 


### PR DESCRIPTION
Bug introduced by me last week.

We should not attempt to navigate to the first passage match if we do not have any.

Causes a console error on prod, so it is not impacting the user directly, but still important to fix for obvious reasons.