### PR TITLE
Remove retired search parameters

### DIFF
--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -8,5 +8,4 @@ export const QUERY_PARAMS = {
   sort_field: "sf",
   sort_order: "so",
   offset: "o",
-  use_vespa: "uv",
 };

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -23,7 +23,6 @@ async function getSearch(query = initialSearchCriteria) {
   const url = "/searches";
   const { data } = await getEnvFromServer();
   const client = new ApiClient(data?.env?.api_url);
-  query["include_results"] = ["htmlsNonTranslated", "pdfsTranslated", "htmlsTranslated"];
   const results = await client.post<TSearch>(url, query, config);
   return results;
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -55,7 +55,6 @@ const useSearch = (query: TRouterQuery, runFreshSearch: boolean = true) => {
       sort_field: searchQuery.sort_field,
       sort_order: searchQuery.sort_order,
       offset: searchQuery.offset,
-      use_vespa: searchQuery.use_vespa,
     };
 
     const cachedResult = getCachedSearch(cacheId);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -16,7 +16,6 @@ export type TSearchCriteria = {
   sort_order: string;
   limit: number;
   offset: number;
-  use_vespa?: boolean;
 };
 
 type TErrorDetail = {

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -64,10 +64,6 @@ export default function buildSearchQuery(routerQuery: TRouterQuery): TSearchCrit
     keyword_filters.countries = Array.isArray(countries) ? countries : [countries];
   }
 
-  if (routerQuery[QUERY_PARAMS.use_vespa]) {
-    query.use_vespa = routerQuery[QUERY_PARAMS.use_vespa] === "true";
-  }
-
   query = {
     ...query,
     keyword_filters,

--- a/src/utils/searchCache.ts
+++ b/src/utils/searchCache.ts
@@ -10,7 +10,6 @@ export type TCacheIdentifier = {
   sort_field: string | null;
   sort_order: string;
   offset: number;
-  use_vespa: boolean;
 };
 
 export type TCacheResult = TCacheIdentifier & {
@@ -43,7 +42,7 @@ const clearOldCache = () => {
 export const getCachedSearch = (cacheId: TCacheIdentifier) => {
   clearOldCache();
   const cache = getCache();
-  const { query_string, exact_match, keyword_filters, year_range, sort_field, sort_order, offset, use_vespa } = cacheId;
+  const { query_string, exact_match, keyword_filters, year_range, sort_field, sort_order, offset } = cacheId;
   const cachedSearch = cache.cache.find(
     (search) =>
       search.query_string === query_string &&
@@ -55,8 +54,7 @@ export const getCachedSearch = (cacheId: TCacheIdentifier) => {
       search.year_range[1] === year_range[1] &&
       search.sort_field === sort_field &&
       search.sort_order === sort_order &&
-      search.offset === offset &&
-      search.use_vespa === use_vespa
+      search.offset === offset
   );
   return cachedSearch;
 };


### PR DESCRIPTION
The backend no longer uses these, removing them here means we can safely remove them from the backend