### PR TITLE
Taxonomy values corpora and displaying system geos

### DIFF
--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -11,31 +11,33 @@ type TCountriesLink = {
 
 export const CountryLinks = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
-    {geographies?.map(
-      (geography) =>
-        !isSystemGeo(geography) && (
-          <span key={geography} className="flex gap-1">
-            <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
-              <span>{getCountryName(geography, countries)}</span>
-            </CountryLink>
-          </span>
-        )
-    )}
+    {geographies?.map((geography) => (
+      <span key={geography} className="flex gap-1">
+        {isSystemGeo(geography) ? (
+          <>{getCountryName(geography, countries)}</>
+        ) : (
+          <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
+            <span>{getCountryName(geography, countries)}</span>
+          </CountryLink>
+        )}
+      </span>
+    ))}
   </>
 );
 
 export const CountryLinksAsList = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
-    {geographies?.map(
-      (geography, index) =>
-        !isSystemGeo(geography) && (
-          <div key={geography} className="flex">
-            <CountryLink countryCode={geography} showFlag={showFlag} className="text-blue-600 underline truncate text-sm text-transform: capitalize">
-              <span>{getCountryName(geography, countries)}</span>
-            </CountryLink>
-            {index !== geographies.length - 1 && <span>,</span>}
-          </div>
-        )
-    )}
+    {geographies?.map((geography, index) => (
+      <div key={geography} className="flex">
+        {isSystemGeo(geography) ? (
+          <>{getCountryName(geography, countries)}</>
+        ) : (
+          <CountryLink countryCode={geography} showFlag={showFlag} className="text-blue-600 underline truncate text-sm text-transform: capitalize">
+            <span>{getCountryName(geography, countries)}</span>
+          </CountryLink>
+        )}
+        {index !== geographies.length - 1 && <span>,</span>}
+      </div>
+    ))}
   </>
 );

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -18,7 +18,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 
 import { getCountriesFromRegions } from "@helpers/getCountriesFromRegions";
 
-import { TGeography, TOrganisationDictionary, TSearchCriteria, TThemeConfigFilter, TThemeConfigOption } from "@types";
+import { TGeography, TOrganisationDictionary, TSearchCriteria, TThemeConfig, TThemeConfigFilter, TThemeConfigOption } from "@types";
 import { ParsedUrlQuery } from "querystring";
 import { canDisplayFilter } from "@utils/canDisplayFilter";
 import { getFilterLabel } from "@utils/getFilterLabel";
@@ -37,12 +37,21 @@ const isCategoryChecked = (selectedCatgeory: string | undefined, themeConfigCate
   return false;
 };
 
+const getTaxonomyAllowedValues = (corporaKey: string, taxonomyKey: string, organisations: TOrganisationDictionary) => {
+  const allowedValues = organisations[corporaKey].corpora.find((corpus) => corpus.taxonomy.hasOwnProperty(taxonomyKey))?.taxonomy[taxonomyKey]
+    ?.allowed_values;
+
+  return allowedValues;
+};
+
 const renderFilterOptions = (
   filter: TThemeConfigFilter,
   query: ParsedUrlQuery,
   handleFilterChange: Function,
-  organisations: TOrganisationDictionary
+  organisations: TOrganisationDictionary,
+  themeConfig: TThemeConfig
 ) => {
+  // If the filter has its own options defined, display them
   if (filter.options && filter.options.length > 0) {
     return filter.options.map((option) =>
       filter.type === "radio" ? (
@@ -67,34 +76,59 @@ const renderFilterOptions = (
       )
     );
   }
-  if (filter.corporaTypeKey && organisations && organisations[filter.corporaTypeKey]) {
-    // check our organisation contains the filter in its list of taxonomies
-    // we  do not want to attempt to render if our config is unaligned or our taxonomy does not exist
-    const corpus = organisations[filter.corporaTypeKey].corpora.find((corpus) => corpus.taxonomy.hasOwnProperty(filter.taxonomyKey));
-    if (corpus) {
-      return corpus.taxonomy[filter.taxonomyKey]?.allowed_values.map((option: string) =>
-        filter.type === "radio" ? (
-          <InputRadio
-            key={option}
-            label={option}
-            checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
-            onChange={() => null} // supress normal radio behaviour to allow to deselection
-            onClick={() => {
-              handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option, true);
-            }}
-          />
-        ) : (
-          <InputCheck
-            key={option}
-            label={option}
-            checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
-            onChange={() => {
-              handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option);
-            }}
-          />
-        )
-      );
+  // Check the dependancy filter key for which filters to load the taxonomy for
+  let options = [];
+  const dependantFilter = themeConfig.filters.find((f) => f.taxonomyKey === filter.dependantFilterKey);
+  const queryDependantFilter = query[QUERY_PARAMS[dependantFilter?.taxonomyKey]] || [];
+
+  // If no filter of a given dependancy is selected, load all dependancy taxonomy values
+  if (queryDependantFilter.length === 0) {
+    for (let index = 0; index < dependantFilter.options.length; index++) {
+      const option = dependantFilter.options[index];
+      const taxonomyAllowedValues = getTaxonomyAllowedValues(option.corporaKey, filter.taxonomyKey, organisations);
+      options = options.concat(taxonomyAllowedValues);
     }
+  } else {
+    // Otherwise, load the taxonomy values for the selected dependancy filter(s)
+    if (typeof queryDependantFilter === "string") {
+      const filterCoporaKey = dependantFilter.options.find((option) => option.slug === queryDependantFilter)?.corporaKey;
+      const taxonomyAllowedValues = getTaxonomyAllowedValues(filterCoporaKey, filter.taxonomyKey, organisations);
+      options = options.concat(taxonomyAllowedValues);
+    } else {
+      for (let index = 0; index < queryDependantFilter.length; index++) {
+        const filterCoporaKey = dependantFilter.options.find((option) => option.slug === queryDependantFilter[index])?.corporaKey;
+        const taxonomyAllowedValues = getTaxonomyAllowedValues(filterCoporaKey, filter.taxonomyKey, organisations);
+        options = options.concat(taxonomyAllowedValues);
+      }
+    }
+  }
+
+  // De-duplicate and sort the options
+  const optionsDeDuped: string[] = [...new Set(options.sort())];
+
+  if (optionsDeDuped.length) {
+    return optionsDeDuped.map((option: string) =>
+      filter.type === "radio" ? (
+        <InputRadio
+          key={option}
+          label={option}
+          checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
+          onChange={() => null} // supress normal radio behaviour to allow to deselection
+          onClick={() => {
+            handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option, true);
+          }}
+        />
+      ) : (
+        <InputCheck
+          key={option}
+          label={option}
+          checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
+          onChange={() => {
+            handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option);
+          }}
+        />
+      )
+    );
   }
   return null;
 };
@@ -208,7 +242,7 @@ const SearchFilters = ({
               startOpen={filter.startOpen === "true" || !!query[QUERY_PARAMS[filter.taxonomyKey]]}
               showFade={filter.showFade}
             >
-              <InputListContainer>{renderFilterOptions(filter, query, handleFilterChange, organisations)}</InputListContainer>
+              <InputListContainer>{renderFilterOptions(filter, query, handleFilterChange, organisations, themeConfig)}</InputListContainer>
             </Accordian>
           );
         })}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -155,6 +155,10 @@ const Search = () => {
       }
     }
 
+    if (type === QUERY_PARAMS.fund) {
+      delete router.query[QUERY_PARAMS.implementing_agency];
+    }
+
     router.query[type] = queryCollection;
     router.push({ query: router.query });
     resetCSVStatus();

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -321,6 +321,7 @@ export type TThemeConfigOption = {
   slug: string;
   value?: string[];
   category?: string[];
+  corporaKey?: string;
 };
 
 type TThemeConfigCategory = {
@@ -330,7 +331,6 @@ type TThemeConfigCategory = {
 
 export type TThemeConfigFilter = {
   label: string;
-  corporaTypeKey?: string;
   taxonomyKey: string;
   apiMetaDataKey?: string;
   type: string;
@@ -338,6 +338,7 @@ export type TThemeConfigFilter = {
   startOpen?: "true" | "false";
   options?: TThemeConfigOption[];
   showFade?: "true" | "false";
+  dependantFilterKey?: string;
 };
 
 type TThemeLink = {

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -44,17 +44,20 @@
         {
           "label": "Green Climate Fund",
           "slug": "green-climate-fund",
-          "value": ["MCF.corpus.GCF.n0000"]
+          "value": ["MCF.corpus.GCF.n0000"],
+          "corporaKey": "GCF"
         },
         {
           "label": "Global Environment Facility",
           "slug": "global-environment-facility",
-          "value": ["MCF.corpus.GEF.n0000"]
+          "value": ["MCF.corpus.GEF.n0000"],
+          "corporaKey": "GEF"
         },
         {
           "label": "Adaptation Fund",
           "slug": "adaptation-fund",
-          "value": ["MCF.corpus.AF.n0000"]
+          "value": ["MCF.corpus.AF.n0000"],
+          "corporaKey": "AF"
         }
       ],
       "type": "checkbox",
@@ -62,20 +65,20 @@
     },
     {
       "label": "Status",
-      "corporaTypeKey": "GCF",
       "taxonomyKey": "status",
       "apiMetaDataKey": "family.status",
       "type": "radio",
-      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"]
+      "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"],
+      "dependantFilterKey": "fund"
     },
     {
       "label": "Implementing agency",
-      "corporaTypeKey": "GCF",
       "taxonomyKey": "implementing_agency",
       "apiMetaDataKey": "family.implementing_agency",
       "type": "radio",
       "category": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000"],
-      "showFade": "true"
+      "showFade": "true",
+      "dependantFilterKey": "fund"
     }
   ],
   "labelVariations": [

--- a/themes/mcf/config.json
+++ b/themes/mcf/config.json
@@ -9,17 +9,20 @@
         {
           "label": "Green Climate Fund",
           "slug": "green-climate-fund",
-          "value": ["MCF.corpus.GCF.n0000"]
+          "value": ["MCF.corpus.GCF.n0000"],
+          "corporaKey": "GCF"
         },
         {
           "label": "Global Environment Facility",
           "slug": "global-environment-facility",
-          "value": ["MCF.corpus.GEF.n0000"]
+          "value": ["MCF.corpus.GEF.n0000"],
+          "corporaKey": "GEF"
         },
         {
           "label": "Adaptation Fund",
           "slug": "adaptation-fund",
-          "value": ["MCF.corpus.AF.n0000"]
+          "value": ["MCF.corpus.AF.n0000"],
+          "corporaKey": "AF"
         }
       ],
       "type": "checkbox",
@@ -27,20 +30,20 @@
     },
     {
       "label": "Status",
-      "corporaTypeKey": "GCF",
       "taxonomyKey": "status",
       "apiMetaDataKey": "family.status",
       "type": "radio",
-      "category": []
+      "category": [],
+      "dependantFilterKey": "fund"
     },
     {
       "label": "Implementing agency",
-      "corporaTypeKey": "GCF",
       "taxonomyKey": "implementing_agency",
       "apiMetaDataKey": "family.implementing_agency",
       "type": "radio",
       "category": [],
-      "showFade": "true"
+      "showFade": "true",
+      "dependantFilterKey": "fund"
     }
   ],
   "labelVariations": [


### PR DESCRIPTION
# What's changed
- List of allowed values for each fund is concatenated from the config -> corpora collections
- Displaying International and No Geography in the meta description, but not as country links

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
