### PR TITLE
PDCT-846 Remove dead Google form links and replace with Jotform.

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -239,7 +239,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
                       </h3>
 
                       <ExternalLink
-                        url="https://docs.google.com/forms/d/e/1FAIpQLSfP2ECC6W92xF5HHvy5KAPVTim0Agrbr4dD2LhiWkDjcY2f6g/viewform"
+                        url="https://form.jotform.com/233542296946365"
                         className="text-sm block mt-4 underline md:mt-0"
                         cy="download-target-csv"
                       >

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -81,11 +81,8 @@ export const FAQS: TFAQ[] = [
           <li>View your search term (and related phrases) highlighted in search results</li>
           <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
           <li>
-            Access the raw data: you just need to{" "}
-            <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-              fill out this form
-            </ExternalLink>{" "}
-            to request a copy of the entire dataset
+            Access the raw data: you just need to <ExternalLink url="https://form.jotform.com/233131638610347">fill out this form</ExternalLink> to
+            request a copy of the entire dataset
           </li>
         </ul>
       </>
@@ -110,10 +107,7 @@ export const FAQS: TFAQ[] = [
           Yes - and we encourage you to do so! The content of our database is available under the Creative Commons Attribution Licence{" "}
           <ExternalLink url="https://creativecommons.org/licenses/by/4.0/">(CC-BY)</ExternalLink>. Before doing so, you should read our Terms of Use
           for more information and to find out how to cite and credit the resources. If you wish to download the data as a .csv file, please{" "}
-          <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-            fill out our form
-          </ExternalLink>
-          .
+          <ExternalLink url="https://form.jotform.com/233131638610347">fill out our form</ExternalLink>.
         </p>
       </>
     ),
@@ -261,11 +255,7 @@ export const FAQS: TFAQ[] = [
     content: (
       <>
         <p>
-          You’ll need to{" "}
-          <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-            fill out this form
-          </ExternalLink>{" "}
-          to request our entire dataset.
+          You’ll need to <ExternalLink url="https://form.jotform.com/233131638610347">fill out this form</ExternalLink> to request our entire dataset.
         </p>
       </>
     ),

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -33,10 +33,7 @@ const About = () => {
             <p>
               We aim for the datasets to be as comprehensive and accurate as possible. However, there is no claim to have identified every relevant
               law, policy or court case in the countries covered. We invite anyone to draw our attention to any information we may have missed or any
-              errors or updates to existing data. Please{" "}
-              <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLScNy6pZTInQKdxNDaZPKyPGgbfRktstzgVDjGBCeTnLVzl3Pg/viewform">
-                fill out our form
-              </ExternalLink>{" "}
+              errors or updates to existing data. Please <ExternalLink url="https://form.jotform.com/233294135296359">fill out our form</ExternalLink>{" "}
               or email <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.ac.uk</ExternalLink> to contribute.
             </p>
           </div>


### PR DESCRIPTION
Alan has noticed that we had some straggling Google forms links in the nav-frontend. Have updated these with the respective Jotform links.