### PR TITLE
Remove bold styling from tooltip text

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -214,7 +214,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
                     id="related-documents-info"
                     place="right"
                     icon="i"
-                    tooltip="Other documents can be previous versions, amendments, annexes, supporting legislation, and more."
+                    tooltip={<>"Other documents can be previous versions, amendments, annexes, supporting legislation, and more."</>}
                   />
                 </h2>
                 <div data-cy="related-documents">

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -208,15 +208,15 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
           {otherDocuments.length > 0 && (
             <>
               <section className="mt-8">
-                <h2 className="flex items-center gap-2 text-base">
-                  Other documents in this entry{" "}
+                <div className="flex items-center gap-2">
+                  <h2 className="text-base">Other documents in this entry </h2>
                   <Tooltip
                     id="related-documents-info"
                     place="right"
                     icon="i"
-                    tooltip={<>"Other documents can be previous versions, amendments, annexes, supporting legislation, and more."</>}
+                    tooltip="Other documents can be previous versions, amendments, annexes, supporting legislation, and more."
                   />
-                </h2>
+                </div>
                 <div data-cy="related-documents">
                   {otherDocuments.map((doc) => (
                     <div key={doc.import_id} className="mt-4">


### PR DESCRIPTION
# What's changed
- removed bold styling on the 'Other documents in this entry' tooltip text

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
