### PR TITLE
Extend accordion to accept className

### DIFF
--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -10,13 +10,14 @@ type TProps = {
   startOpen?: boolean;
   overflowOverride?: boolean;
   children: React.ReactNode;
+  className?: string;
 };
 
 export const Accordian = ({ title, startOpen = false, overflowOverride, children, ...props }: TProps) => {
   const [isOpen, setIsOpen] = useState(startOpen);
 
   return (
-    <div className="" {...props}>
+    <div {...props}>
       <div className={`flex justify-between cursor-pointer group`} onClick={() => setIsOpen(!isOpen)} data-cy="accordian-control">
         <Heading>{title}</Heading>
         <span className={`opacity-40 group-hover:opacity-100 ${isOpen ? "" : ""}`}>{isOpen ? <AccordianCloseIcon /> : <AccordianOpenIcon />}</span>

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -231,6 +231,7 @@ const SearchFilters = ({
         title={getFilterLabel("Published jurisdiction", "country", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="countries"
         overflowOverride
+        className="relative z-10"
       >
         <InputListContainer>
           <TypeAhead


### PR DESCRIPTION
# What's changed
- Accordion component now accepts `className` as prop

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
