### PR TITLE
feature/pdct-1660-mobile-view-filters-and-faq-to-display-icon

### DIFF
--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 
 import { Heading } from "./Heading";
 
-import { AccordianCloseIcon, AccordianOpenIcon } from "@components/svg/Icons";
+import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 
 type TProps = {
   title: string;
@@ -23,7 +23,7 @@ export const Accordian = ({ title, startOpen = false, overflowOverride, fixedHei
       <div className={`flex justify-between cursor-pointer group`} onClick={() => setIsOpen(!isOpen)} data-cy="accordian-control">
         <Heading>{title}</Heading>
         <span className={`text-textDark opacity-40 group-hover:opacity-100 ${isOpen ? "" : ""}`}>
-          {isOpen ? <AccordianCloseIcon /> : <AccordianOpenIcon />}
+          {isOpen ? <AiOutlineMinus /> : <AiOutlinePlus />}
         </span>
       </div>
       <AnimatePresence initial={false}>


### PR DESCRIPTION
# What's changed

fix: switch to using reacticons for open/close icons

- we were using svgs for the open and close accordian icon which was presenting some rendering issues on the firefox browser and on some smaller mobile screens. So we will use react icons instead which fixes these issues



## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
