### PR TITLE
Switch search param `limit` to `page_size`

### DIFF
--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -10,6 +10,7 @@ export const initialSearchCriteria: TSearchCriteria = {
   year_range: [minYear, currentYear()],
   sort_field: null,
   sort_order: "desc",
-  limit: PER_PAGE,
+  page_size: PER_PAGE,
+  limit: 100,
   offset: 0,
 };

--- a/src/hooks/useDownloadCsv.ts
+++ b/src/hooks/useDownloadCsv.ts
@@ -38,7 +38,7 @@ async function getDownloadCsv(query: TRouterQuery) {
 
   const searchQuery = buildSearchQuery(query);
   // Manually set this to 100, overriding the default 10 which is used for pagination
-  searchQuery.limit = 100;
+  searchQuery.page_size = 100;
 
   const results = await client.post<TSearch>("/searches/download-csv", searchQuery, config);
   if (results.status !== 200) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,6 +14,7 @@ export type TSearchCriteria = {
   year_range: [number, number];
   sort_field: string | null;
   sort_order: string;
+  page_size: number;
   limit: number;
   offset: number;
   family_ids?: string[] | null;


### PR DESCRIPTION
Following the change in the backend that untangles these: https://github.com/climatepolicyradar/navigator-backend/pull/288 

Note that the backend change must be deployed first! 

# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
