### PR TITLE
Align map legend & handle W. Sahara edge case

### DIFF
--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -27,7 +27,7 @@ export const Legend = ({ max }: { max: number }) => {
           <p>{scale[4]}</p>
         </div>
       </div>
-      <p className="mb-2">The size and colour of the circles indicate the number of laws and policies or UNFCCC submissions in our knowledge base</p>
+      <p className="mb-2">The size and colour of the circles indicate the number of laws and policies or UNFCCC submissions in our knowledge base.</p>
     </div>
   );
 };

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -2,8 +2,7 @@ export const Legend = ({ max }: { max: number }) => {
   const scale = [1, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), max];
 
   return (
-    <div className="border border-t-0 p-4">
-      <p className="mb-2">The size and colour of the circles indicate the number of laws and policies or UNFCCC submissions in our knowledge base</p>
+    <div className="border border-t-0 p-4 flex gap-6 items-baseline">
       <div className="map-circles">
         <div className="scale-item">
           <div className="circle"></div>
@@ -28,6 +27,7 @@ export const Legend = ({ max }: { max: number }) => {
           <p>{scale[4]}</p>
         </div>
       </div>
+      <p className="mb-2">The size and colour of the circles indicate the number of laws and policies or UNFCCC submissions in our knowledge base</p>
     </div>
   );
 };

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -89,7 +89,7 @@ const getMarketStroke = (active: boolean) => {
 
 const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeographiesWithCoords }) => {
   const geography = Object.values(geographies).find((country) => country.display_value === geo);
-  if (!geography) {
+  if (!geography || geography.value === "ESH") {
     return (
       <>
         <p>We do not have any information for this area yet. ({geo})</p>
@@ -285,6 +285,7 @@ export default function MapChart() {
                   if (!geo.coords) return null;
                   if (!showUnifiedEU && geo.value === "EUR") return null;
                   if (showUnifiedEU && GEO_EU_COUNTRIES.includes(geo.value)) return null;
+                  if (geo.value === "ESH") return null; // Western Sahara (disputed territory)
                   return (
                     <Marker
                       key={geo.slug}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -639,6 +639,7 @@ ul li.selected {
       height: 8px;
       border-radius: 100%;
       border: 1px solid #1d2939;
+      margin: 0 auto;
     }
 
     p {

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -480,4 +480,17 @@ export const FAQS: TFAQ[] = [
       </>
     ),
   },
+  {
+    title: "What map and boundaries are used?",
+    content: (
+      <p>
+        This map was made with the{" "}
+        <ExternalLink url="https://www.naturalearthdata.com/downloads/50m-cultural-vectors/50m-admin-0-countries-2/">
+          Admin o - Countries
+        </ExternalLink>{" "}
+        map package by <ExternalLink url="https://www.naturalearthdata.com/">Natural Earth</ExternalLink>. Climate Policy Radar's usage of this World
+        map does not represent an opinion on any disputed boundaries.
+      </p>
+    ),
+  },
 ];


### PR DESCRIPTION
# What's changed

- Align the map legend in accordance with the design review.
- Remove hover and tool tip for Western Sahara as it is a disputed territory

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
