### PR TITLE
PDCT-1643 & PDCT-1642 search filters date range

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -44,7 +44,7 @@ type TSearchFiltersProps = {
   countries: TGeography[];
   organisations: TOrganisationDictionary;
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
-  handleYearChange(values: number[], reset?: boolean): void;
+  handleYearChange(values: string[], reset?: boolean): void;
   handleRegionChange(region: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -5,9 +5,10 @@ import { DateRangeInput } from "./DateRangeInput";
 import { FormError } from "../forms/FormError";
 import { InputListContainer } from "@components/filters/InputListContainer";
 import { InputRadio } from "@components/forms/Radio";
+import Button from "@components/buttons/Button";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
-import { currentYear } from "../../constants/timedate";
+import { currentYear } from "@constants/timedate";
 
 type TProps = {
   type: string;
@@ -67,37 +68,28 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => 
   };
 
   // Custom date selectors
-  const submitCustomRange = (updatedDate: string, name: string) => {
-    const updatedDateInt = Number(updatedDate);
+  const submitCustomRange = () => {
     const startInputInt = Number(startInput);
     const endInputInt = Number(endInput);
     // Validate
     setError("");
-    if (typeof updatedDateInt !== "number" || isNaN(updatedDateInt)) {
+    if (typeof startInputInt !== "number" || typeof endInputInt !== "number" || isNaN(startInputInt) || isNaN(endInputInt)) {
       setError("Please enter a valid year");
       return;
     }
-    if (name === "From") {
-      if (updatedDateInt > endInputInt) {
-        setError("Please enter a year on or before " + endInput);
-        return;
-      }
-      if (updatedDateInt < min) {
-        setError("Please enter a year on or after " + min);
-        return;
-      }
-      handleChange([updatedDateInt.toString(), endInput]);
-    } else {
-      if (updatedDateInt > max) {
-        setError("Please enter a year on or before " + max);
-        return;
-      }
-      if (updatedDateInt < startInputInt) {
-        setError("Please enter a year on or after " + startInputInt);
-        return;
-      }
-      handleChange([startInput, updatedDateInt.toString()]);
+    if (startInputInt > endInputInt) {
+      setError("Please enter a start date before the end date");
+      return;
     }
+    if (startInputInt < min) {
+      setError("Please enter a year on or after " + min);
+      return;
+    }
+    if (endInputInt > max) {
+      setError("Please enter a year on or before " + max);
+      return;
+    }
+    handleChange([startInput, endInput]);
   };
 
   return (
@@ -114,6 +106,13 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => 
             <DateRangeInput label="Latest year" name="To" value={endInput} handleSubmit={submitCustomRange} handleChange={setEndInput} />
           </div>
           {error && <FormError message={error} />}
+          {!error && (defaultValues[0] !== startInput || defaultValues[1] !== endInput) && (
+            <div>
+              <Button onClick={submitCustomRange} extraClasses="w-auto !inline">
+                Search
+              </Button>
+            </div>
+          )}
         </>
       )}
     </InputListContainer>

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -44,6 +44,10 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => 
     }
   }, [router.query]);
 
+  useEffect(() => {
+    setError("");
+  }, [startInput, endInput]);
+
   const isChecked = (range?: number): boolean => {
     if (range) {
       if (showDateInput) return false;

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -11,8 +11,8 @@ import { currentYear } from "../../constants/timedate";
 
 interface ByDateRangeProps {
   type: string;
-  handleChange(values: number[], reset?: boolean): void;
-  defaultValues: number[];
+  handleChange(values: string[], reset?: boolean): void;
+  defaultValues: string[];
   min: number;
   max: number;
 }
@@ -46,7 +46,7 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: ByDateRange
   const isChecked = (range?: number): boolean => {
     if (range) {
       if (showDateInput) return false;
-      return Number(endYear) === currentYear() && Number(startYear) === endYear - range;
+      return Number(endYear) === currentYear() && Number(startYear) === Number(endYear) - range;
     }
 
     return showDateInput;
@@ -63,37 +63,40 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: ByDateRange
     setShowDateInput(false);
     const thisYear = currentYear();
     const calculatedStart = thisYear - range;
-    handleChange([calculatedStart, thisYear], reset);
+    handleChange([calculatedStart.toString(), thisYear.toString()], reset);
   };
 
   // Custom date selectors
-  const submitCustomRange = (updatedDate: number, name: string) => {
+  const submitCustomRange = (updatedDate: string, name: string) => {
+    const updatedDateInt = Number(updatedDate);
+    const startInputInt = Number(startInput);
+    const endInputInt = Number(endInput);
     // Validate
     setError("");
-    if (typeof updatedDate !== "number") {
+    if (typeof updatedDateInt !== "number" || isNaN(updatedDateInt)) {
       setError("Please enter a valid year");
       return;
     }
     if (name === "From") {
-      if (updatedDate > endInput) {
+      if (updatedDateInt > endInputInt) {
         setError("Please enter a year on or before " + endInput);
         return;
       }
-      if (updatedDate < min) {
+      if (updatedDateInt < min) {
         setError("Please enter a year on or after " + min);
         return;
       }
-      handleChange([updatedDate, Number(endInput)]);
+      handleChange([updatedDateInt.toString(), endInput]);
     } else {
-      if (updatedDate > max) {
+      if (updatedDateInt > max) {
         setError("Please enter a year on or before " + max);
         return;
       }
-      if (updatedDate < startInput) {
-        setError("Please enter a year on or after " + startInput);
+      if (updatedDateInt < startInputInt) {
+        setError("Please enter a year on or after " + startInputInt);
         return;
       }
-      handleChange([Number(startInput), updatedDate]);
+      handleChange([startInput, updatedDateInt.toString()]);
     }
   };
 

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -113,7 +113,7 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => 
           {!error && (defaultValues[0] !== startInput || defaultValues[1] !== endInput) && (
             <div>
               <Button onClick={submitCustomRange} extraClasses="w-auto !inline">
-                Search
+                Apply
               </Button>
             </div>
           )}

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -77,7 +77,7 @@ export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => 
     const endInputInt = Number(endInput);
     // Validate
     setError("");
-    if (typeof startInputInt !== "number" || typeof endInputInt !== "number" || isNaN(startInputInt) || isNaN(endInputInt)) {
+    if (isNaN(startInputInt) || isNaN(endInputInt)) {
       setError("Please enter a valid year");
       return;
     }

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -9,15 +9,15 @@ import { InputRadio } from "@components/forms/Radio";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { currentYear } from "../../constants/timedate";
 
-interface ByDateRangeProps {
+type TProps = {
   type: string;
   handleChange(values: string[], reset?: boolean): void;
   defaultValues: string[];
   min: number;
   max: number;
-}
+};
 
-export const DateRange = ({ handleChange, defaultValues, min, max }: ByDateRangeProps) => {
+export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => {
   const router = useRouter();
   const [startYear, endYear] = defaultValues;
   const [showDateInput, setShowDateInput] = useState(false);

--- a/src/components/filters/DateRangeInput.tsx
+++ b/src/components/filters/DateRangeInput.tsx
@@ -4,14 +4,14 @@ type TProps = {
   label: string;
   name: string;
   value: string;
-  handleSubmit(updatedDate: string, name: string): void;
+  handleSubmit(): void;
   handleChange(value: string): void;
 };
 
 export const DateRangeInput = ({ label, name, value, handleSubmit, handleChange }: TProps) => {
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      handleSubmit(value, name);
+      handleSubmit();
     }
   };
 

--- a/src/components/filters/DateRangeInput.tsx
+++ b/src/components/filters/DateRangeInput.tsx
@@ -3,34 +3,22 @@ import { InputListContainer } from "./InputListContainer";
 type TProps = {
   label: string;
   name: string;
-  value: string | number;
-  handleSubmit(updatedDate: number, name: string): void;
-  handleChange(value: number): void;
+  value: string;
+  handleSubmit(updatedDate: string, name: string): void;
+  handleChange(value: string): void;
 };
 
 export const DateRangeInput = ({ label, name, value, handleSubmit, handleChange }: TProps) => {
-  const onBlur = () => {
-    handleSubmit(Number(value), name);
-  };
-
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      handleSubmit(Number(value), name);
+      handleSubmit(value, name);
     }
   };
 
   return (
     <InputListContainer>
       <label>{label}</label>
-      <input
-        name={name}
-        value={value}
-        onChange={(e) => handleChange(Number(e.target.value))}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        type="text"
-        className="w-full"
-      />
+      <input name={name} value={value} onChange={(e) => handleChange(e.target.value)} onKeyDown={onKeyDown} type="text" className="w-full" />
     </InputListContainer>
   );
 };

--- a/src/components/filters/DateRangeInput.tsx
+++ b/src/components/filters/DateRangeInput.tsx
@@ -28,7 +28,7 @@ export const DateRangeInput = ({ label, name, value, handleSubmit, handleChange 
         onChange={(e) => handleChange(Number(e.target.value))}
         onBlur={onBlur}
         onKeyDown={onKeyDown}
-        type="number"
+        type="text"
         className="w-full"
       />
     </InputListContainer>

--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -7,7 +7,7 @@ export const initialSearchCriteria: TSearchCriteria = {
   exact_match: false,
   max_passages_per_doc: PASSAGES_PER_DOC,
   keyword_filters: {},
-  year_range: [minYear, currentYear()],
+  year_range: [minYear.toString(), currentYear().toString()],
   sort_field: null,
   sort_order: "desc",
   page_size: RESULTS_PER_PAGE,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -255,8 +255,8 @@ const Search = () => {
     resetCSVStatus();
   };
 
-  const handleYearChange = (values: number[], reset = false) => {
-    const newVals = values.map((value: number) => Number(value).toFixed(0));
+  const handleYearChange = (values: string[], reset = false) => {
+    const newVals = values.map((value) => Number(value).toFixed(0));
     handleSearchChange(QUERY_PARAMS.year_range, newVals, reset);
   };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -481,7 +481,7 @@ const Search = () => {
                 </div>
               )}
             </div>
-            {hits > 1 && (
+            {status !== "loading" && hits > 1 && (
               <div className="mb-12">
                 <Pagination
                   onChange={handlePageChange}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -16,7 +16,7 @@ export type TSearchCriteria = {
   exact_match: boolean;
   max_passages_per_doc: number;
   keyword_filters?: TSearchKeywordFilters;
-  year_range: [number, number];
+  year_range: [string, string];
   sort_field: string | null;
   sort_order: string;
   page_size: number;

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -46,7 +46,7 @@ export default function buildSearchQuery(
   if (routerQuery[QUERY_PARAMS.year_range]) {
     const yearRange = routerQuery[QUERY_PARAMS.year_range];
     if (Array.isArray(yearRange)) {
-      query.year_range = [Number(yearRange[0]), Number(yearRange[1])];
+      query.year_range = [yearRange[0], yearRange[1]];
     }
   }
 

--- a/src/utils/searchCache.ts
+++ b/src/utils/searchCache.ts
@@ -21,7 +21,7 @@ export type TCacheIdentifier = {
   query_string: string;
   exact_match: boolean;
   keyword_filters?: TSearchKeywordFilters;
-  year_range: [number, number];
+  year_range: [string, string];
   sort_field: string | null;
   sort_order: string;
   offset: number;


### PR DESCRIPTION
# What's changed
- Custom date range filter no longer submtits `onBlur`
- If dates changed but not applied we show a button "Apply"
- Fix issue with defaulting to "0" and not allowing it to be deleted
- Fix the logic to determine whether to display the custom date inputs

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
