### PR TITLE
Return null for default corpusImage and check if data is ready

### DIFF
--- a/src/helpers/getCorpusInfo.tsx
+++ b/src/helpers/getCorpusInfo.tsx
@@ -8,8 +8,12 @@ type TProps = {
 };
 
 export const getCorpusInfo = ({ organisations, organisation, corpus_id }: TProps) => {
+  if (!organisations) {
+    // No organisations means we're not yet ready
+    return { corpusImage: null, corpusAltImage: null, corpusNote: null };
+  }
   const defaultResult = {
-    corpusImage: "image",
+    corpusImage: null,
     corpusAltImage: "No corpus image found",
     corpusNote: "No corpus note found",
   };


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
