### PR TITLE
Fix placement of tooltip on matches button

### DIFF
--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -16,9 +16,11 @@ const SearchResult = ({ family, active, onClick }: ISearchResultProps) => {
   return (
     <FamilyListItem family={family}>
       {family_documents.length > 0 && (
-        <div data-tooltip-content="View passages in this document that match your search" data-tooltip-id={family_slug}>
-          <SearchMatchesButton count={total_passage_hits} dataAttribute={family_slug} onClick={onClick} active={active} />
-          <ToolTipSSR id={family_slug} place={"top"} />
+        <div>
+          <div className="inline-block" data-tooltip-content="View passages in this document that match your search" data-tooltip-id={family_slug}>
+            <SearchMatchesButton count={total_passage_hits} dataAttribute={family_slug} onClick={onClick} active={active} />
+            <ToolTipSSR id={family_slug} place={"top"} />
+          </div>
         </div>
       )}
     </FamilyListItem>


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
