### PR TITLE
Bug/unfccc refereces cclw

### DIFF
--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -27,7 +27,7 @@ export const Legend = ({ max }: { max: number }) => {
           <p>{scale[4]}</p>
         </div>
       </div>
-      <p>Size and colour show the number of laws, policies or UNFCCC submission in our databases.</p>
+      <p>Size and colour show the number of laws, policies or international agreements submission in our databases.</p>
     </div>
   );
 };

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -102,7 +102,7 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
       {(geography.familyCounts?.EXECUTIVE || geography.familyCounts?.LEGISLATIVE) && (
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}
-      {geography.familyCounts?.UNFCCC > 0 && <p>UNFCCC documents: {geography.familyCounts?.UNFCCC || 0}</p>}
+      {geography.familyCounts?.UNFCCC > 0 && <p>Intl. agreements: {geography.familyCounts?.UNFCCC || 0}</p>}
       <p>
         <LinkWithQuery href={`/geographies/${geography.slug}`}>View more</LinkWithQuery>
       </p>
@@ -228,7 +228,7 @@ export default function MapChart() {
             name="Document type selector"
           >
             <option value="lawsPolicies">Laws and policies</option>
-            <option value="unfccc">UNFCCC</option>
+            <option value="unfccc">Intl. agreements</option>
           </select>
         </div>
         <div>

--- a/themes/cclw/constants/instructions.tsx
+++ b/themes/cclw/constants/instructions.tsx
@@ -15,7 +15,7 @@ export const INSTRUCTIONS = (documentTotals: TDocumentTotals) => [
     content: (
       <ul>
         <li>
-          <Link href="/search?c=Legislation" className={heroLinkClasses}>
+          <Link href="/search?c=laws" className={heroLinkClasses}>
             <b>{documentTotals.laws}</b> laws{" "}
             <span className="self-center">
               <ExternalLinkIcon height="12" width="12" />
@@ -23,7 +23,7 @@ export const INSTRUCTIONS = (documentTotals: TDocumentTotals) => [
           </Link>
         </li>
         <li>
-          <Link href="/search?c=Policies" className={heroLinkClasses}>
+          <Link href="/search?c=policies" className={heroLinkClasses}>
             <b>{documentTotals.policies}</b> policies{" "}
             <span className="self-center">
               <ExternalLinkIcon height="12" width="12" />
@@ -31,8 +31,8 @@ export const INSTRUCTIONS = (documentTotals: TDocumentTotals) => [
           </Link>
         </li>
         <li>
-          <Link href="/search?c=UNFCCC" className={heroLinkClasses}>
-            <b>{documentTotals.unfccc}</b> UNFCCC submissions{" "}
+          <Link href="/search?c=intl-agreements" className={heroLinkClasses}>
+            <b>{documentTotals.unfccc}</b> Intl. agreements{" "}
             <span className="self-center">
               <ExternalLinkIcon height="12" width="12" />
             </span>


### PR DESCRIPTION
# What's changed
- Remove references to UNFCCC and replace with Intl. agreements where appropriate
- Fix links on cclw homepage hero to link to correct category in search

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
