### PR TITLE
feature/pdct-1687-replace-af-link-to-their-terms-and-conditions

### DIFF
--- a/themes/mcf/components/Footer.tsx
+++ b/themes/mcf/components/Footer.tsx
@@ -10,7 +10,7 @@ const Footer = () => {
     <footer className="flex flex-col bg-grey-400">
       <div className="py-12">
         <SiteWidth>
-          <div className="flex flex-col md:flex-row gap-32">
+          <div className="flex flex-col md:flex-row sm:gap-32">
             <div className="footer__section w-full md:w-1/2 lg:w-2/3" data-cy="footer-mcf">
               <Heading level={2} extraClasses="custom-header">
                 About

--- a/themes/mcf/pages/terms-of-use.tsx
+++ b/themes/mcf/pages/terms-of-use.tsx
@@ -203,10 +203,7 @@ const TermsOfUse = () => {
                       <td>Adaptation Fund (AF) projects and guidance</td>
                       <td>November 2024</td>
                       <td>
-                        <ExternalLink url="https://www.adaptation-fund.org/documents-publications/legal-documents/">
-                          Terms and Conditions - AF
-                        </ExternalLink>{" "}
-                        <br />
+                        <ExternalLink url="https://www.adaptation-fund.org/legal/">Terms and Conditions - AF</ExternalLink> <br />
                         <ExternalLink url="https://www.worldbank.org/en/about/legal/terms-and-conditions">
                           Terms and Conditions - World Bank
                         </ExternalLink>


### PR DESCRIPTION
# What's changed

Update link to legal page for AF in the terms and conditions

- driveby: fix footer padding for smaller screens

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
