### PR TITLE
feature/pdct-1582-react-is-rendering-one-image-for-all-fund-logos-on-mcf-page

### DIFF
--- a/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
+++ b/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
@@ -34,8 +34,8 @@ const fundInformation: FundData[] = [
 export const MultilateralClimateFundLogos = () => {
   return (
     <div className="hidden sm:flex justify-center items-center gap-8 mt-8 mb-4">
-      {fundInformation.map((fund) => (
-        <div key={fund.name} className="w-[120px] h-[60px]">
+      {fundInformation.map((fund, index) => (
+        <div key={index} className="w-[120px] h-[60px]">
           <ExternalLink url={fund.url} className="block w-full h-full">
             <Image src={fund.imgSrc} alt={`${fund.name} logo`} width={120} height={60} className="object-contain w-full h-full" />
           </ExternalLink>


### PR DESCRIPTION
# What's changed

fix: use index as key for logo mapping

react is rendering one image for all four logos, this only occurs on staging so will use the index, incase the fact that we don't redefine the mcf data specifically the name which is used for the key for  every render is causing rendering issues. 
When there are not unique keys used for mapping, occasionally react does not render elements as expected.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
