### PR TITLE
Feature/pdct 1571 render multiple geographies in frontend

### DIFF
--- a/src/components/CountriesLink.tsx
+++ b/src/components/CountriesLink.tsx
@@ -1,0 +1,26 @@
+import { CountryLink } from "@components/CountryLink";
+import { getCountryName } from "@helpers/getCountryFields";
+import { isSystemGeo } from "@utils/isSystemGeo";
+import { TGeography } from "@types";
+
+type TProps = {
+  geographies: string[];
+  countries: TGeography[];
+};
+
+const CountriesLinks = ({ geographies, countries }: TProps) => (
+  <>
+    {geographies?.map(
+      (geography, index) =>
+        !isSystemGeo(geography) && (
+          <span key={index} className="flex gap-1">
+            <CountryLink countryCode={geography} className="text-textDark no-underline">
+              <span>{getCountryName(geography, countries)}</span>
+            </CountryLink>
+          </span>
+        )
+    )}
+  </>
+);
+
+export default CountriesLinks;

--- a/src/components/CountriesLink.tsx
+++ b/src/components/CountriesLink.tsx
@@ -1,14 +1,15 @@
+import { FC } from "react";
 import { CountryLink } from "@components/CountryLink";
 import { getCountryName } from "@helpers/getCountryFields";
 import { isSystemGeo } from "@utils/isSystemGeo";
 import { TGeography } from "@types";
 
-type TProps = {
+type TCountriesLink = {
   geographies: string[];
   countries: TGeography[];
 };
 
-const CountriesLinks = ({ geographies, countries }: TProps) => (
+export const CountriesLink: FC<TCountriesLink> = ({ geographies, countries }) => (
   <>
     {geographies?.map(
       (geography, index) =>
@@ -22,5 +23,3 @@ const CountriesLinks = ({ geographies, countries }: TProps) => (
     )}
   </>
 );
-
-export default CountriesLinks;

--- a/src/components/CountriesLink.tsx
+++ b/src/components/CountriesLink.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react";
 import { CountryLink } from "@components/CountryLink";
 import { getCountryName } from "@helpers/getCountryFields";
 import { isSystemGeo } from "@utils/isSystemGeo";
@@ -9,7 +8,7 @@ type TCountriesLink = {
   countries: TGeography[];
 };
 
-export const CountriesLink: FC<TCountriesLink> = ({ geographies, countries }) => (
+export const CountriesLink = ({ geographies, countries }: TCountriesLink) => (
   <>
     {geographies?.map(
       (geography, index) =>

--- a/src/components/CountriesLink.tsx
+++ b/src/components/CountriesLink.tsx
@@ -11,9 +11,9 @@ type TCountriesLink = {
 export const CountriesLink = ({ geographies, countries }: TCountriesLink) => (
   <>
     {geographies?.map(
-      (geography, index) =>
+      (geography) =>
         !isSystemGeo(geography) && (
-          <span key={index} className="flex gap-1">
+          <span key={geography} className="flex gap-1">
             <CountryLink countryCode={geography} className="text-textDark no-underline">
               <span>{getCountryName(geography, countries)}</span>
             </CountryLink>

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,6 @@
 import { LinkWithQuery } from "@components/LinkWithQuery";
+import { isSystemGeo } from "@utils/isSystemGeo";
+
 const BREADCRUMB_MAXLENGTH = 50;
 
 type TBreadcrumbLink = {
@@ -40,7 +42,7 @@ export const BreadCrumbs = ({ geography = null, category = null, family = null, 
   return (
     <ul className="flex items-baseline flex-wrap gap-2 text-sm" data-cy="breadcrumbs">
       <BreadCrumb label="Home" href="/" cy="home" />
-      {geography && <BreadCrumb label={geography.label} href={geography.label === "No Geography" ? null : geography.href} cy="geography" />}
+      {geography && <BreadCrumb label={geography.label} href={isSystemGeo(geography.label) ? null : geography.href} cy="geography" />}
       {category && <BreadCrumb label={category.label} href={category.href} cy="category" />}
       {family && <BreadCrumb label={family.label} href={family.href} cy="family" />}
       <BreadCrumb label={label} last cy="current" />

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -42,7 +42,7 @@ export const BreadCrumbs = ({ geography = null, category = null, family = null, 
   return (
     <ul className="flex items-baseline flex-wrap gap-2 text-sm" data-cy="breadcrumbs">
       <BreadCrumb label="Home" href="/" cy="home" />
-      {geography && <BreadCrumb label={geography.label} href={isSystemGeo(geography.label) ? null : geography.href} cy="geography" />}
+      {geography && <BreadCrumb label={geography.label} href={isSystemGeo(String(geography.label)) ? null : geography.href} cy="geography" />}
       {category && <BreadCrumb label={category.label} href={category.href} cy="category" />}
       {family && <BreadCrumb label={family.label} href={family.href} cy="family" />}
       <BreadCrumb label={label} last cy="current" />

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -7,7 +7,6 @@ import { TFamilyPage } from "@types";
 
 type TProps = {
   family: TFamilyPage;
-  geographyName: string;
   onCollectionClick?: (e: any, i: number) => void;
 };
 

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -42,7 +42,7 @@ export const FamilyHead = ({ family, onCollectionClick }: TProps) => {
           category={family.category}
           corpus_type_name={family.corpus_type_name}
           date={family.published_date}
-          geography={family.geographies[0]}
+          geographies={family.geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
           topics={family.metadata.topic}
           author={family.metadata.author_type}
         />

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -42,7 +42,7 @@ export const FamilyHead = ({ family, onCollectionClick }: TProps) => {
           category={family.category}
           corpus_type_name={family.corpus_type_name}
           date={family.published_date}
-          geographies={family.geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
+          geographies={family.geographies}
           topics={family.metadata.topic}
           author={family.metadata.author_type}
         />

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -17,12 +17,7 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
   return (
     <div className="family-list-item relative">
       <div className="flex flex-wrap text-[13px] gap-1 mb-2 items-center middot-between">
-        <FamilyMeta
-          category={family_category}
-          corpus_type_name={corpus_type_name}
-          date={family_date}
-          geographies={family_geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
-        />
+        <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} date={family_date} geographies={family_geographies} />
         {children}
       </div>
       <LinkWithQuery

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -21,7 +21,7 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
           category={family_category}
           corpus_type_name={corpus_type_name}
           date={family_date}
-          geography={family_geographies.length > 0 ? family_geographies[0] : ""}
+          geographies={family_geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
         />
         {children}
       </div>

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -1,10 +1,8 @@
 import useConfig from "@hooks/useConfig";
-import { CountryLink } from "@components/CountryLink";
-import { getCountryName } from "@helpers/getCountryFields";
 import { getCategoryName } from "@helpers/getCategoryName";
-import { isSystemGeo } from "@utils/isSystemGeo";
 import { convertDate } from "@utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@types";
+import { CountriesLinks } from "@components/CountriesLinks";
 
 type TProps = {
   category: TCategory;
@@ -23,16 +21,7 @@ export const FamilyMeta = ({ category, date, geographies, topics, author, corpus
 
   return (
     <>
-      {geographies?.map(
-        (geography, index) =>
-          !isSystemGeo(geography) && (
-            <span key={index} className="flex gap-1">
-              <CountryLink countryCode={geography} className="text-textDark no-underline">
-                <span>{getCountryName(geography, countries)}</span>
-              </CountryLink>
-            </span>
-          )
-      )}
+      <CountriesLinks geographies={geographies} countries={countries} />
       {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY: {year}</span>}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -10,7 +10,7 @@ type TProps = {
   category: TCategory;
   corpus_type_name: TCorpusTypeSubCategory;
   date: string;
-  geographies: string[] | null;
+  geographies: string[];
   topics?: string[];
   author?: string[];
 };

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -2,7 +2,7 @@ import useConfig from "@hooks/useConfig";
 import { getCategoryName } from "@helpers/getCategoryName";
 import { convertDate } from "@utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@types";
-import { CountriesLinks } from "@components/CountriesLinks";
+import { CountriesLink } from "@components/CountriesLink";
 
 type TProps = {
   category: TCategory;
@@ -21,7 +21,7 @@ export const FamilyMeta = ({ category, date, geographies, topics, author, corpus
 
   return (
     <>
-      <CountriesLinks geographies={geographies} countries={countries} />
+      <CountriesLink geographies={geographies} countries={countries} />
       {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY: {year}</span>}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -10,26 +10,28 @@ type TProps = {
   category: TCategory;
   corpus_type_name: TCorpusTypeSubCategory;
   date: string;
-  geography: string;
+  geographies: string[] | null;
   topics?: string[];
   author?: string[];
 };
 
-export const FamilyMeta = ({ category, date, geography, topics, author, corpus_type_name }: TProps) => {
+export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name }: TProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
 
   const [year] = convertDate(date);
-  const country_name = getCountryName(geography, countries);
 
   return (
     <>
-      {!isSystemGeo(geography) && (
-        <span className="flex gap-1">
-          <CountryLink countryCode={geography} className="text-textDark no-underline">
-            <span>{country_name}</span>
-          </CountryLink>
-        </span>
+      {geographies?.map(
+        (geography, index) =>
+          !isSystemGeo(geography) && (
+            <span key={index} className="flex gap-1">
+              <CountryLink countryCode={geography} className="text-textDark no-underline">
+                <span>{getCountryName(geography, countries)}</span>
+              </CountryLink>
+            </span>
+          )
       )}
       {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY: {year}</span>}
       {category && (

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -77,12 +77,15 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
             <Heading level={1}>{document.title}</Heading>
             <div className="my-4 md:my-2 md:flex justify-between items-center">
               <div className="flex text-sm items-center gap-2 middot-between">
-                {!isSystemGeo(family.geographies[0]) && (
-                  <span className="flex gap-1">
-                    <CountryLink countryCode={family.geographies[0]} className="text-textDark font-medium">
-                      <span>{geoName}</span>
-                    </CountryLink>
-                  </span>
+                {family.geographies?.map(
+                  (geography, index) =>
+                    !isSystemGeo(geography) && (
+                      <span key={index} className="flex gap-1">
+                        <CountryLink countryCode={geography} className="text-textDark no-underline">
+                          <span>{getCountryName(geography, countries)}</span>
+                        </CountryLink>
+                      </span>
+                    )
                 )}
                 {!isMain && <span className="capitalize">{document.document_role.toLowerCase()}</span>}
                 {family.category && <span className="capitalize">{family.category}</span>}

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -39,10 +39,12 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
 
   const configQuery = useConfig();
   const { data: { countries = [], languages = {} } = {} } = configQuery;
-  const geoName = getCountryName(family.geographies[0], countries);
-  const geoSlug = getCountrySlug(family.geographies[0], countries);
+
+  const geographyNames = family.geographies ? family.geographies.map((geo) => getCountryName(geo, countries)) : null;
+  const geoName = geographyNames ? geographyNames[0] : "";
+  const geoSlug = family.geographies ? getCountrySlug(family.geographies[0], countries) : "";
   const isMain = document.document_role.toLowerCase().includes("main");
-  const breadcrumbGeography = { label: geoName, href: `/geographies/${geoSlug}` };
+  const breadcrumbGeography = family.geographies && family.geographies.length > 1 ? null : { label: geoName, href: `/geographies/${geoSlug}` };
   const breadcrumbFamily = { label: family.title, href: `/document/${family.slug}` };
   const breadcrumbLabel = isMain ? "Document" : document.document_role.toLowerCase();
   const breadcrumbCategory = { label: "Search results", href: "/search" };

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -4,7 +4,6 @@ import useConfig from "@hooks/useConfig";
 import { SiteWidth } from "@components/panels/SiteWidth";
 
 import { SubNav } from "@components/nav/SubNav";
-import { CountryLink } from "@components/CountryLink";
 import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
 import Button from "@components/buttons/Button";
 import { ExternalLinkIcon, AlertCircleIcon } from "@components/svg/Icons";
@@ -14,9 +13,8 @@ import { Heading } from "@components/typography/Heading";
 
 import { getLanguage } from "@helpers/getLanguage";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
-
+import { CountriesLinks } from "@components/CountriesLinks";
 import { truncateString } from "@utils/truncateString";
-import { isSystemGeo } from "@utils/isSystemGeo";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@constants/document";
 
@@ -77,16 +75,7 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
             <Heading level={1}>{document.title}</Heading>
             <div className="my-4 md:my-2 md:flex justify-between items-center">
               <div className="flex text-sm items-center gap-2 middot-between">
-                {family.geographies?.map(
-                  (geography, index) =>
-                    !isSystemGeo(geography) && (
-                      <span key={index} className="flex gap-1">
-                        <CountryLink countryCode={geography} className="text-textDark no-underline">
-                          <span>{getCountryName(geography, countries)}</span>
-                        </CountryLink>
-                      </span>
-                    )
-                )}
+                <CountriesLinks geographies={family.geographies} countries={countries} />
                 {!isMain && <span className="capitalize">{document.document_role.toLowerCase()}</span>}
                 {family.category && <span className="capitalize">{family.category}</span>}
                 {!!document.language && (

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -13,7 +13,7 @@ import { Heading } from "@components/typography/Heading";
 
 import { getLanguage } from "@helpers/getLanguage";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
-import { CountriesLinks } from "@components/CountriesLinks";
+import { CountriesLink } from "@components/CountriesLink";
 import { truncateString } from "@utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@constants/document";
@@ -75,7 +75,7 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
             <Heading level={1}>{document.title}</Heading>
             <div className="my-4 md:my-2 md:flex justify-between items-center">
               <div className="flex text-sm items-center gap-2 middot-between">
-                <CountriesLinks geographies={family.geographies} countries={countries} />
+                <CountriesLink geographies={family.geographies} countries={countries} />
                 {!isMain && <span className="capitalize">{document.document_role.toLowerCase()}</span>}
                 {family.category && <span className="capitalize">{family.category}</span>}
                 {!!document.language && (

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -42,12 +42,7 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
         <div className="p-5 pb-0 pr-10 md:pr-12">
           <Heading level={2}>{family_name}</Heading>
           <div className="flex flex-wrap text-sm gap-1 mt-2 items-center middot-between">
-            <FamilyMeta
-              category={family_category}
-              corpus_type_name={corpus_type_name}
-              geographies={family_geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
-              date={family_date}
-            />
+            <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} geographies={family_geographies} date={family_date} />
           </div>
           <div className="mt-5">
             <Heading level={3}>Summary</Heading>

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -45,7 +45,7 @@ export const FamilyMatchesDrawer = ({ family }: TProps) => {
             <FamilyMeta
               category={family_category}
               corpus_type_name={corpus_type_name}
-              geography={family_geographies.length > 0 ? family_geographies[0] : ""}
+              geographies={family_geographies} // FIXME family_geographies.length > 0 ? family_geographies[0] : ""
               date={family_date}
             />
           </div>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -162,13 +162,14 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
   return (
     <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)}>
       <Script id="analytics">
-        analytics.category = "{page.category}"; analytics.type = "{getDocumentCategories().join(",")}"; analytics.geography = "{page.geographies[0]}";
+        analytics.category = "{page.category}"; analytics.type = "{getDocumentCategories().join(",")}"; analytics.geography = "
+        {page.geographies?.join(",")}";
       </Script>
       <section
         className="mb-8"
         data-analytics-category={page.category}
         data-analytics-type={getDocumentCategories().join(",")}
-        data-analytics-geography={page.geographies[0]}
+        data-analytics-geography={page.geographies?.join(",")}
       >
         <SubNav>
           <BreadCrumbs geography={breadcrumbGeography} category={breadcrumbCategory} label={page.title} />

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -75,10 +75,12 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
   const publishedTargets = sortFilterTargets(targets);
   const hasTargets = !!publishedTargets && publishedTargets?.length > 0;
 
-  const geographyName = getCountryName(page.geographies[0], countries);
-  const geographySlug = getCountrySlug(page.geographies[0], countries);
+  const geographyNames = page.geographies ? page.geographies.map((geo) => getCountryName(geo, countries)) : null;
+  const geographyName = geographyNames ? geographyNames[0] : "";
+  const geographySlug = page.geographies ? getCountrySlug(page.geographies[0], countries) : "";
   const breadcrumbCategory = { label: "Search results", href: "/search" };
-  const breadcrumbGeography = { label: geographyName, href: `/geographies/${geographySlug}` };
+  const breadcrumbGeography =
+    page.geographies && page.geographies.length > 1 ? null : { label: geographyName, href: `/geographies/${geographySlug}` };
 
   let searchFamily: TMatchedFamily = null;
   const { status, families } = useSearch(router.query, page.import_id, null, !!router.query[QUERY_PARAMS.query_string], MAX_PASSAGES);
@@ -158,7 +160,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
   };
 
   return (
-    <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyName, page.category)}>
+    <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)}>
       <Script id="analytics">
         analytics.category = "{page.category}"; analytics.type = "{getDocumentCategories().join(",")}"; analytics.geography = "{page.geographies[0]}";
       </Script>
@@ -173,7 +175,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ pa
         </SubNav>
         <SiteWidth>
           <SingleCol extraClasses="mt-8">
-            <FamilyHead family={page} geographyName={geographyName} onCollectionClick={handleCollectionClick} />
+            <FamilyHead family={page} onCollectionClick={handleCollectionClick} />
             <section className="mt-6">
               {/* SSR summary */}
               <div className={`text-content mt-4 ${summary && "hidden"}`} dangerouslySetInnerHTML={{ __html: page.summary }} />

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -148,7 +148,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       <section
         className="pb-8 flex-1 flex flex-col"
         data-analytics-date={family.published_date}
-        data-analytics-geography={family.geographies[0]}
+        data-analytics-geography={family.geographies?.join(",")}
         data-analytics-variant={document.variant}
         data-analytics-type={document.content_type}
       >

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -158,7 +158,6 @@ export type TFamilyPage = {
   organisation: string;
   title: string;
   summary: string;
-  geography: string;
   geographies: string[];
   import_id: string;
   category: TCategory;

--- a/src/utils/isSystemGeo.ts
+++ b/src/utils/isSystemGeo.ts
@@ -2,5 +2,5 @@ import { systemGeoCodes, systemGeoNames } from "@constants/systemGeos";
 
 export const isSystemGeo = (geo?: string) => {
   if (!geo) return false;
-  return systemGeoCodes.includes(geo.toLowerCase()) || systemGeoNames.includes(geo.toLowerCase());
+  return systemGeoCodes.includes(geo.toLowerCase()) || systemGeoNames.includes(geo.replace(" ", "-").toLowerCase());
 };


### PR DESCRIPTION
# What's changed

Render multiple geographies in the frontend.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
