### PR TITLE
Do not show "no geography" in the meta detail list of geographies

### DIFF
--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -1,6 +1,11 @@
+import { Fragment } from "react";
+
 import { CountryLink } from "@components/CountryLink";
+
 import { getCountryName } from "@helpers/getCountryFields";
-import { isSystemGeo } from "@utils/isSystemGeo";
+
+import { isSystemGeo, isSystemInternational } from "@utils/isSystemGeo";
+
 import { TGeography } from "@types";
 
 type TCountriesLink = {
@@ -12,15 +17,20 @@ type TCountriesLink = {
 export const CountryLinks = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
     {geographies?.map((geography) => (
-      <span key={geography} className="flex gap-1">
-        {isSystemGeo(geography) ? (
-          <>{getCountryName(geography, countries)}</>
-        ) : (
-          <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
-            <span>{getCountryName(geography, countries)}</span>
-          </CountryLink>
+      <Fragment key={geography}>
+        {isSystemInternational(geography) && (
+          <span className="flex gap-1">
+            <>{getCountryName(geography, countries)}</>
+          </span>
         )}
-      </span>
+        {!isSystemGeo(geography) && (
+          <span className="flex gap-1">
+            <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
+              <span>{getCountryName(geography, countries)}</span>
+            </CountryLink>
+          </span>
+        )}
+      </Fragment>
     ))}
   </>
 );
@@ -28,16 +38,22 @@ export const CountryLinks = ({ geographies, countries, showFlag = true }: TCount
 export const CountryLinksAsList = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
     {geographies?.map((geography, index) => (
-      <div key={geography} className="flex">
-        {isSystemGeo(geography) ? (
-          <>{getCountryName(geography, countries)}</>
-        ) : (
-          <CountryLink countryCode={geography} showFlag={showFlag} className="text-blue-600 underline truncate text-sm text-transform: capitalize">
-            <span>{getCountryName(geography, countries)}</span>
-          </CountryLink>
+      <Fragment key={geography}>
+        {isSystemInternational(geography) && (
+          <div className="flex">
+            <>{getCountryName(geography, countries)}</>
+            {index !== geographies.length - 1 && <span>,</span>}
+          </div>
         )}
-        {index !== geographies.length - 1 && <span>,</span>}
-      </div>
+        {!isSystemGeo(geography) && (
+          <div className="flex">
+            <CountryLink countryCode={geography} showFlag={showFlag} className="text-blue-600 underline truncate text-sm text-transform: capitalize">
+              <span>{getCountryName(geography, countries)}</span>
+            </CountryLink>
+            {index !== geographies.length - 1 && <span>,</span>}
+          </div>
+        )}
+      </Fragment>
     ))}
   </>
 );

--- a/src/constants/systemGeos.ts
+++ b/src/constants/systemGeos.ts
@@ -1,9 +1,8 @@
+export const SYSTEM_NO_GEOGRAPHY_CODE = "xaa";
+export const SYSTEM_NO_GEOGRAPHY_NAME = "no-geography";
 export const SYSTEM_INTERNATIONAL_CODE = "xab";
 export const SYSTEM_INTERNATIONAL_NAME = "international";
 
-export const systemGeoCodes = [
-  "xaa", // No Geography
-  SYSTEM_INTERNATIONAL_CODE,
-];
+export const systemGeoCodes = [SYSTEM_NO_GEOGRAPHY_CODE, SYSTEM_INTERNATIONAL_CODE];
 
-export const systemGeoNames = ["no-geography", SYSTEM_INTERNATIONAL_NAME];
+export const systemGeoNames = [SYSTEM_NO_GEOGRAPHY_NAME, SYSTEM_INTERNATIONAL_NAME];

--- a/src/constants/systemGeos.ts
+++ b/src/constants/systemGeos.ts
@@ -1,6 +1,9 @@
+export const SYSTEM_INTERNATIONAL_CODE = "xab";
+export const SYSTEM_INTERNATIONAL_NAME = "international";
+
 export const systemGeoCodes = [
   "xaa", // No Geography
-  "xab", // International
+  SYSTEM_INTERNATIONAL_CODE,
 ];
 
-export const systemGeoNames = ["no-geography", "international"];
+export const systemGeoNames = ["no-geography", SYSTEM_INTERNATIONAL_NAME];

--- a/src/utils/isSystemGeo.ts
+++ b/src/utils/isSystemGeo.ts
@@ -1,6 +1,11 @@
-import { systemGeoCodes, systemGeoNames } from "@constants/systemGeos";
+import { systemGeoCodes, systemGeoNames, SYSTEM_INTERNATIONAL_CODE, SYSTEM_INTERNATIONAL_NAME } from "@constants/systemGeos";
 
 export const isSystemGeo = (geo?: string) => {
   if (!geo) return false;
   return systemGeoCodes.includes(geo.toLowerCase()) || systemGeoNames.includes(geo.replace(" ", "-").toLowerCase());
+};
+
+export const isSystemInternational = (geo?: string) => {
+  if (!geo) return false;
+  return SYSTEM_INTERNATIONAL_CODE.includes(geo.toLowerCase()) || SYSTEM_INTERNATIONAL_NAME.includes(geo.replace(" ", "-").toLowerCase());
 };


### PR DESCRIPTION
# What's changed
- Only display "International" in the list of associated geographies
- Strictly not to display "No Geography" at any point

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
