### PR TITLE
fix: avoid LegacyKeyValueFormat in Docker by using =

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --chmod=0755  . .
 # Install dependencies.
 RUN npm ci && npm cache clean --force
 
-ENV PATH /home/node/app/node_modules/.bin:$PATH
+ENV PATH=/home/node/app/node_modules/.bin:$PATH
 
 RUN npm run build
 


### PR DESCRIPTION
# What's changed

I had received a `LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)` error when running `make`.

This resolved that.

This is more being done to help me, as a new starter, to verify I have everything that I need to make a change and deploy - rather than being excessively useful change.


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version
