### PR TITLE
feature/pdct-1501-update-text-on-framework-laws-page

### DIFF
--- a/themes/cclw/pages/framework-laws.tsx
+++ b/themes/cclw/pages/framework-laws.tsx
@@ -45,8 +45,8 @@ const FrameworkLaws = () => {
               </ul>
               <p>
                 The laws are tagged to indicate the policy response area(s) to which they relate, whether mitigation, adaptation and/or disaster risk
-                management. <strong>There are currently 67 climate change framework laws in our database</strong>. Please see these listed
-                alphabetically by country below. You can search within each document though their links below.
+                management. <strong>There are currently {totalFrameworkLaws} climate change framework laws in our database</strong>. Please see these
+                listed alphabetically by country below. You can search within each document though their links below.
               </p>
               <table>
                 <thead>


### PR DESCRIPTION
# What's changed

Use the variable that calculates the length of the array to display the total number of climate laws

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
