### PR TITLE
Feature/pdct 1658 mobile predictive search to have a non transparent

### DIFF
--- a/themes/mcf/components/AboutClimateProjectExplorer.tsx
+++ b/themes/mcf/components/AboutClimateProjectExplorer.tsx
@@ -13,8 +13,8 @@ const AboutClimateProjectExplorer = () => {
           className="max-h-[824px] max-w-[1024px] object-cover"
         />{" "}
       </div>
-      <div className="relative lg:h-[824px] w-auto pb-16 lg:pb-0">
-        <div className="max-w-xl relative lg:z-10 ">
+      <div className="lg:relative lg:h-[824px] w-auto pb-16 lg:pb-0">
+        <div className="max-w-xl lg:relative lg:z-10 ">
           <Heading level={2} extraClasses="custom-header">
             About Climate Project Explorer
           </Heading>

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -20,7 +20,7 @@ const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
         </div>
         <AboutClimateProjectExplorer />
         <ContextualSearchContent />
-        <div className={`bg-white border-slate-700 border-solid border-2`}>
+        <div className={`bg-white border-slate-700 border-solid border-t-2`}>
           <AboutTheFunds />
         </div>
         <ClimatePolicyRadarBanner />


### PR DESCRIPTION
# What's changed

Fix issue where search suggestion dropdown appeared to have a non transparent background

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
