### PR TITLE
Correct links from geo -> search using category

### DIFF
--- a/src/components/forms/DocumentSearchForm.tsx
+++ b/src/components/forms/DocumentSearchForm.tsx
@@ -25,13 +25,13 @@ const DocumentSearchForm = ({
         <div className="mt-4 md:flex gap-2 text-sm items-center">
           {suggestionsAsLinks && (
             <>
-              <div className="mb-2 md:mb-0 flex-shrink-0 text-blue-900">Featured searches</div>
+              <div className="mb-2 md:mb-0 flex-shrink-0 text-textDark">Featured searches</div>
               <ul className="flex gap-1 flex-wrap items-center">
                 {featuredSearches.map((searchTerm) => (
                   <li key={searchTerm}>
                     <button
                       onClick={() => handleSearchInput(searchTerm)}
-                      className="text-gray-800 bg-white border border-gray-300 rounded-[40px] py-1 px-2 transition hover:bg-blue-600 hover:text-white"
+                      className="bg-white border rounded-[40px] py-1 px-2 transition hover:border-blue-600 hover:text-textDark"
                     >
                       {searchTerm}
                     </button>

--- a/src/constants/documentCategories.ts
+++ b/src/constants/documentCategories.ts
@@ -1,4 +1,4 @@
-export const DOCUMENT_CATEGORIES = ["All", "Legislation", "Policies", "UNFCCC", "Litigation"];
+export const DOCUMENT_CATEGORIES = ["All", "Legislation", "Policies", "Intl. agreements", "Litigation"];
 
 // For now all individual fund documents are returning as MCF, so we do not need separate categories
 export const MCF_DOCUMENT_CATEGORIES = ["All"];

--- a/src/helpers/getCategoryTooltip.ts
+++ b/src/helpers/getCategoryTooltip.ts
@@ -10,7 +10,7 @@ export const getCategoryTooltip = (category: TDocumentCategory): string => {
       return "For example: Policies, strategies, decrees, action plans (from executive branch)";
     case "Litigation":
       return "For example: Court cases and tribunal proceedings";
-    case "UNFCCC":
+    case "Intl. agreements":
       return "Documents submitted to the UNFCCC (including NDCs)";
     default:
       return "";

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -20,7 +20,6 @@ import { FamilyListItem } from "@components/document/FamilyListItem";
 import { Targets } from "@components/Targets";
 import Button from "@components/buttons/Button";
 import TabbedNav from "@components/nav/TabbedNav";
-import { TargetIcon } from "@components/svg/Icons";
 import { ExternalLink } from "@components/ExternalLink";
 import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
 import DocumentSearchForm from "@components/forms/DocumentSearchForm";
@@ -51,10 +50,10 @@ type TProps = {
 
 const categoryByIndex = {
   0: "All",
-  1: "Legislation",
-  2: "Policies",
-  3: "UNFCCC",
-  4: "Litigation",
+  1: "laws",
+  2: "policies",
+  3: "intl-agreements",
+  4: "laws",
 };
 
 const MAX_NUMBER_OF_FAMILIES = 3;
@@ -91,7 +90,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
       case "Policies":
         count = summary.family_counts.Executive;
         break;
-      case "UNFCCC":
+      case "Intl. agreements":
         count = summary.family_counts.UNFCCC;
         break;
       case "Litigation":


### PR DESCRIPTION
# What's changed
- When linking from geo to search page it was incorrectly using old categories
(We need to come back and refactor this to use the themeConfig )

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
