### PR TITLE
fix-ignore-project-value-fund-spend-of-zero

### DIFF
--- a/src/helpers/mapFamilyMetadata.ts
+++ b/src/helpers/mapFamilyMetadata.ts
@@ -18,6 +18,7 @@ export const mapFamilyMetadata = (metadata: Metadata) => {
 
   for (const [key, values] of Object.entries(metadata)) {
     const mapping = metadataLabelMappings[key];
+
     if (mapping && values) {
       if (key === "geographies") {
         result.push({
@@ -25,8 +26,10 @@ export const mapFamilyMetadata = (metadata: Metadata) => {
           iconLabel: mapping.iconLabel,
           value: values as string | string[],
         });
-      } else if (key.includes("project_value") && values[0] !== "0") {
-        result.push({ label: mapping.label, iconLabel: mapping.iconLabel, value: getSumUSD(values as string[]) });
+      } else if (key.includes("project_value")) {
+        if (values[0] !== "0") {
+          result.push({ label: mapping.label, iconLabel: mapping.iconLabel, value: getSumUSD(values as string[]) });
+        }
       } else if (key === "organisation") {
         result.push({ label: mapping.label, iconLabel: mapping.iconLabel, value: getSubCategoryName(values as TCorpusTypeSubCategory) });
       } else {


### PR DESCRIPTION
# What's changed

fix: ignore project value spend of 0

- whilst the code was initially ignore instances where there was no fund value i.e '0', it was still being mapped due to the else block. This correctly ignores those values

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
