### PR TITLE
Feature/pdct 1597 update search result list item familylistitem to include the

### DIFF
--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -41,6 +41,7 @@ export const FamilyHead = ({ family, onCollectionClick }: TProps) => {
       <div className="flex flex-wrap text-sm gap-1 mt-2 items-center middot-between" data-cy="family-metadata">
         <FamilyMeta
           category={family.category}
+          corpus_type_name={family.corpus_type_name}
           date={family.published_date}
           geography={family.geography}
           topics={family.metadata.topic}

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -12,12 +12,17 @@ type TProps = {
 };
 
 export const FamilyListItem: FC<TProps> = ({ family, children }) => {
-  const { family_slug, family_geographies, family_description, family_name, family_date, family_category } = family;
+  const { corpus_type_name, family_slug, family_geographies, family_description, family_name, family_date, family_category } = family;
 
   return (
     <div className="family-list-item relative">
       <div className="flex flex-wrap text-[13px] gap-1 mb-2 items-center middot-between">
-        <FamilyMeta category={family_category} date={family_date} geography={family_geographies.length > 0 ? family_geographies[0] : ""} />
+        <FamilyMeta
+          category={family_category}
+          corpus_type_name={corpus_type_name}
+          date={family_date}
+          geography={family_geographies.length > 0 ? family_geographies[0] : ""}
+        />
         {children}
       </div>
       <LinkWithQuery

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -31,7 +31,7 @@ export const FamilyMeta = ({ category, date, geography, topics, author, corpus_t
           </CountryLink>
         </span>
       )}
-      {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY {year}</span>}
+      {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY: {year}</span>}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">
           {getCategoryName(category, corpus_type_name)}

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -4,17 +4,18 @@ import { getCountryName } from "@helpers/getCountryFields";
 import { getCategoryName } from "@helpers/getCategoryName";
 import { isSystemGeo } from "@utils/isSystemGeo";
 import { convertDate } from "@utils/timedate";
-import { TCategory } from "@types";
+import { TCategory, TCorpusTypeSubCategory } from "@types";
 
 type TProps = {
   category: TCategory;
+  corpus_type_name: TCorpusTypeSubCategory;
   date: string;
   geography: string;
   topics?: string[];
   author?: string[];
 };
 
-export const FamilyMeta = ({ category, date, geography, topics, author }: TProps) => {
+export const FamilyMeta = ({ category, date, geography, topics, author, corpus_type_name }: TProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
 
@@ -30,10 +31,10 @@ export const FamilyMeta = ({ category, date, geography, topics, author }: TProps
           </CountryLink>
         </span>
       )}
-      {!isNaN(year) && <span data-cy="family-metadata-year">{year}</span>}
+      {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY {year}</span>}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">
-          {getCategoryName(category)}
+          {getCategoryName(category, corpus_type_name)}
         </span>
       )}
       {topics && topics.length > 0 && (

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -21,7 +21,7 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
   const router = useRouter();
 
   if (!family) return null;
-  const { family_geographies, family_name, family_category, family_date, family_documents } = family;
+  const { family_geographies, family_name, family_category, family_date, family_documents, corpus_type_name } = family;
 
   const onPassageClick = (passageIndex: number, documentIndex: number) => {
     const document = family_documents[documentIndex];
@@ -42,7 +42,12 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
         <div className="p-5 pb-0 pr-10 md:pr-12">
           <Heading level={2}>{family_name}</Heading>
           <div className="flex flex-wrap text-sm gap-1 mt-2 items-center middot-between">
-            <FamilyMeta category={family_category} geography={family_geographies.length > 0 ? family_geographies[0] : ""} date={family_date} />
+            <FamilyMeta
+              category={family_category}
+              corpus_type_name={corpus_type_name}
+              geography={family_geographies.length > 0 ? family_geographies[0] : ""}
+              date={family_date}
+            />
           </div>
           <div className="mt-5">
             <Heading level={3}>Summary</Heading>

--- a/src/helpers/getCategoryName.ts
+++ b/src/helpers/getCategoryName.ts
@@ -1,6 +1,6 @@
-import { TCategory } from "@types";
+import { TCategory, TCorpusTypeSubCategory } from "@types";
 
-export const getCategoryName = (category: TCategory) => {
+export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory) => {
   let name = "";
   switch (category) {
     case "Litigation":
@@ -16,6 +16,9 @@ export const getCategoryName = (category: TCategory) => {
       break;
     case "UNFCCC":
       name = "UNFCCC";
+      break;
+    case "MCF":
+      name = subCategory ? subCategory.toUpperCase() : "MCF";
       break;
   }
   return name;

--- a/src/helpers/getCategoryName.ts
+++ b/src/helpers/getCategoryName.ts
@@ -1,25 +1,29 @@
 import { TCategory, TCorpusTypeSubCategory } from "@types";
 
-export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory) => {
-  let name = "";
-  switch (category) {
-    case "Litigation":
-      name = "Litigation";
-      break;
-    case "Legislative":
-    case "Law":
-      name = "Legislative";
-      break;
-    case "Executive":
-    case "Policy":
-      name = "Policy";
-      break;
-    case "UNFCCC":
-      name = "UNFCCC";
-      break;
-    case "MCF":
-      name = subCategory ? subCategory.toUpperCase() : "MCF";
-      break;
-  }
-  return name;
+const subCategories: Record<TCorpusTypeSubCategory, string> = {
+  AF: "Adaptation Fund",
+  CIF: "Climate Investment Funds",
+  GCF: "Green Climate Fund",
+  GEF: "Global Environment Facility",
+  "Intl. agreements": "Intl. agreements",
+  "Laws and Policies": "Laws and Policies",
+};
+
+const categories: Record<TCategory, string> = {
+  Litigation: "Litigation",
+  Legislative: "Legislative",
+  Law: "Legislative",
+  Executive: "Policy",
+  Policy: "Policy",
+  UNFCCC: "UNFCCC",
+  MCF: "MCF",
+};
+
+const getSubCategoryName = (subCategory: TCorpusTypeSubCategory): string => {
+  return subCategories[subCategory as TCorpusTypeSubCategory];
+};
+
+export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory): string => {
+  const name = categories[category as TCategory];
+  return category === "MCF" && subCategory ? getSubCategoryName(subCategory) : name;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -107,7 +107,8 @@ export type TGeographySummary = {
   top_families: TGeoFamilys;
 };
 
-export type TCategory = "Legislative" | "Executive" | "Litigation" | "Policy" | "Law" | "UNFCCC";
+export type TCategory = "Legislative" | "Executive" | "Litigation" | "Policy" | "Law" | "UNFCCC" | "MCF";
+export type TCorpusTypeSubCategory = "AF" | "CIF" | "GCF" | "GEF" | "Laws and Policies" | "Intl. agreements";
 export type TDisplayCategory = "All" | TCategory;
 export type TEventCategory = TCategory | "Target";
 
@@ -141,6 +142,7 @@ export type TFamilyDocument = {
 };
 
 export type TFamily = {
+  corpus_type_name: TCorpusTypeSubCategory;
   family_category: TCategory;
   family_description: string;
   family_documents: TFamilyDocument[];
@@ -159,6 +161,7 @@ export type TFamilyPage = {
   geography: string;
   import_id: string;
   category: TCategory;
+  corpus_type_name: TCorpusTypeSubCategory;
   metadata: TFamilyMetadata;
   slug: string;
   corpus_id: string;


### PR DESCRIPTION
# What's changed

Update Metadata tiles on the search page to include MCF corporas.  

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
