### PR TITLE
feature/pdct-1707-remove-references-to-world-bank-in-mcf-terms-of-use-page

### DIFF
--- a/themes/mcf/pages/terms-of-use.tsx
+++ b/themes/mcf/pages/terms-of-use.tsx
@@ -203,10 +203,7 @@ const TermsOfUse = () => {
                       <td>Adaptation Fund (AF) projects and guidance</td>
                       <td>November 2024</td>
                       <td>
-                        <ExternalLink url="https://www.adaptation-fund.org/legal/">Terms and Conditions - AF</ExternalLink> <br />
-                        <ExternalLink url="https://www.worldbank.org/en/about/legal/terms-and-conditions">
-                          Terms and Conditions - World Bank
-                        </ExternalLink>
+                        <ExternalLink url="https://www.adaptation-fund.org/legal/">Terms and Conditions</ExternalLink> <br />
                       </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
# What's changed
fix: remove reference to world bank in the terms and conditions
## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
