### PR TITLE
feature/pdct-1336-add-search-component-to-skeleton-mcf-custom-app

### DIFF
--- a/e2e/cypress/e2e/mcf/pages/homepage.cy.js
+++ b/e2e/cypress/e2e/mcf/pages/homepage.cy.js
@@ -6,6 +6,6 @@ describe("Landing page", () => {
   });
 
   it("should display the placeholder homepage", () => {
-    cy.contains("Hello World").should("be.visible");
+    cy.contains("MCF Custom App").should("be.visible");
   });
 });

--- a/e2e/cypress/e2e/mcf/pages/homepage.cy.js
+++ b/e2e/cypress/e2e/mcf/pages/homepage.cy.js
@@ -6,6 +6,6 @@ describe("Landing page", () => {
   });
 
   it("should display the placeholder homepage", () => {
-    cy.contains("MCF Custom App").should("be.visible");
+    cy.contains("Multilateral Climate Funds").should("be.visible");
   });
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,7 +5,6 @@ const config: Config = {
   verbose: true,
 
   moduleNameMapper: {
-    // Map `@mcf/components` to the correct directory
     "^@constants/(.*)$": "<rootDir>/src/constants/$1",
     "^@components/(.*)$": "<rootDir>/src/components/$1",
     "^@hooks/(.*)$": "<rootDir>/src/hooks/$1",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "jsdom",
+  verbose: true,
+
+  moduleNameMapper: {
+    // Map `@mcf/components` to the correct directory
+    "^@constants/(.*)$": "<rootDir>/src/constants/$1",
+    "^@components/(.*)$": "<rootDir>/src/components/$1",
+    "^@hooks/(.*)$": "<rootDir>/src/hooks/$1",
+    "^@mcf/(.*)$": "<rootDir>/themes/mcf/$1",
+    "^@utils/(.*)$": "<rootDir>/src/utils/$1",
+    // Add other aliases if needed
+  },
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "jest": "^29.7.0",
         "postcss-preset-env": "^7.0.2",
         "tailwindcss": "^3.0.5",
+        "ts-node": "^10.9.2",
         "typescript": "^4.5.4"
       }
     },
@@ -1740,6 +1741,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/postcss-cascade-layers": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.1.1.tgz",
@@ -3042,6 +3067,34 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -4764,6 +4817,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -5204,6 +5264,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -8998,6 +9068,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -11820,6 +11897,70 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -11979,7 +12120,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12135,6 +12276,13 @@
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -12548,6 +12696,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -13634,6 +13792,27 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "devOptional": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@csstools/postcss-cascade-layers": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.1.1.tgz",
@@ -14481,6 +14660,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
     },
     "@types/aria-query": {
       "version": "5.0.4",
@@ -15731,6 +15934,12 @@
         "prompts": "^2.0.1"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -16035,6 +16244,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -18626,6 +18841,12 @@
         "semver": "^6.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -20353,6 +20574,44 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.3.3",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+          "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+          "devOptional": true,
+          "requires": {
+            "acorn": "^8.11.0"
+          }
+        },
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "devOptional": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -20468,7 +20727,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
+      "devOptional": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -20563,6 +20822,12 @@
     "v8-compile-cache": {
       "version": "2.3.0",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "v8-to-istanbul": {
       "version": "9.3.0",
@@ -20847,6 +21112,12 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
     "jest": "^29.7.0",
     "postcss-preset-env": "^7.0.2",
     "tailwindcss": "^3.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^4.5.4"
-  },
-  "jest": {
-    "testEnvironment": "jsdom"
   }
 }

--- a/themes/mcf/components/Hero.tsx
+++ b/themes/mcf/components/Hero.tsx
@@ -1,0 +1,23 @@
+import LandingSearchForm from "./LandingSearchForm";
+
+type TProps = {
+  handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
+  searchInput: string;
+};
+
+const Hero = ({ handleSearchInput, searchInput }: TProps) => (
+  <div className="pb-6 text-white pt-[28px] sm:pt-[48px] md:pt-[180px] lg:pt-[100px] xl:pt-[140px]">
+    <div className="container">
+      <div className="mx-auto text-center">
+        <p className="font-medium tracking-slight text-lg lg:text-3xl" data-cy="intro-message">
+          MCF Custom App : Search over 5000 climate laws and policies worldwide
+        </p>
+      </div>
+      <div className="max-w-screen-md mx-auto mt-6">
+        <LandingSearchForm handleSearchInput={handleSearchInput} placeholder="Search full text of any document" input={searchInput} />
+      </div>
+    </div>
+  </div>
+);
+
+export default Hero;

--- a/themes/mcf/components/Hero.tsx
+++ b/themes/mcf/components/Hero.tsx
@@ -10,7 +10,7 @@ const Hero = ({ handleSearchInput, searchInput }: TProps) => (
     <div className="container">
       <div className="mx-auto text-center">
         <p className="font-medium tracking-slight text-lg lg:text-3xl" data-cy="intro-message">
-          MCF Custom App : Search over 5000 climate laws and policies worldwide
+          MCFs: Multilateral Climate Funds
         </p>
       </div>
       <div className="max-w-screen-md mx-auto mt-6">

--- a/themes/mcf/components/LandingSearchForm.tsx
+++ b/themes/mcf/components/LandingSearchForm.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect, useRef, ChangeEvent } from "react";
+
+import { Search2Icon } from "@components/svg/Icons";
+import { SearchDropdown } from "@components/forms/SearchDropdown";
+import Button from "@components/buttons/Button";
+
+import { QUERY_PARAMS } from "@constants/queryParams";
+
+// See the method handleSearchInput in the index.tsx file for the processing of the example searches
+const EXAMPLE_SEARCHES = [
+  { id: 1, term: "Adaptation" },
+  { id: 2, filterValue: "Brazil", filterType: QUERY_PARAMS.country },
+  { id: 3, term: "Climate framework laws" },
+  { id: 4, term: "Coastal zones" },
+];
+
+interface SearchFormProps {
+  placeholder?: string;
+  handleSearchInput(term: string, filter?: string, filterValue?: string): void;
+  input?: string;
+}
+
+const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
+  const [term, setTerm] = useState("");
+  const [formFocus, setFormFocus] = useState(false);
+  const formRef = useRef(null);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTerm(e.currentTarget.value);
+  };
+
+  useEffect(() => {
+    if (input) setTerm(input);
+  }, [input]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (formRef.current && !formRef.current.contains(event.target)) {
+        return setFormFocus(false);
+      }
+      setFormFocus(true);
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [formRef]);
+
+  const displayPlaceholder = placeholder ?? "Search full text of any document";
+
+  return (
+    <>
+      <form data-cy="search-form" ref={formRef} onSubmit={(e) => e.preventDefault()}>
+        <div className="max-w-screen-lg mx-auto flex items-stretch relative text-indigo-400">
+          <input
+            id="landingPage-searchInput-cclw"
+            data-analytics="landingPage-searchInput"
+            data-cy="search-input"
+            type="search"
+            className="text-xl leading-5 py-3 h-[48px] pl-6 pr-3 mr-[72px] w-full text-cpr-dark focus:ring-0 rounded-l-4xl border-0"
+            value={term}
+            onChange={onChange}
+            placeholder={displayPlaceholder}
+            aria-label="Search term"
+          />
+          <button
+            className="absolute right-0 h-full px-6 text-white bg-blue-400 rounded-r-4xl hover:bg-blue-300 active:bg-blue-700"
+            onClick={() => handleSearchInput(term)}
+            aria-label="Search"
+          >
+            <span className="block">
+              <Search2Icon height="24" width="24" />
+            </span>
+          </button>
+          <SearchDropdown term={term} show={formFocus} handleSearchClick={handleSearchInput} largeSpacing />
+        </div>
+      </form>
+      <div className="hidden mt-4 md:flex flex-wrap items-center gap-2">
+        <span className="text-gray-200">Search by:</span>
+        {EXAMPLE_SEARCHES.map((example) => (
+          <Button
+            key={example.id}
+            thin
+            color="dark"
+            onClick={() => handleSearchInput(example.term, example.filterType, example.filterValue)}
+            data-cy={`example-search-${example.id}`}
+          >
+            {example.term ?? example.filterValue}
+          </Button>
+        ))}
+      </div>
+    </>
+  );
+};
+export default LandingSearchForm;

--- a/themes/mcf/components/index.ts
+++ b/themes/mcf/components/index.ts
@@ -1,0 +1,3 @@
+export { default as Analytics } from "./Analytics";
+export { default as MethodologyLink } from "./MethodologyLink";
+export { default as Hero } from "./Hero";

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 
-// generic layer component
-import Layout from "@components/layouts/LandingPage";
-
 import { Hero } from "@mcf/components";
 
 type TProps = {
@@ -12,13 +9,11 @@ type TProps = {
 
 const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
   return (
-    <Layout title="MCF">
-      <main id="main" className="relative h-full">
-        <div className="bg-cclw-dark text-white h-full">
-          <Hero handleSearchInput={handleSearchInput} searchInput={searchInput} />
-        </div>
-      </main>
-    </Layout>
+    <main id="main" className="relative h-full">
+      <div className="bg-cclw-dark text-white h-full">
+        <Hero handleSearchInput={handleSearchInput} searchInput={searchInput} />
+      </div>
+    </main>
   );
 };
 

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -1,3 +1,25 @@
-const LandingPage = ({}) => <div> Hello World </div>;
+import React from "react";
+
+// generic layer component
+import Layout from "@components/layouts/LandingPage";
+
+import { Hero } from "@mcf/components";
+
+type TProps = {
+  handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
+  searchInput: string;
+};
+
+const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
+  return (
+    <Layout title="MCF">
+      <main id="main" className="relative h-full">
+        <div className="bg-cclw-dark text-white h-full">
+          <Hero handleSearchInput={handleSearchInput} searchInput={searchInput} />
+        </div>
+      </main>
+    </Layout>
+  );
+};
 
 export default LandingPage;

--- a/themes/mcf/tests/pages/homepage.test.tsx
+++ b/themes/mcf/tests/pages/homepage.test.tsx
@@ -21,6 +21,6 @@ jest.mock("react-query", () => ({
 describe("Landing Page: ", () => {
   it("should render MCF Landing Page", () => {
     render(<LandingPage handleSearchInput={mockHandleSearchInput} searchInput={mockSearchInput} />);
-    expect(screen.getByText("MCF Custom App : Search over 5000 climate laws and policies worldwide")).toBeInTheDocument();
+    expect(screen.getByText("MCFs: Multilateral Climate Funds")).toBeInTheDocument();
   });
 });

--- a/themes/mcf/tests/pages/homepage.test.tsx
+++ b/themes/mcf/tests/pages/homepage.test.tsx
@@ -3,9 +3,24 @@ import "@testing-library/jest-dom";
 
 import LandingPage from "../../pages/homepage";
 
+const mockHandleSearchInput = jest.fn();
+const mockSearchInput = "mockSearchInput";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("react-query", () => ({
+  useQuery: jest.fn(() => ({
+    data: {},
+    isLoading: false,
+    error: null,
+  })),
+}));
+
 describe("Landing Page: ", () => {
-  it("should render hello world", () => {
-    render(<LandingPage />);
-    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  it("should render MCF Landing Page", () => {
+    render(<LandingPage handleSearchInput={mockHandleSearchInput} searchInput={mockSearchInput} />);
+    expect(screen.getByText("MCF Custom App : Search over 5000 climate laws and policies worldwide")).toBeInTheDocument();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,7 @@
       "@mcf/*": ["themes/mcf/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/api/pdf.js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/api/pdf.js", "jest.config.ts"],
   "exclude": ["node_modules"],
   "types": ["cypress", "cypress-file-upload"]
 }


### PR DESCRIPTION
feat: add search component to skeleton app

- this reuses the component in the cpr app and repurposes it for the mcf custom app
- updates to the data, filtering and a methodology page will be handled in a separate PR

# What's changed
![Screenshot 2024-08-14 at 17 21 28](https://github.com/user-attachments/assets/4444392d-d84c-4ae8-9545-60541812512a)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
