### PR TITLE
feature/pdct-1625-ui-adjustments

### DIFF
--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -29,7 +29,7 @@ export const CountryLinksAsList = ({ geographies, countries, showFlag = true }: 
     {geographies?.map(
       (geography, index) =>
         !isSystemGeo(geography) && (
-          <div key={geography} className="flex pl-1">
+          <div key={geography} className="flex">
             <CountryLink countryCode={geography} showFlag={showFlag} className="text-blue-600 underline truncate text-sm text-transform: capitalize">
               <span>{getCountryName(geography, countries)}</span>
             </CountryLink>

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -38,10 +38,12 @@ const ListOfCountries = ({ countryCodes, icon, label }: ListOfCountriesProps) =>
 
   return (
     <>
-      <GeographyIconComponent className="min-w-[16px] min-h-[16px]" />
-      <span className="text-sm font-bold pl-1">
-        <strong>{label}</strong>
-      </span>
+      <div className="flex row items-center">
+        <GeographyIconComponent className="min-w-[16px] min-h-[16px]" />
+        <span className="text-sm font-bold pl-1">
+          <strong>{label}</strong>
+        </span>
+      </div>
       <CountryLinksAsList geographies={countryCodes} countries={countries} showFlag={false} />
     </>
   );
@@ -52,12 +54,14 @@ const MultipleValuesContentComponent = ({ label, values, icon }: MultipleValuesC
 
   return (
     <>
-      <IconComponent className="min-w-[16px] min-h-[16px]" />
-      <span className="text-sm font-bold px-1">
-        <strong>{label}</strong>
-      </span>
+      <div className="flex row items-center">
+        <IconComponent className="min-w-[16px] min-h-[16px]" />
+        <span className="text-sm font-bold px-1">
+          <strong>{label}</strong>
+        </span>
+      </div>
       {values.map((item, index) => (
-        <div key={item} className="flex items-center pr-2">
+        <div key={item} className="flex items-center">
           <span key={item} className="text-sm">
             {item}
           </span>
@@ -76,12 +80,12 @@ const MetadataItem = ({ label, icon, values }: MetadataItemProps) => {
   const getValueContent = () => {
     if (isUrl && typeof values === "string") {
       return (
-        <ExternalLink url={values} className="text-blue-600 underline truncate text-sm">
+        <ExternalLink url={values} className="text-blue-600 underline truncate text-sm pl-1">
           Visit project page
         </ExternalLink>
       );
     } else {
-      return <span className="text-sm">{values}</span>;
+      return <span className="pl-1 text-sm">{values}</span>;
     }
   };
 
@@ -94,10 +98,10 @@ const MetadataItem = ({ label, icon, values }: MetadataItemProps) => {
   }
 
   return (
-    <div className="flex items-center gap-1 pt-1 pr-2 pb-1 max-w-full">
+    <div className="flex items-center row">
       <IconComponent className="min-w-[16px] min-h-[16px]" />
-      <div className="flex flex-row gap-1 items-center max-w-full">
-        <span className="text-sm font-bold ">
+      <div className="pl-1">
+        <span className="text-sm font-bold">
           <strong>{label}</strong>
         </span>
         {getValueContent()}
@@ -111,7 +115,7 @@ export const McfFamilyMeta = ({ metadata }: McfFamilyMetaProps) => {
 
   return (
     <div className="w-full bg-white py-4">
-      <div className="flex flex-wrap items-center">
+      <div className="flex flex-wrap items-center gap-y-1 gap-x-1.5">
         {mappedMetadata.map((item, index) => (
           <MetadataItem key={index} label={item.label} icon={item.iconLabel} values={item.value} />
         ))}


### PR DESCRIPTION
# What's changed

Fix spacing on metadata component - 
remove individual padding and just use a gap on the parent flexbox to ensure that there is consistent spacing.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
