### PR TITLE
Disable hadolint as it hangs on Mac

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,6 +25,7 @@ runtimes:
 # (https://docs.trunk.io/check/configuration)
 lint:
   disabled:
+    - hadolint
     - osv-scanner
   ignore:
     - linters: [ALL]
@@ -40,7 +41,6 @@ lint:
     - checkov@3.2.46
     - eslint@8.57.0
     - git-diff-check
-    - hadolint@2.12.0
     - markdownlint@0.39.0
     - oxipng@9.0.0
     - prettier@3.2.5


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
