### PR TITLE
Pdct 846/some old google forms still linked to from product

### DIFF
--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -164,7 +164,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
                           You’ll soon be able to view the full-text of the document here, along with any English translation.
                         </p>
                         <p className="text-sm">
-                          <ExternalLink className="underline" url="https://forms.gle/yJTRdwTNBdTesexW8">
+                          <ExternalLink className="underline" url="https://form.jotform.com/233293886694373">
                             Sign up here
                           </ExternalLink>{" "}
                           to be notified when it’s available.

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -239,7 +239,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
                       </h3>
 
                       <ExternalLink
-                        url="https://docs.google.com/forms/d/e/1FAIpQLSfP2ECC6W92xF5HHvy5KAPVTim0Agrbr4dD2LhiWkDjcY2f6g/viewform"
+                        url="https://form.jotform.com/233542296946365"
                         className="text-sm block mt-4 underline md:mt-0"
                         cy="download-target-csv"
                       >

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -120,7 +120,7 @@ export const FAQS: TFAQ[] = [
           New data, and updates to existing data, are collected from official sources such as government websites, parliamentary records and court
           documents. We add these to the database on a rolling basis. Submissions to the UNFCCC portals were first added on the 23rd of May 2023, and
           are checked for updates regularly. If you’re aware of documents that are missing, please let us know using our{" "}
-          <ExternalLink url="https://forms.gle/QQMXoKdnvAEWh9Sr5">data contributors form</ExternalLink>.
+          <ExternalLink url="https://form.jotform.com/233294135296359">data contributors form</ExternalLink>.
         </p>
       </>
     ),
@@ -381,7 +381,7 @@ export const FAQS: TFAQ[] = [
           The database is not exhaustive. We don’t have access to some law and policy documents, while others aren’t currently machine-readable,
           meaning we can’t extract the text from them. We’re working to improve this so that you can search through the full text of more documents in
           the database. If you think we’re missing some data, you can tell us about it using the{" "}
-          <ExternalLink url="https://forms.gle/gyRo9AqC8yiM9eaz7">data contribution form</ExternalLink>.
+          <ExternalLink url="https://form.jotform.com/233294135296359">data contribution form</ExternalLink>.
         </p>
         <p>
           We also limit the number of matches you can see in a document to 10 so that you get the best performance from the tool. This means you might
@@ -421,7 +421,7 @@ export const FAQS: TFAQ[] = [
       <>
         <p>
           We’d love to hear about this! Please tell us using our{" "}
-          <ExternalLink url="https://forms.gle/gyRo9AqC8yiM9eaz7">data contribution form</ExternalLink>.
+          <ExternalLink url="https://form.jotform.com/233294135296359">data contribution form</ExternalLink>.
         </p>
       </>
     ),
@@ -449,7 +449,7 @@ export const FAQS: TFAQ[] = [
         <p>
           Our current database includes documents from every national government. Including subnational and city-level data is part of our planned
           expansion. So if you’re aware of datasets you think we should include as part of this, please let us know using our{" "}
-          <ExternalLink url="https://forms.gle/gyRo9AqC8yiM9eaz7">data contribution form</ExternalLink>.
+          <ExternalLink url="https://form.jotform.com/233294135296359">data contribution form</ExternalLink>.
         </p>
       </>
     ),

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -81,11 +81,8 @@ export const FAQS: TFAQ[] = [
           <li>View your search term (and related phrases) highlighted in search results</li>
           <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
           <li>
-            Access the raw data: you just need to{" "}
-            <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-              fill out this form
-            </ExternalLink>{" "}
-            to request a copy of the entire dataset
+            Access the raw data: you just need to <ExternalLink url="https://form.jotform.com/233131638610347">fill out this form</ExternalLink> to
+            request a copy of the entire dataset
           </li>
         </ul>
       </>
@@ -110,10 +107,7 @@ export const FAQS: TFAQ[] = [
           Yes - and we encourage you to do so! The content of our database is available under the Creative Commons Attribution Licence{" "}
           <ExternalLink url="https://creativecommons.org/licenses/by/4.0/">(CC-BY)</ExternalLink>. Before doing so, you should read our Terms of Use
           for more information and to find out how to cite and credit the resources. If you wish to download the data as a .csv file, please{" "}
-          <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-            fill out our form
-          </ExternalLink>
-          .
+          <ExternalLink url="https://form.jotform.com/233131638610347">fill out our form</ExternalLink>.
         </p>
       </>
     ),
@@ -261,11 +255,7 @@ export const FAQS: TFAQ[] = [
     content: (
       <>
         <p>
-          You’ll need to{" "}
-          <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLSdFkgTNfzms7PCpfIY3d2xGDP5bYXx8T2-2rAk_BOmHMXvCoA/viewform">
-            fill out this form
-          </ExternalLink>{" "}
-          to request our entire dataset.
+          You’ll need to <ExternalLink url="https://form.jotform.com/233131638610347">fill out this form</ExternalLink> to request our entire dataset.
         </p>
       </>
     ),

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -33,10 +33,7 @@ const About = () => {
             <p>
               We aim for the datasets to be as comprehensive and accurate as possible. However, there is no claim to have identified every relevant
               law, policy or court case in the countries covered. We invite anyone to draw our attention to any information we may have missed or any
-              errors or updates to existing data. Please{" "}
-              <ExternalLink url="https://docs.google.com/forms/d/e/1FAIpQLScNy6pZTInQKdxNDaZPKyPGgbfRktstzgVDjGBCeTnLVzl3Pg/viewform">
-                fill out our form
-              </ExternalLink>{" "}
+              errors or updates to existing data. Please <ExternalLink url="https://form.jotform.com/233294135296359">fill out our form</ExternalLink>{" "}
               or email <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.ac.uk</ExternalLink> to contribute.
             </p>
           </div>

--- a/themes/cclw/pages/terms-of-use.tsx
+++ b/themes/cclw/pages/terms-of-use.tsx
@@ -165,8 +165,8 @@ const TermsOfUse = () => {
               </li>
               <li>
                 If you identify incomplete or inaccurate information please let us know by{" "}
-                <ExternalLink url="https://forms.gle/J1va24deERTSs8LXA">filling this form</ExternalLink> and Climate Policy Radar will endeavour to
-                complete or correct it, as soon as practicable.
+                <ExternalLink url="https://form.jotform.com/233294135296359">filling this form</ExternalLink> and Climate Policy Radar will endeavour
+                to complete or correct it, as soon as practicable.
               </li>
             </ul>
             <h2>Our trade marks</h2>

--- a/themes/cpr/pages/terms-of-use.tsx
+++ b/themes/cpr/pages/terms-of-use.tsx
@@ -137,8 +137,8 @@ const TermsOfUse = () => {
               </li>
               <li>
                 If you identify incomplete or inaccurate information please let us know by{" "}
-                <ExternalLink url="https://forms.gle/J1va24deERTSs8LXA">filling this form</ExternalLink> and Climate Policy Radar will endeavour to
-                complete or correct it, as soon as practicable.
+                <ExternalLink url="https://form.jotform.com/233294135296359">filling this form</ExternalLink> and Climate Policy Radar will endeavour
+                to complete or correct it, as soon as practicable.
               </li>
             </ul>
             <h2>Our trade marks</h2>


### PR DESCRIPTION
# Description

Remove old shortform Google form links and replace with relevant JotForm links.

PDCT-846