### PR TITLE
PDCT-1618: family search result

### DIFF
--- a/src/components/buttons/SearchMatchesButton.tsx
+++ b/src/components/buttons/SearchMatchesButton.tsx
@@ -11,7 +11,7 @@ type TProps = {
 };
 
 const formatCount = (count: number) => {
-  return count >= MAX_RESULTS ? `More than ${MAX_RESULTS}` : count;
+  return count >= MAX_RESULTS ? `${MAX_RESULTS}+` : count;
 };
 
 export const SearchMatchesButton = ({ count, dataAttribute, overideText, active, onClick }: TProps) => {
@@ -20,7 +20,7 @@ export const SearchMatchesButton = ({ count, dataAttribute, overideText, active,
       data-analytics="search-result-matches-button"
       data-slug={dataAttribute}
       onClick={onClick}
-      className={`flex gap-1 items-center rounded-full border border-gray-200 py-1 px-2 transition hover:bg-blue-100 hover:border-blue-200 active:bg-blue-600 active:text-white ${
+      className={`flex gap-1 items-center text-[13px] rounded-full border py-1 px-2 transition hover:text-textNormal hover:bg-blue-100 hover:border-blue-200 active:bg-blue-600 active:text-white ${
         active && "bg-blue-600 text-white"
       }`}
       aria-label={`View ${formatCount(count)} match${count > 1 ? "es" : ""} in documents`}

--- a/src/components/buttons/SearchMatchesButton.tsx
+++ b/src/components/buttons/SearchMatchesButton.tsx
@@ -20,7 +20,7 @@ export const SearchMatchesButton = ({ count, dataAttribute, overideText, active,
       data-analytics="search-result-matches-button"
       data-slug={dataAttribute}
       onClick={onClick}
-      className={`flex gap-1 items-center text-[13px] rounded-full border py-1 px-2 transition hover:text-textNormal hover:bg-blue-100 hover:border-blue-200 active:bg-blue-600 active:text-white ${
+      className={`flex gap-1 items-center text-sm rounded-full border py-1 px-2 transition hover:text-textNormal hover:bg-blue-100 hover:border-blue-200 active:bg-blue-600 active:text-white ${
         active && "bg-blue-600 text-white"
       }`}
       aria-label={`View ${formatCount(count)} match${count > 1 ? "es" : ""} in documents`}

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -24,7 +24,7 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
       >
         {family_name}
       </LinkWithQuery>
-      <div className="flex flex-wrap text-[13px] gap-1 my-3 items-center middot-between">
+      <div className="flex flex-wrap text-sm gap-1 my-3 items-center middot-between">
         <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} date={family_date} geographies={family_geographies} />
       </div>
       <p

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -16,23 +16,23 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
 
   return (
     <div className="family-list-item relative">
-      <div className="flex flex-wrap text-[13px] gap-1 mb-2 items-center middot-between">
-        <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} date={family_date} geographies={family_geographies} />
-        {children}
-      </div>
       <LinkWithQuery
         href={`/document/${family_slug}`}
-        className="result-title text-left text-blue-500 font-medium text-lg transition duration-300 leading-tight hover:underline flex items-start"
+        className="result-title text-left font-medium text-xl duration-300 hover:underline flex items-start"
         passHref
         data-cy="family-title"
       >
         {family_name}
       </LinkWithQuery>
+      <div className="flex flex-wrap text-[13px] gap-1 my-3 items-center middot-between">
+        <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} date={family_date} geographies={family_geographies} />
+      </div>
       <p
-        className="mt-2 text-content"
+        className="my-3 text-content"
         data-cy="family-description"
         dangerouslySetInnerHTML={{ __html: truncateString(family_description.replace(/(<([^>]+)>)/gi, ""), 375) }}
       />
+      {children}
     </div>
   );
 };

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -60,7 +60,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
   return (
     <>
       {families?.map((family, index: number) => (
-        <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
+        <div key={index} className={`my-16 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
         </div>
       ))}

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -60,7 +60,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
   return (
     <>
       {families?.map((family, index: number) => (
-        <div key={index} className={`my-16 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
+        <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
         </div>
       ))}

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -157,7 +157,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
       return allFamilies.map((family) => {
         if (family)
           return (
-            <div key={family.family_slug} className="mt-6">
+            <div key={family.family_slug} className="mb-10">
               <FamilyListItem family={family} />
             </div>
           );
@@ -169,7 +169,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
         return summary.top_families.Legislative.length === 0
           ? renderEmpty("Legislative")
           : summary.top_families.Legislative.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mt-6">
+              <div key={family.family_slug} className="mb-10">
                 <FamilyListItem family={family} />
               </div>
             ));
@@ -179,7 +179,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
         return summary.top_families.Executive.length === 0
           ? renderEmpty("Executive")
           : summary.top_families.Executive.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mt-6">
+              <div key={family.family_slug} className="mb-10">
                 <FamilyListItem family={family} />
               </div>
             ));
@@ -189,7 +189,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
         return summary.top_families.UNFCCC.length === 0
           ? renderEmpty("UNFCCC")
           : summary.top_families.UNFCCC.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mt-6">
+              <div key={family.family_slug} className="mb-10">
                 <FamilyListItem family={family} />
               </div>
             ));
@@ -246,7 +246,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
               {hasFamilies && (
                 <>
                   <section className="mt-10" data-cy="top-documents">
-                    <div className="mt-4 md:flex">
+                    <div className="my-4 md:flex">
                       <div className="flex-grow">
                         <TabbedNav activeIndex={selectedCategoryIndex} items={documentCategories} handleTabClick={handleDocumentCategoryClick} />
                       </div>


### PR DESCRIPTION
# What's changed
- Updates to how we present the family items in lists search as search and geography

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
