### PR TITLE
Add settings button ref check for displaying and hiding the settings

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { MutableRefObject, useEffect, useRef, useState } from "react";
 import { ParsedUrlQuery } from "querystring";
 
 import { SearchSettingsList } from "./SearchSettingsList";
@@ -12,6 +12,7 @@ type TProps = {
   handleSortClick?: (sortOption: string) => void;
   handleSearchChange?: (key: string, value: string) => void;
   setShowOptions?: (value: boolean) => void;
+  settingsButtonRef?: MutableRefObject<any>;
 };
 
 const getCurrentSortChoice = (queryParams: ParsedUrlQuery, isBrowsing: boolean) => {
@@ -32,7 +33,7 @@ const getCurrentSemanticSearchChoice = (queryParams: ParsedUrlQuery) => {
   return exactMatch as string;
 };
 
-export const SearchSettings = ({ queryParams, handleSortClick, handleSearchChange, setShowOptions }: TProps) => {
+export const SearchSettings = ({ queryParams, handleSortClick, handleSearchChange, setShowOptions, settingsButtonRef }: TProps) => {
   const searchOptionsRef = useRef(null);
   const [options, setOptions] = useState(sortOptions);
 
@@ -55,7 +56,12 @@ export const SearchSettings = ({ queryParams, handleSortClick, handleSearchChang
   // Clicking outside the search options will close them
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (searchOptionsRef.current && !searchOptionsRef.current.contains(event.target)) {
+      if (
+        searchOptionsRef?.current &&
+        !searchOptionsRef.current.contains(event.target) &&
+        settingsButtonRef?.current &&
+        !settingsButtonRef.current.contains(event.target)
+      ) {
         setShowOptions && setShowOptions(false);
       }
     };
@@ -63,7 +69,7 @@ export const SearchSettings = ({ queryParams, handleSortClick, handleSearchChang
     return () => {
       document.removeEventListener("click", handleClickOutside, true);
     };
-  }, [searchOptionsRef, setShowOptions]);
+  }, [searchOptionsRef, settingsButtonRef, setShowOptions]);
 
   return (
     <div

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { ParsedUrlQueryInput } from "querystring";
 import { motion, AnimatePresence } from "framer-motion";
@@ -39,6 +39,7 @@ const Search = () => {
   const [showCSVDownloadPopup, setShowCSVDownloadPopup] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [drawerFamily, setDrawerFamily] = useState<boolean | number>(false);
+  const settingsButtonRef = useRef(null);
 
   const { status, families, hits, continuationToken, searchQuery } = useSearch(router.query);
 
@@ -420,6 +421,7 @@ const Search = () => {
                       className="px-4 flex justify-center items-center text-textDark text-xl"
                       onClick={() => setShowOptions(!showOptions)}
                       data-cy="search-options"
+                      ref={settingsButtonRef}
                     >
                       <MdOutlineTune />
                     </button>
@@ -440,6 +442,7 @@ const Search = () => {
                             handleSortClick={handleSortClick}
                             handleSearchChange={handleSearchChange}
                             setShowOptions={setShowOptions}
+                            settingsButtonRef={settingsButtonRef}
                           />
                         </motion.div>
                       )}


### PR DESCRIPTION
# What's changed
- Click on settings button again will close the panel

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
