### PR TITLE
feature/pdct-1619-update-geography-page

### DIFF
--- a/src/constants/documentCategories.ts
+++ b/src/constants/documentCategories.ts
@@ -1,3 +1,6 @@
 export const DOCUMENT_CATEGORIES = ["All", "Legislation", "Policies", "UNFCCC", "Litigation"];
 
+// For now all individual fund documents are returning as MCF, so we do not need separate categories
+export const MCF_DOCUMENT_CATEGORIES = ["All"];
+
 export type TDocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -92,12 +92,14 @@ type TGeoFamilyCounts = {
   Legislative: number;
   Executive: number;
   UNFCCC: number;
+  MCF: number;
 };
 
 type TGeoFamilys = {
   Legislative: TFamily[];
   Executive: TFamily[];
   UNFCCC: TFamily[];
+  MCF: TFamily[];
 };
 
 export type TGeographySummary = {


### PR DESCRIPTION


# What's changed

- As we want to keep the functionality and look of the geography page at this stage, we are just updating the way we present the data
- filter the data in the server side prop only return MCF related data
- define variable to hold if the app is currently mcf, if so update the document categories that we pass to the nav index, as well as the docs that we are rendering in the render docs file. For the latter we we only parse the current category if there are more than one categories/families, in which case is a non mcf app

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
