### PR TITLE
Add Adaptation Fund to MCF config for search

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -66,7 +66,7 @@
       "taxonomyKey": "status",
       "apiMetaDataKey": "family.status",
       "type": "radio",
-      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"]
+      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"]
     },
     {
       "label": "Implementing agency",
@@ -74,7 +74,7 @@
       "taxonomyKey": "implementing_agency",
       "apiMetaDataKey": "family.implementing_agency",
       "type": "radio",
-      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"],
+      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"],
       "showFade": "true"
     }
   ],
@@ -82,7 +82,7 @@
     {
       "key": "date",
       "label": "First published",
-      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"]
+      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"]
     }
   ],
   "links": [

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -27,7 +27,7 @@
       {
         "label": "Multilateral Climate Funds",
         "slug": "multilateral-climate-funds",
-        "value": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"]
+        "value": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"]
       },
       {
         "label": "Litigation",
@@ -50,10 +50,15 @@
           "label": "Global Environment Facility",
           "slug": "global-environment-facility",
           "value": ["MCF.corpus.GEF.n0000"]
+        },
+        {
+          "label": "Adaptation Fund",
+          "slug": "adaptation-fund",
+          "value": ["MCF.corpus.AF.n0000"]
         }
       ],
       "type": "checkbox",
-      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"]
+      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"]
     },
     {
       "label": "Status",

--- a/themes/mcf/config.json
+++ b/themes/mcf/config.json
@@ -1,5 +1,5 @@
 {
-  "defaultCorpora": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000"],
+  "defaultCorpora": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"],
   "filters": [
     {
       "label": "Climate funds",
@@ -15,6 +15,11 @@
           "label": "Global Environment Facility",
           "slug": "global-environment-facility",
           "value": ["MCF.corpus.GEF.n0000"]
+        },
+        {
+          "label": "Adaptation Fund",
+          "slug": "adaptation-fund",
+          "value": ["MCF.corpus.AF.n0000"]
         }
       ],
       "type": "checkbox",


### PR DESCRIPTION
# What's changed
- added Adaptation Fund to MCF config

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
