### PR TITLE
Re-order links and fix typo

### DIFF
--- a/themes/cclw/constants/menuLinks.ts
+++ b/themes/cclw/constants/menuLinks.ts
@@ -6,12 +6,6 @@ const menuLinks = [
     cy: "home",
   },
   {
-    text: "Framework laws",
-    href: "/framework-laws",
-    external: false,
-    cy: "framework-laws",
-  },
-  {
     text: "About",
     href: "/about",
     external: false,
@@ -40,6 +34,12 @@ const menuLinks = [
     href: "/search",
     external: false,
     cy: "search",
+  },
+  {
+    text: "Framework laws",
+    href: "/framework-laws",
+    external: false,
+    cy: "framework-laws",
   },
   {
     text: "Contact",

--- a/themes/cclw/pages/framework-laws.tsx
+++ b/themes/cclw/pages/framework-laws.tsx
@@ -25,7 +25,7 @@ const FrameworkLaws = () => {
               applied with increasing frequency by the academic and policy community to laws that share some or all of the following characteristics:
             </p>
             <ul>
-              <li>Set out the strategic of travel for national climate change policy</li>
+              <li>Set out the strategic direction of travel for national climate change policy</li>
               <li>Are passed by the legislative branch of government</li>
               <li>Contain national long-term and/or medium targets and/or pathways for change</li>
               <li>Set out institutional arrangements for climate governance at the national level</li>


### PR DESCRIPTION
# What's changed
- Re-order framework laws link
- Fix typo on page

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
