### PR TITLE
PDCT-1151 Remove offSet from search query builder when in the context of family or document

### DIFF
--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -66,10 +66,14 @@ export default function buildSearchQuery(routerQuery: TRouterQuery, familyId = "
 
   if (familyId) {
     query.family_ids = [familyId];
+    // Some query params are causing issues when we are on a family page
+    query.offset = 0;
   }
 
   if (documentId) {
     query.document_ids = [documentId];
+    // Some query params are causing issues when we are on a document page
+    query.offset = 0;
   }
 
   query = {


### PR DESCRIPTION
# What's changed
- Fix a bug with search within a family or document when the offSet is included in the `/searches` payload

API layer will remove this in the long term but for now its a simple one-liner for front-end.

PDCT-1151

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
