### PR TITLE
PDCT 739 handle vespa default

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,15 +1,7 @@
-import { useRouter } from "next/router";
 import { ExternalLink } from "@components/ExternalLink";
 import FooterLinks from "./FooterLinks";
-import { triggerNewSearch } from "@utils/triggerNewSearch";
-import { QUERY_PARAMS } from "@constants/queryParams";
 
 const Footer = () => {
-  const router = useRouter();
-  const handleVespaClick = () => {
-    triggerNewSearch(router, "", QUERY_PARAMS.use_vespa, "true");
-  };
-
   return (
     <footer className="py-12 dark-gradient flex items-center shrink-0">
       <div className="container">
@@ -20,9 +12,6 @@ const Footer = () => {
           </ExternalLink>
         </p>
         <FooterLinks landing={true} />
-        <span onClick={handleVespaClick} className="cursor-pointer">
-          v
-        </span>
       </div>
     </footer>
   );

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -20,12 +20,9 @@ async function getSearch(query = initialSearchCriteria) {
     },
   };
 
-  // TODO: remove this later when BE is updated
-  const url = `/searches${query.use_vespa ? "?use_vespa=true" : ""}`;
+  const url = "/searches";
   const { data } = await getEnvFromServer();
   const client = new ApiClient(data?.env?.api_url);
-  // TODO: remove this later when BE is updated
-  query["jit_query"] = "disabled";
   query["include_results"] = ["htmlsNonTranslated", "pdfsTranslated", "htmlsTranslated"];
   const results = await client.post<TSearch>(url, query, config);
   return results;


### PR DESCRIPTION
- Remove hidden link that was triggering a vespa search
- Remove query string to `/searches` API url
- Remove old open search payload property `jit_query`