### PR TITLE
Pass in the context theme to check for page title

### DIFF
--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -30,8 +30,8 @@ const Layout: FC<TProps> = ({ children, title, theme, description, themeConfig, 
   return (
     <div className="h-full flex flex-col">
       <Head>
-        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme)}`}</title>
-        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme)}`} />
+        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`}</title>
+        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`} />
         <meta name="description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} key="desc" />
         <meta property="og:description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} />
         <link rel="canonical" href={getCanonicalUrl(router, contextTheme)} />

--- a/src/utils/getAppTitle.ts
+++ b/src/utils/getAppTitle.ts
@@ -2,9 +2,12 @@ import { TTheme } from "@types";
 
 const DEFAULT_APP_NAME = "Climate Policy Radar";
 
-export const getAppTitle = (site: TTheme) => {
+export const getAppTitle = (site: TTheme, contextTheme: TTheme) => {
   let title = DEFAULT_APP_NAME;
-  switch (site) {
+
+  const theme = site ?? contextTheme;
+
+  switch (theme) {
     case "cclw":
       title = "Climate Change Laws of the World";
       break;


### PR DESCRIPTION
# What's changed
This issue only affects the custom pages for each theme.
- Oversight on my behalf to only rely on the manually passed-in theme prop when determining the page title

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
