### PR TITLE
feature/pdct-1688-fix-lse-footer-email

### DIFF
--- a/themes/cclw/components/Footer.tsx
+++ b/themes/cclw/components/Footer.tsx
@@ -47,7 +47,7 @@ const Footer = () => {
                 <ul>
                   <li className="mb-2">
                     For media enquiries or queries about research and policy analysis contact{" "}
-                    <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.co.uk</ExternalLink>
+                    <ExternalLink url="mailto:gri.cgl@lse.ac.uk">gri.cgl@lse.ac.uk</ExternalLink>
                   </li>
                 </ul>
               </div>

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -81,7 +81,7 @@ const About = () => {
                 law, policy or court case in the countries covered. We invite anyone to draw our attention to any information we may have missed or
                 any errors or updates to existing data. Please{" "}
                 <ExternalLink url="https://form.jotform.com/233294135296359">fill out our form</ExternalLink> or email{" "}
-                <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.ac.uk</ExternalLink> to contribute.
+                <ExternalLink url="mailto:gri.cgl@lse.ac.uk">gri.cgl@lse.ac.uk</ExternalLink> to contribute.
               </p>
               <p>
                 For information about using and referencing the data, please see our <LinkWithQuery href="/terms-of-use">Terms of Use</LinkWithQuery>.

--- a/themes/cclw/pages/contact.tsx
+++ b/themes/cclw/pages/contact.tsx
@@ -25,7 +25,7 @@ const Contact = () => {
               </Heading>
               <p>
                 Please get in touch with the Climate Change Laws of the World team with any questions or comments by emailing{" "}
-                <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.ac.uk</ExternalLink>
+                <ExternalLink url="mailto:gri.cgl@lse.ac.uk">gri.cgl@lse.ac.uk</ExternalLink>
               </p>
               <p>
                 We particularly welcome comments and inputs about the content of the database, including laws and policies we may have missed. We are
@@ -57,7 +57,7 @@ const Contact = () => {
                 <ExternalLink url="tel:+44 (0)20 7107 5442">+44 (0)20 7107 5442</ExternalLink>
               </p>
               <p>
-                Email: <ExternalLink url="mailto:gri.cgl@lse.co.uk">gri.cgl@lse.ac.uk</ExternalLink>
+                Email: <ExternalLink url="mailto:gri.cgl@lse.ac.uk">gri.cgl@lse.ac.uk</ExternalLink>
               </p>
               <Heading level={2}>Finding specific contact information</Heading>
               <p>


### PR DESCRIPTION
# What's changed
fix: incorrect email address for lse contact

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
