### PR TITLE
Pdct 1250/faq update

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v3
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v8
 
   code-quality:
     if: |

--- a/src/components/modals/DownloadCsv.tsx
+++ b/src/components/modals/DownloadCsv.tsx
@@ -17,6 +17,7 @@ export const DownloadCsvPopup = ({ active, onCancelClick, onConfirmClick }: TPro
         <p className="mb-4">
           Please read our <LinkWithQuery href="/terms-of-use">terms of use</LinkWithQuery>, including any specific terms relevant to commercial use.
           Please contact <ExternalLink url="mailto:partners@climatepolicyradar.org">partners@climatepolicyradar.org</ExternalLink> with any questions.
+          Note that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
         </p>
         <div className="flex">
           <Button onClick={onConfirmClick}>Download</Button>

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -263,7 +263,10 @@ export const FAQS: TFAQ[] = [
     title: "Why is the number of search results limited?",
     content: (
       <>
-        <p>The number of search results is currently limited to 100 to optimise system performance. We’re working to remove this limit.</p>
+        <p>
+          The number of search results is currently limited to 500 to optimise system performance. We’re working to remove this limit. Please note
+          that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
+        </p>
       </>
     ),
   },
@@ -383,8 +386,8 @@ export const FAQS: TFAQ[] = [
           <ExternalLink url="https://form.jotform.com/233294135296359">data contribution form</ExternalLink>.
         </p>
         <p>
-          We also limit the number of matches you can see in a document to 10 so that you get the best performance from the tool. This means you might
-          miss some matches. We’re working on a way to remove this limit.
+          We also limit the number of matches you can see in a document to 500, so that you get the best performance from the tool. This means that
+          for very long documents or very broad search terms, you might miss some matches. We’re working to remove this limit.
         </p>
       </>
     ),
@@ -472,9 +475,8 @@ export const FAQS: TFAQ[] = [
       <>
         <p>You can download a csv of data for "this search" or the "whole database" from the top right of the search results page.</p>
         <p>
-          If you download a csv for “this search” and you used the “related phrases” search function this will contain all documents related to the
-          top 100 entries returned by your search. If you use the “exact match” search function, fewer than 100 entries may be returned for some
-          search terms where these appear less than 100 times within the dataset searched.
+          If you download a csv for “this search” it will contain all documents related to the top 500 entries returned by your search. Note that the
+          actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
         </p>
       </>
     ),


### PR DESCRIPTION
# What's changed
- updated text on 3 of the FAQs to reflect the increased search result limit and the actual number of results returned
- updated text on the Download This Search popup to include a note on the actual number of results returned

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
