### PR TITLE
Feature/pdct 455 put country page search box at bottom of family and physical document

### DIFF
--- a/src/components/forms/DocumentSearchForm.tsx
+++ b/src/components/forms/DocumentSearchForm.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect, useRef } from "react";
+import SearchForm from "./SearchForm";
+
+interface DocumentSearchFormProps {
+  input?: string;
+  placeholder: string;
+  handleSearchInput(term: string): void;
+  featuredSearches: string[];
+}
+
+const DocumentSearchForm = ({ input, placeholder, handleSearchInput, featuredSearches }: DocumentSearchFormProps) => {
+  return (
+    <div className="p-4 rounded-xl bg-blue-100">
+      <SearchForm placeholder={placeholder} handleSearchInput={handleSearchInput} input={""} />
+      <div className="mt-4 md:flex gap-2 text-sm">
+        <div className="mb-2 md:mb-0 flex-shrink-0 text-blue-900 pt-1">Featured searches</div>
+        <ul className="flex gap-1 flex-wrap items-center">
+          {featuredSearches.map((searchTerm) => (
+            <li key={searchTerm}>
+              <button
+                onClick={() => handleSearchInput(searchTerm)}
+                className="text-gray-800 bg-white border border-gray-300 rounded-[40px] py-1 px-2 transition hover:bg-blue-600 hover:text-white"
+              >
+                {searchTerm}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+export default DocumentSearchForm;

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -27,10 +27,9 @@ import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { getOrganisationNote } from "@helpers/getOrganisationNote";
 import { sortFilterTargets } from "@utils/sortFilterTargets";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
-import { TFamilyPage, TMatchedFamily, TTarget } from "@types";
+import { TFamilyPage, TMatchedFamily, TTarget, TGeographySummary } from "@types";
 import Tooltip from "@components/tooltip";
 import SearchForm from "@components/forms/SearchForm";
-import { TGeographySummary } from "@types";
 
 type TProps = {
   page: TFamilyPage;
@@ -99,11 +98,8 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
   const sourceLogo = page?.organisation === "CCLW" ? "grantham-logo.png" : null;
   const sourceName = page?.organisation === "CCLW" ? "Grantham Research Institute" : page?.organisation;
 
-  const allDocumentsCount = () => {
-    const allDocumentsCount =
-      geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
-    return allDocumentsCount;
-  };
+  const totalDocsInPageGeography =
+    geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
 
   const mainDocs = page.documents.filter((doc) => doc.document_role && doc.document_role.toLowerCase().includes("main"));
   const otherDocs = page.documents.filter((doc) => !doc.document_role || !doc.document_role.toLowerCase().includes("main"));
@@ -307,7 +303,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
             <h3 className="mb-4">Documents</h3>
             <div className="p-4 rounded-xl bg-blue-100">
               <SearchForm
-                placeholder={`Search the full text of ${allDocumentsCount()} documents from ${geographyName}`}
+                placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
                 handleSearchInput={handleSearchInput}
                 input={""}
               />

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -98,8 +98,11 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
   const sourceLogo = page?.organisation === "CCLW" ? "grantham-logo.png" : null;
   const sourceName = page?.organisation === "CCLW" ? "Grantham Research Institute" : page?.organisation;
 
-  const totalDocsInPageGeography =
-    geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
+  const totalDocsInPageGeography = () => {
+    if (!!geographySummary) {
+      return geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
+    }
+  };
 
   const mainDocs = page.documents.filter((doc) => doc.document_role && doc.document_role.toLowerCase().includes("main"));
   const otherDocs = page.documents.filter((doc) => !doc.document_role || !doc.document_role.toLowerCase().includes("main"));

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -299,14 +299,16 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
             </section>
           ))}
 
-          <section className="mt-8" data-cy="top-documents">
-            <DocumentSearchForm
-              placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
-              handleSearchInput={handleSearchInput}
-              input={""}
-              featuredSearches={FEATURED_SEARCHES}
-            />
-          </section>
+          {!!geographySummary && (
+            <section className="mt-8" data-cy="top-documents">
+              <DocumentSearchForm
+                placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
+                handleSearchInput={handleSearchInput}
+                input={""}
+                featuredSearches={FEATURED_SEARCHES}
+              />
+            </section>
+          )}
         </SingleCol>
       </section>
     </Layout>
@@ -347,7 +349,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     } catch (error) {}
   }
 
-  if (!familyData || !geographySummaryData) {
+  if (!familyData) {
     return {
       notFound: true,
     };

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -29,7 +29,7 @@ import { sortFilterTargets } from "@utils/sortFilterTargets";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { TFamilyPage, TMatchedFamily, TTarget, TGeographySummary } from "@types";
 import Tooltip from "@components/tooltip";
-import SearchForm from "@components/forms/SearchForm";
+import DocumentSearchForm from "@components/forms/DocumentSearchForm";
 
 type TProps = {
   page: TFamilyPage;
@@ -299,30 +299,13 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
             </section>
           ))}
 
-          <section className="mt-10" data-cy="top-documents">
-            <h3 className="mb-4">Documents</h3>
-            <div className="p-4 rounded-xl bg-blue-100">
-              <SearchForm
-                placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
-                handleSearchInput={handleSearchInput}
-                input={""}
-              />
-              <div className="mt-4 md:flex gap-2 text-sm">
-                <div className="mb-2 md:mb-0 flex-shrink-0 text-blue-900 pt-1">Featured searches</div>
-                <ul className="flex gap-1 flex-wrap items-center">
-                  {FEATURED_SEARCHES.map((searchTerm) => (
-                    <li key={searchTerm}>
-                      <button
-                        onClick={() => handleSearchInput(searchTerm)}
-                        className="text-gray-800 bg-white border border-gray-300 rounded-[40px] py-1 px-2 transition hover:bg-blue-600 hover:text-white"
-                      >
-                        {searchTerm}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
+          <section className="mt-8" data-cy="top-documents">
+            <DocumentSearchForm
+              placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
+              handleSearchInput={handleSearchInput}
+              input={""}
+              featuredSearches={FEATURED_SEARCHES}
+            />
           </section>
         </SingleCol>
       </section>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -302,10 +302,10 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
             </section>
           ))}
 
-          {!!geographySummary && (
+          {!!geographySummary && totalDocsInPageGeography() > 0 && (
             <section className="mt-8" data-cy="top-documents">
               <DocumentSearchForm
-                placeholder={`Search the full text of ${totalDocsInPageGeography} documents from ${geographyName}`}
+                placeholder={`Search the full text of ${totalDocsInPageGeography()} documents from ${geographyName}`}
                 handleSearchInput={handleSearchInput}
                 input={""}
                 featuredSearches={FEATURED_SEARCHES}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -174,15 +174,16 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
             </div>
           </section>
         )}
-
-        <section className="flex mt-8 mx-auto max-w-screen-md px-4 lg:px-0" data-cy="top-documents">
-          <DocumentSearchForm
-            placeholder={`Search the full text of ${totalDocsInFamilyGeography} documents from ${geographyName}`}
-            handleSearchInput={handleSearchInput}
-            input={""}
-            featuredSearches={FEATURED_SEARCHES}
-          />
-        </section>
+        {!!geographySummary && (
+          <section className="flex mt-8 mx-auto max-w-screen-md px-4 lg:px-0" data-cy="country-search">
+            <DocumentSearchForm
+              placeholder={`Search the full text of ${totalDocsInFamilyGeography} documents from ${geographyName}`}
+              handleSearchInput={handleSearchInput}
+              input={""}
+              featuredSearches={FEATURED_SEARCHES}
+            />
+          </section>
+        )}
       </section>
     </Layout>
   );
@@ -218,7 +219,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     } catch (error) {}
   }
 
-  if (!documentData || !familyData || !geographySummaryData) {
+  if (!documentData || !familyData) {
     return {
       notFound: true,
     };

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -68,7 +68,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     if (!!geographySummary) {
       return geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
     }
-    return 0;
   };
 
   const scrollToPassage = (index: number) => {
@@ -178,10 +177,10 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
             </div>
           </section>
         )}
-        {!!geographySummary && (
+        {!!geographySummary && totalDocsInFamilyGeography() > 0 && (
           <section className="flex mt-8 mx-auto max-w-screen-md px-4 lg:px-0" data-cy="country-search">
             <DocumentSearchForm
-              placeholder={`Search the full text of ${totalDocsInFamilyGeography} documents from ${geographyName}`}
+              placeholder={`Search the full text of ${totalDocsInFamilyGeography()} documents from ${geographyName}`}
               handleSearchInput={handleSearchInput}
               input={""}
               featuredSearches={FEATURED_SEARCHES}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -64,8 +64,12 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   const hasPassageMatches = passageMatches.length > 0;
   const canPreview = document.content_type === "application/pdf";
 
-  const totalDocsInFamilyGeography =
-    geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
+  const totalDocsInFamilyGeography = () => {
+    if (!!geographySummary) {
+      return geographySummary.family_counts.Legislative + geographySummary.family_counts.Executive + geographySummary.family_counts.UNFCCC;
+    }
+    return 0;
+  };
 
   const scrollToPassage = (index: number) => {
     setTimeout(() => {

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -13,10 +13,9 @@ import { BookOpenIcon } from "@components/svg/Icons";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { getDocumentDescription } from "@constants/metaDescriptions";
 import { TDocumentFamily, TDocumentPage, TGeographySummary } from "@types";
-import SearchForm from "@components/forms/SearchForm";
+import DocumentSearchForm from "@components/forms/DocumentSearchForm";
 import useConfig from "@hooks/useConfig";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
-import { SingleCol } from "@components/SingleCol";
 
 type TProps = {
   document: TDocumentPage;
@@ -176,35 +175,14 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
           </section>
         )}
 
-        <div className="flex place-content-center">
-          <div className="mt-8 mx-auto max-w-screen-md px-4 lg:px-0">
-            <section className="mt-10" data-cy="top-documents">
-              <h3 className="mb-4">Documents</h3>
-              <div className="p-4 rounded-xl bg-blue-100">
-                <SearchForm
-                  placeholder={`Search the full text of ${totalDocsInFamilyGeography} documents from ${geographyName}`}
-                  handleSearchInput={handleSearchInput}
-                  input={""}
-                />
-                <div className="mt-4 md:flex gap-2 text-sm">
-                  <div className="mb-2 md:mb-0 flex-shrink-0 text-blue-900 pt-1">Featured searches</div>
-                  <ul className="flex gap-1 flex-wrap items-center">
-                    {FEATURED_SEARCHES.map((searchTerm) => (
-                      <li key={searchTerm}>
-                        <button
-                          onClick={() => handleSearchInput(searchTerm)}
-                          className="text-gray-800 bg-white border border-gray-300 rounded-[40px] py-1 px-2 transition hover:bg-blue-600 hover:text-white"
-                        >
-                          {searchTerm}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </section>
-          </div>
-        </div>
+        <section className="flex mt-8 mx-auto max-w-screen-md px-4 lg:px-0" data-cy="top-documents">
+          <DocumentSearchForm
+            placeholder={`Search the full text of ${totalDocsInFamilyGeography} documents from ${geographyName}`}
+            handleSearchInput={handleSearchInput}
+            input={""}
+            featuredSearches={FEATURED_SEARCHES}
+          />
+        </section>
       </section>
     </Layout>
   );

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -199,7 +199,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
             </div>
             <SingleCol>
               <CountryHeader country={geography} targetCount={hasTargets ? publishedTargets?.length : 0} onTargetClick={handleTargetClick} />
-              <section className="mt-8" data-cy="top-documents">
+              <section className="mt-8" data-cy="country-search">
                 <h3 className="mb-4">Documents</h3>
                 <DocumentSearchForm
                   placeholder={`Search the full text of ${allDocumentsCount} documents from ${geography.name}`}

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -27,7 +27,7 @@ import { getGeoDescription } from "@constants/metaDescriptions";
 import { systemGeoNames } from "@constants/systemGeos";
 import { TGeographyStats, TGeographySummary } from "@types";
 import { TTarget, TEvent, TGeography } from "@types";
-import SearchForm from "@components/forms/SearchForm";
+import DocumentSearchForm from "@components/forms/DocumentSearchForm";
 
 type TProps = {
   geography: TGeographyStats;
@@ -199,30 +199,14 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
             </div>
             <SingleCol>
               <CountryHeader country={geography} targetCount={hasTargets ? publishedTargets?.length : 0} onTargetClick={handleTargetClick} />
-              <section className="mt-10" data-cy="top-documents">
+              <section className="mt-8" data-cy="top-documents">
                 <h3 className="mb-4">Documents</h3>
-                <div className="p-4 rounded-xl bg-blue-100">
-                  <SearchForm
-                    placeholder={`Search the full text of ${allDocumentsCount} documents from ${geography.name}`}
-                    handleSearchInput={handleSearchInput}
-                    input={""}
-                  />
-                  <div className="mt-4 md:flex gap-2 text-sm">
-                    <div className="mb-2 md:mb-0 flex-shrink-0 text-blue-900 pt-1">Featured searches</div>
-                    <ul className="flex gap-1 flex-wrap items-center">
-                      {FEATURED_SEARCHES.map((searchTerm) => (
-                        <li key={searchTerm}>
-                          <button
-                            onClick={() => handleSearchInput(searchTerm)}
-                            className="text-gray-800 bg-white border border-gray-300 rounded-[40px] py-1 px-2 transition hover:bg-blue-600 hover:text-white"
-                          >
-                            {searchTerm}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
+                <DocumentSearchForm
+                  placeholder={`Search the full text of ${allDocumentsCount} documents from ${geography.name}`}
+                  handleSearchInput={handleSearchInput}
+                  input={""}
+                  featuredSearches={FEATURED_SEARCHES}
+                />
               </section>
               {hasFamilies && (
                 <>


### PR DESCRIPTION
Added country page search box to the bottoms of the family and physical document pages.

Linked to [this backend change](https://github.com/climatepolicyradar/navigator-backend/pull/175).