### PR TITLE
Bug - Analytics not consenting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,7 +3233,8 @@
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.14.tgz",
       "integrity": "sha512-NcR9rf3B93ie5T086NIpXGTtoIJeOeQ14+IBIBwfNBztb175e/0gONc60ywUU4+f9dwctgz9L3I4h5Gs/hl31g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/src/components/cookies/CookieConsent.tsx
+++ b/src/components/cookies/CookieConsent.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from "react";
 import Script from "next/script";
+
 import Button from "@components/buttons/Button";
-import { getCookie, setCookie } from "@utils/cookies";
-import { COOKIE_CONSENT_NAME } from "@constants/cookies";
 import { ExternalLink } from "@components/ExternalLink";
+
+import { getCookie, setCookie } from "@utils/cookies";
 import getDomain from "@utils/getDomain";
 
+import { COOKIE_CONSENT_NAME } from "@constants/cookies";
+
 const { default: ThemeAnalytics } = await import(`/themes/${process.env.THEME}/components/Analytics`);
+
+declare let gtag: Function;
 
 export const CookieConsent = () => {
   const [hide, setHide] = useState(true);
@@ -18,14 +23,14 @@ export const CookieConsent = () => {
     if (cc === "true") setEnableAnalytics(true);
   }, []);
 
-  const gtag = (...args: any) => window.dataLayer.push(...args);
-
   useEffect(() => {
     // If the user has accepted cookies, update the consent options for Google Tag Manager
     if (enableAnalytics) {
       gtag("consent", "update", {
         ad_storage: "granted",
         analytics_storage: "granted",
+        ad_user_data: "granted",
+        ad_personalization: "granted",
       });
     }
   }, [enableAnalytics]);
@@ -76,6 +81,8 @@ export const CookieConsent = () => {
             gtag("consent", "default", {
               ad_storage: "denied",
               analytics_storage: "denied",
+              ad_user_data: "denied",
+              ad_personalization: "denied",
             });
           `}
       </Script>


### PR DESCRIPTION
# What's changed
Analytics were not being tracked using google tag manager. I noticed that where we instantiate our `gtag` method, we did not appear to be updating the 'consent' values.

The confusing thing here is that this previously was working. I have redeclared the gtag as a `Function` and this now appears to be passing the consent update as a method call with arguments.

I've checked this through the google tag manager console and can confirm the consent is being updated correctly.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
