### PR TITLE
Update to climate framework laws page

### DIFF
--- a/themes/cclw/constants/frameworkLaws.ts
+++ b/themes/cclw/constants/frameworkLaws.ts
@@ -36,6 +36,12 @@ export const FRAMEWORK_LAWS = [
     url: "https://climate-laws.org/document/climate-change-and-carbon-market-initiatives-act-2022_db37",
   },
   {
+    title: "Law on the governance of federal climate policy",
+    geo_iso: "BEL",
+    geography: "Belgium",
+    url: "https://climate-laws.org/document/law-on-the-governance-of-federal-climate-policy_b052?l=belgium&c=Legislation",
+  },
+  {
     title: "Law no 2018/18 regulating climate change actions",
     geo_iso: "BEN",
     geography: "Benin",
@@ -199,6 +205,12 @@ export const FRAMEWORK_LAWS = [
     url: "https://climate-laws.org/document/climate-change-act-2016_7078",
   },
   {
+    title: "Disaster Risk Management and Climate Change Act",
+    geo_iso: "KIR",
+    geography: "Kiribati",
+    url: "https://climate-laws.org/document/disaster-risk-management-and-climate-change-act_1110",
+  },
+  {
     title: "Law on Climate Change",
     geo_iso: "XKX",
     geography: "Kosovo",
@@ -347,6 +359,12 @@ export const FRAMEWORK_LAWS = [
     geo_iso: "SVN",
     geography: "Slovenia",
     url: "https://climate-laws.org/document/environmental-protection-act_1297",
+  },
+  {
+    title: "Climate Change Act, 2024",
+    geo_iso: "ZAR",
+    geography: "South Africa",
+    url: "https://climate-laws.org/document/climate-change-act_6e08?q=climate+change+act",
   },
   {
     title: "Carbon Neutral Green Growth Framework Act to tackle the Climate Crisis",

--- a/themes/cclw/constants/frameworkLaws.ts
+++ b/themes/cclw/constants/frameworkLaws.ts
@@ -39,7 +39,7 @@ export const FRAMEWORK_LAWS = [
     title: "Law on the governance of federal climate policy",
     geo_iso: "BEL",
     geography: "Belgium",
-    url: "https://climate-laws.org/document/law-on-the-governance-of-federal-climate-policy_b052?l=belgium&c=Legislation",
+    url: "https://climate-laws.org/document/law-on-the-governance-of-federal-climate-policy_b052",
   },
   {
     title: "Law no 2018/18 regulating climate change actions",
@@ -364,7 +364,7 @@ export const FRAMEWORK_LAWS = [
     title: "Climate Change Act, 2024",
     geo_iso: "ZAR",
     geography: "South Africa",
-    url: "https://climate-laws.org/document/climate-change-act_6e08?q=climate+change+act",
+    url: "https://climate-laws.org/document/climate-change-act_6e08",
   },
   {
     title: "Carbon Neutral Green Growth Framework Act to tackle the Climate Crisis",

--- a/themes/cclw/constants/frameworkLaws.ts
+++ b/themes/cclw/constants/frameworkLaws.ts
@@ -138,7 +138,7 @@ export const FRAMEWORK_LAWS = [
     url: "https://climate-laws.org/document/federal-climate-adaptation-act-kang-6100",
   },
   {
-    title: 'Federal Climate Protection Act ("Bundesklimaschutzgesetz‚Äù or ‚ÄúKSG")',
+    title: 'Federal Climate Protection Act ("Bundesklimaschutzgesetz” or “KSG")',
     geo_iso: "DEU",
     geography: "Germany",
     url: "https://climate-laws.org/document/federal-climate-protection-act-and-to-change-further-regulations-bundesklimaschutzgesetz-or-ksg_c1c2",


### PR DESCRIPTION
# What's changed

fix mistranslation in german framework law title
add climate laws for belgium, kirabiti, south africa to the climate laws framework

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
