### PR TITLE
Update logic for displaying the clear search button

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -79,16 +79,14 @@ const SearchFilters = ({
 
   // Show clear button if there are filters applied
   useEffect(() => {
-    if (searchCriteria.year_range[0] !== minYear || searchCriteria.year_range[1] !== thisYear) {
-      setShowClear(true);
-    } else if (Object.keys(searchCriteria.keyword_filters).length > 0) {
-      setShowClear(true);
-    } else if (searchCriteria.exact_match) {
-      setShowClear(true);
+    if (query && Object.keys(query).length > 0) {
+      if (Object.keys(query).length === 1 && query[QUERY_PARAMS.query_string]) {
+        setShowClear(false);
+      } else setShowClear(true);
     } else {
       setShowClear(false);
     }
-  }, [thisYear, searchCriteria]);
+  }, [query]);
 
   return (
     <div id="search_filters" data-cy="seach-filters" className="text-sm text-textNormal flex flex-col gap-5">

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -345,7 +345,9 @@ const Search = () => {
             </div>
             <div className="relative z-10 flex justify-center">
               <button
-                className={`w-[55px] flex justify-center items-center text-textDark text-xl ${showOptions ? "bg-nearBlack text-white rounded-full" : ""}`}
+                className={`w-[55px] flex justify-center items-center text-textDark text-xl ${
+                  showOptions ? "bg-nearBlack text-white rounded-full" : ""
+                }`}
                 onClick={() => setShowOptions(!showOptions)}
                 data-cy="search-options-mobile"
                 ref={settingsButtonRef}
@@ -424,7 +426,9 @@ const Search = () => {
                   </div>
                   <div className="relative z-10 flex justify-center">
                     <button
-                      className={`w-[55px] flex justify-center items-center text-textDark text-xl ${showOptions ? "bg-nearBlack text-white rounded-full" : ""}`}
+                      className={`w-[55px] flex justify-center items-center text-textDark text-xl ${
+                        showOptions ? "bg-nearBlack text-white rounded-full" : ""
+                      }`}
                       onClick={() => setShowOptions(!showOptions)}
                       data-cy="search-options"
                       ref={settingsButtonRef}


### PR DESCRIPTION
# What's changed
- Update logic for when ti display the "Clear search" button in the list of filters

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
