### PR TITLE
Use family_geographies instead of family_geography

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -12,12 +12,12 @@ type TProps = {
 };
 
 export const FamilyListItem: FC<TProps> = ({ family, children }) => {
-  const { family_slug, family_geography, family_description, family_name, family_date, family_category } = family;
+  const { family_slug, family_geographies, family_description, family_name, family_date, family_category } = family;
 
   return (
     <div className="family-list-item relative">
       <div className="flex flex-wrap text-[13px] gap-1 mb-2 items-center middot-between">
-        <FamilyMeta category={family_category} date={family_date} geography={family_geography} />
+        <FamilyMeta category={family_category} date={family_date} geography={family_geographies.length > 0 ? family_geographies[0] : ""} />
         {children}
       </div>
       <LinkWithQuery

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -21,7 +21,7 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
   const router = useRouter();
 
   if (!family) return null;
-  const { family_geography, family_name, family_category, family_date, family_documents } = family;
+  const { family_geographies, family_name, family_category, family_date, family_documents } = family;
 
   const onPassageClick = (passageIndex: number, documentIndex: number) => {
     const document = family_documents[documentIndex];
@@ -42,7 +42,7 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
         <div className="p-5 pb-0 pr-10 md:pr-12">
           <Heading level={2}>{family_name}</Heading>
           <div className="flex flex-wrap text-sm gap-1 mt-2 items-center middot-between">
-            <FamilyMeta category={family_category} geography={family_geography} date={family_date} />
+            <FamilyMeta category={family_category} geography={family_geographies.length > 0 ? family_geographies[0] : ""} date={family_date} />
           </div>
           <div className="mt-5">
             <Heading level={3}>Summary</Heading>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -203,7 +203,7 @@ export type TFamily = {
   family_category: TCategory;
   family_description: string;
   family_documents: TFamilyDocument[];
-  family_geography: string;
+  family_geographies: string[];
   family_metadata: {}; // TODO: type this
   family_name: string;
   family_slug: string;


### PR DESCRIPTION
# What's changed

Use new `family_geographies` property on a family instead of the old `family_geography`.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
