### PR TITLE
Revert change to adobe page index

### DIFF
--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -15,7 +15,7 @@ function generateHighlights(document: TDocumentPage, documentPassageMatches: TPa
         source: document.import_id,
         selector: {
           node: {
-            index: passage.text_block_page,
+            index: passage.text_block_page - 1,
           },
           subtype: "highlight",
           // WE CAN ASSUME BLOCK_COORDS IS ALWAYS LENGTH 4
@@ -102,8 +102,7 @@ export default function usePDFPreview(document: TDocumentPage, documentPassageMa
     }
     if (passageIndex === null || !documentPassageMatches[passageIndex]) return;
     setTimeout(() => {
-      // Adobe's page indexing is out by 1
-      embedApi.gotoLocation(documentPassageMatches[passageIndex]?.text_block_page + 1);
+      embedApi.gotoLocation(documentPassageMatches[passageIndex]?.text_block_page);
     }, PDF_SCROLL_DELAY);
   };
 


### PR DESCRIPTION
The issue is not with adobe in this case but instead the page indexing difference between vespa and opensearch.

In opensearch the page indexes from 1, whereas in vespa it appears to be 0.

I think rather than set lots of business logic in code to check which search we are using we should update vespa to match opensearch - even if this means we switch it out later.

For clarity:
**In Vespa's search results, the passage matches are all out by 1 page.**

This PR corrects the page number for OpenSearch results whilst we await Vespa being changed to match the logic for page numbers.