### PR TITLE
fix: update methodology url in cclw FAQ

### DIFF
--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -502,7 +502,7 @@ export const FAQS: TFAQ[] = [
         the NewClimate Institute and its partners for the{" "}
         <ExternalLink url="https://climatepolicydatabase.org/">Climate Policy Database</ExternalLink> project. Prior to their ingest into the
         database, documents were reviewed by researchers at Climate Policy Radar to ensure that no duplicate entries were added and that entries fell
-        within the scope of the Climate Change Laws of the World  <ExternalLink url="https://climatepolicydatabase.org/">methodology</ExternalLink>.
+        within the scope of the Climate Change Laws of the World <ExternalLink url="https://climate-laws.org/methodology">methodology</ExternalLink>.
         This data has been ingested with permission from NewClimate Institute, in order to advance efforts by Climate Policy Radar and LSE to provide
         users with the most comprehensive dataset possible.
       </p>


### PR DESCRIPTION
This should point to the internal methodology page Remove extra space from updated FAQ

# What's changed

Update methodology link in CCLW FAQ app to point to methodology page

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
