### PR TITLE
add initial playwright test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,15 @@
-API_URL=http://localhost:8000/api/v1
-S3_URL=https://s3.amazonaws.com
+# This is if you are working exclusively on navigator-frontend
+# To test changes to navigator-backend - swap this out for
+# API_URL=http://localhost:8888/api/v1
+API_URL=https://app.dev.climatepolicyradar.org/api/v1
+S3_URL=https://cpr-staging-targets-json-store.s3.eu-west-1.amazonaws.com
 
 THEME=cpr
 
-ADOBE_API_KEY=1234567890
+ADOBE_API_KEY=dca9187b65294374a6367824df902fdf
 
 REDIRECT_FILE="test.json"
 
-HOSTNAME=https://localhost:3000
+HOSTNAME=http://localhost:3000
 
-NEXT_PUBLIC_APP_TOKEN=some_token
+NEXT_PUBLIC_APP_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbGxvd2VkX2NvcnBvcmFfaWRzIjpbIkNDTFcuY29ycHVzLmkwMDAwMDAwMS5uMDAwMCIsIkNQUi5jb3JwdXMuaTAwMDAwMDAxLm4wMDAwIiwiVU5GQ0NDLmNvcnB1cy5pMDAwMDAwMDEubjAwMDAiXSwiZXhwIjoyMDQyMTEzMzY5LCJpYXQiOjE3MjY1NzY5NjksImlzcyI6IkNsaW1hdGUgUG9saWN5IFJhZGFyIiwic3ViIjoiQ1BSIiwiYXVkIjoiaHR0cHM6Ly9hcHAuZGV2LmNsaW1hdGVwb2xpY3lyYWRhci5vcmcvIn0.mJ2qLJmMyPLGt0rM_tTXhlVv1glxooxmQV0bWrvPwKU

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,30 @@
+name: Playwright tests
+permissions: read-all
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, master]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Build app
+        run: npm run build
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,8 +16,12 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
+      - name: Copy .env
+        run: cp .env.example .env
       - name: Build app
         run: npm run build
+        env:
+          NODE_ENV: production
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ e2e/cypress/fixtures/importData.csv
 
 # tsconfig
 tsconfig.tsbuildinfo
+/test-results/
+
+# playwright
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/cypress/e2e/cclw/journeys/browse.cy.js
+++ b/e2e/cypress/e2e/cclw/journeys/browse.cy.js
@@ -2,6 +2,7 @@
 import { clickCookiePolicy } from "../../../utils/cookiePolicy";
 
 const searchResultsSelector = '[data-cy="search-results"]';
+const searchResultSelector = '[data-cy="search-result"]';
 const countryLinkSelector = '[data-cy="country-link"]';
 const familyTitleSelector = '[data-cy="family-title"]';
 
@@ -28,11 +29,11 @@ describe("Browse Flow", () => {
   });
 
   it("should display a list of 20 search results", () => {
-    cy.get(searchResultsSelector).children({ timeout: 10000 }).should("have.length", 20);
+    cy.get(searchResultsSelector).children(searchResultSelector).children({ timeout: 10000 }).should("have.length", 20);
   });
 
   it("should have a clickable header, which navigates to the document family view", () => {
-    cy.get(searchResultsSelector).children().eq(0).find(familyTitleSelector).should("be.visible").click();
+    cy.get(searchResultsSelector).children(searchResultSelector).children().eq(0).find(familyTitleSelector).should("be.visible").click();
   });
 
   it("should now be on the document family page", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@babel/core": "^7.16.5",
         "@babel/preset-env": "^7.16.5",
+        "@playwright/test": "^1.49.0",
         "@tailwindcss/forms": "^0.5.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
@@ -2965,6 +2966,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -10768,6 +10785,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "add": "docker-compose exec -w /opt/node_app frontend npm install -S",
     "add-dev": "docker-compose exec -w /opt/node_app frontend npm install -D",
     "remove": "docker-compose exec -w /opt/node_app frontend npm uninstall",
-    "test": "jest"
+    "test": "jest",
+    "test-e2e": "npx playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^2.8.8",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
+    "@playwright/test": "^1.49.0",
     "@tailwindcss/forms": "^0.5.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,80 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:3000",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -58,14 +58,13 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
     return <div className="h-96 mt-4 md:mt-0">Your search returned no results.</div>;
   }
   return (
-    <section>
-      <h2 className="sr-only">Search results</h2>
+    <>
       {families?.map((family, index: number) => (
         <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
         </div>
       ))}
-    </section>
+    </>
   );
 };
 

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -58,14 +58,14 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
     return <div className="h-96 mt-4 md:mt-0">Your search returned no results.</div>;
   }
   return (
-    <div>
+    <section>
       <h2 className="sr-only">Search results</h2>
       {families?.map((family, index: number) => (
         <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
         </div>
       ))}
-    </div>
+    </section>
   );
 };
 

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -61,9 +61,9 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
     <div>
       <h2 className="sr-only">Search results</h2>
       {families?.map((family, index: number) => (
-        <section key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
+        <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
-        </section>
+        </div>
       ))}
     </div>
   );

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -58,13 +58,14 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
     return <div className="h-96 mt-4 md:mt-0">Your search returned no results.</div>;
   }
   return (
-    <>
+    <div>
+      <h2 className="sr-only">Search results</h2>
       {families?.map((family, index: number) => (
-        <div key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
+        <section key={index} className={`my-10 ${index === 0 && "md:mt-0"}`} data-cy="search-result">
           <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
-        </div>
+        </section>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -478,7 +478,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   <Loader />
                 </div>
               ) : (
-                <div data-cy="search-results">
+                <div data-cy="search-results" role="main">
                   <SearchResultList
                     category={router.query[QUERY_PARAMS.category]?.toString()}
                     families={families}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -478,14 +478,15 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   <Loader />
                 </div>
               ) : (
-                <div data-cy="search-results">
+                <section data-cy="search-results">
+                  <h2 className="sr-only">Search results</h2>
                   <SearchResultList
                     category={router.query[QUERY_PARAMS.category]?.toString()}
                     families={families}
                     onClick={handleMatchesButtonClick}
                     activeFamilyIndex={drawerFamily}
                   />
-                </div>
+                </section>
               )}
             </div>
             {status !== "loading" && hits > 1 && (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -478,7 +478,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   <Loader />
                 </div>
               ) : (
-                <div data-cy="search-results" role="main">
+                <div data-cy="search-results">
                   <SearchResultList
                     category={router.query[QUERY_PARAMS.category]?.toString()}
                     families={families}

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,9 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 test("search", async ({ page }) => {
-  /** Reject the consent banner */
   await page.goto("/");
-  await page.getByRole("button", { name: "Reject" }).click();
+
+  /** Reject the consent banner */
+  const consentHeading = page.getByText("Cookies and your privacy");
+  const consentBanner = page.locator("div").filter({ has: consentHeading });
+  await consentBanner.getByRole("button", { name: "Reject" }).click();
 
   /** Homepage */
   await expect(page.getByLabel("Search").first()).toBeVisible();

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+test("search", async ({ page }) => {
+  /** Reject the consent banner */
+  await page.goto("/");
+  await page.getByRole("button", { name: "Reject" }).click();
+
+  /** Homepage */
+  await expect(page.getByLabel("Search").first()).toBeVisible();
+  await page.getByLabel("Search").first().fill("Adaptation strategy");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  /** Search */
+  await page.waitForURL("/search*");
+  const searchResultsHeading = page.getByRole("heading", { name: "Search results" });
+  /**
+   * This finds the first container that has the heading search results.
+   * We could probably have a more semantic search markup with lists.
+   */
+  const searchResults = page.locator("div").filter({ has: searchResultsHeading }).last();
+  await expect(searchResults).toBeVisible();
+  await searchResults.getByRole("link").first().click();
+
+  /** Document page */
+  await page.waitForURL("/document/*");
+  await page.getByText(/View \d+ matches/).click();
+
+  /** Documents Page */
+  await page.waitForURL("/documents/*");
+  await expect(page.getByText("View source document")).toBeVisible();
+});

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -12,11 +12,11 @@ test("search", async ({ page }) => {
 
   /** Search */
   await page.waitForURL("/search*");
-  const searchResultsHeading = page.getByRole("heading", { name: "Search results" });
   /**
    * This finds the first container that has the heading search results.
    * We could probably have a more semantic search markup with lists.
    */
+  const searchResultsHeading = page.getByRole("heading", { name: "Search results" });
   const searchResults = page.locator("div").filter({ has: searchResultsHeading }).last();
   await expect(searchResults).toBeVisible();
   await searchResults.getByRole("link").first().click();


### PR DESCRIPTION
# What's changed
- adds an initial playwright e2e test

[🍏 Here's a successful run](https://github.com/climatepolicyradar/navigator-frontend/actions/runs/11957984101/job/33336425619?pr=288)

[🔴 Here's broken run](https://github.com/climatepolicyradar/navigator-frontend/actions/runs/11938826616/job/33277946517)

[📜 Here's some nice docs on how to debug the broken run](https://playwright.dev/docs/ci-intro#html-report)

There is a few areas where this significantly differs from [the current implementation of e2e tests](https://github.com/climatepolicyradar/navigator-frontend/tree/main/e2e). Here's the thinking around it

- **The e2e test are now part of the `src` app.**
  - Yup. This is partially because of co-location reasons. We try to keep the tests as close to the implementation as possible to make them less of an after thought.
  - It's easier to just start the app as they're co-located
  - This does make it less modular though, but haven't seen an opportunity where composition would be useful, so this might be a premature abstraction, but could be missing things
- **Playwright?**
  - after talking to @annaCPR and @PatFawbertMills there did not seem to be any reason we went with Cypress bar that it's there. I have done a few migrations recently from Cypress => Playwright, so I am biased, but those were driven by cypress being a little more flaky, and playwright's ecosystem being far more rich due to the engineering effort going into it (thanks M$)
- **A new actions?** This is to keep this PR clear in it's inception, with the desire to bring it into the [ci/cd pipeline](https://github.com/climatepolicyradar/navigator-frontend/blob/main/.github/workflows/ci-cd.yml). The current e2e tests are also located in the `theme-factory` action, which is coupled to this repo, so we're making that coupling more explicit by keeping the code that tests this code here

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
