### PR TITLE
Up limit to 100 on download CSV payload object

### DIFF
--- a/src/hooks/useDownloadCsv.ts
+++ b/src/hooks/useDownloadCsv.ts
@@ -37,6 +37,8 @@ async function getDownloadCsv(query: TRouterQuery) {
   const client = new ApiClient(data?.env?.api_url);
 
   const searchQuery = buildSearchQuery(query);
+  // Manually set this to 100, overriding the default 10 which is used for pagination
+  searchQuery.limit = 100;
 
   const results = await client.post<TSearch>("/searches/download-csv", searchQuery, config);
   if (results.status !== 200) {


### PR DESCRIPTION
Discovered there was an issue with the download-csv endpoint only returning a maximum of 10 results.

I assume there was a change in the back-end / API logic to use this limit where previously it was ignoring it.