### PR TITLE
Remove links to old acknowledgement page

### DIFF
--- a/e2e/cypress/e2e/cclw/pages/homepage.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/homepage.cy.js
@@ -52,7 +52,7 @@ describe("Homepage", () => {
 
   it("should display correct menu and navigation elements", () => {
     cy.get("[data-cy='menu-icon']").click();
-    cy.get("[data-cy='dropdown-menu']").children().should("have.length", 8);
+    cy.get("[data-cy='dropdown-menu']").children().should("have.length", 7);
 
     navigationSelectors.forEach((selector) => {
       cy.get(selector).should("be.visible");

--- a/themes/cclw/constants/menuLinks.ts
+++ b/themes/cclw/constants/menuLinks.ts
@@ -18,12 +18,6 @@ const menuLinks = [
     cy: "methodology",
   },
   {
-    text: "Acknowledgements",
-    href: "/acknowledgements",
-    external: false,
-    cy: "acknowledgements",
-  },
-  {
     text: "FAQ",
     href: "/faq",
     external: false,

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -84,16 +84,3 @@ const About = () => {
 };
 
 export default About;
-
-{
-  /* <iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/rgOHHasg88c?si=t9Lqckm550hA-8lx"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
-></iframe> */
-}

--- a/themes/cclw/redirects.json
+++ b/themes/cclw/redirects.json
@@ -63,7 +63,12 @@
   },
   {
     "source": "/collaborations-and-acknowledgements",
-    "destination": "/acknowledgements",
+    "destination": "/about",
+    "permanent": true
+  },
+  {
+    "source": "/acknowledgements",
+    "destination": "/about",
     "permanent": true
   },
   {


### PR DESCRIPTION
# What's changed

- A link to removed `/acknolwedgements` page was still in the code (I added a redirect to the about page in case)
- Some commented out code for the youtube video was left in

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
