### PR TITLE
Only show Approval FY for MCF families

### DIFF
--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -22,7 +22,8 @@ export const FamilyMeta = ({ category, date, geographies, topics, author, corpus
   return (
     <>
       <CountriesLink geographies={geographies} countries={countries} />
-      {!isNaN(year) && <span data-cy="family-metadata-year">Approval FY: {year}</span>}
+      {/* TODO: we need to revisit this once we have updated the config, so that we can determine this output based on the corpora */}
+      {!isNaN(year) && <span data-cy="family-metadata-year">{`${category === "MCF" ? "Approval FY: " + year : year}`}</span>}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">
           {getCategoryName(category, corpus_type_name)}


### PR DESCRIPTION
# What's changed

Only show Approval FY for MCF families.

Fix bug so I can prod deploy the frontend.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
