### PR TITLE
Fix issues with the region vs. geo selectors

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -213,7 +213,11 @@ const SearchFilters = ({
           );
         })}
 
-      <Accordian title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)} data-cy="regions">
+      <Accordian
+        title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)}
+        data-cy="regions"
+        startOpen={!!query[QUERY_PARAMS.region]}
+      >
         <InputListContainer>
           {regions.map((region) => (
             <InputCheck
@@ -246,7 +250,11 @@ const SearchFilters = ({
         </InputListContainer>
       </Accordian>
 
-      <Accordian title={getFilterLabel("Date", "date", query[QUERY_PARAMS.category], themeConfig)} data-cy="date-range">
+      <Accordian
+        title={getFilterLabel("Date", "date", query[QUERY_PARAMS.category], themeConfig)}
+        data-cy="date-range"
+        startOpen={!!query[QUERY_PARAMS.year_range]}
+      >
         <DateRange type="year_range" handleChange={handleYearChange} defaultValues={searchCriteria.year_range} min={minYear} max={thisYear} />
       </Accordian>
 

--- a/src/helpers/getCountriesFromRegions.ts
+++ b/src/helpers/getCountriesFromRegions.ts
@@ -12,10 +12,11 @@ export const getCountriesFromRegions = ({ regions, countries, selectedRegions }:
   let newList = countries;
 
   if (selectedRegionsGeo.length > 0) {
+    newList = [];
     // for each selected region, filter the countries
     for (let i = 0; i < selectedRegionsGeo.length; i++) {
       const region = selectedRegionsGeo[i];
-      newList = countries.filter((item: any) => item.parent_id === region.id);
+      newList = newList.concat(countries.filter((item: any) => item.parent_id === region.id));
     }
   }
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -91,6 +91,9 @@ const Search = () => {
 
   const handleRegionChange = (regionName: string) => {
     delete router.query[QUERY_PARAMS.offset];
+    delete router.query[QUERY_PARAMS.active_continuation_token];
+    delete router.query[QUERY_PARAMS.continuation_tokens];
+    delete router.query[QUERY_PARAMS.country];
     const query = { ...router.query };
     const regions = (query[QUERY_PARAMS.region] as string[]) || [];
 


### PR DESCRIPTION
# What's changed
- When selecting / deselecting a region it removes selected geos
- List of geos is built up of all selected regions, not just one as it was previously
- Filters start open if one is applied

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
