### PR TITLE
Feature/pdct 1360 update geographies data on world map to show mcf documents

### DIFF
--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -103,7 +103,7 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
       {(geography.familyCounts?.EXECUTIVE || geography.familyCounts?.LEGISLATIVE) && (
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}
-      {geography.familyCounts?.UNFCCC > 0 && <p>Intl. agreements: {geography.familyCounts?.UNFCCC || 0}</p>}
+      {geography.familyCounts?.UNFCCC > 0 && <p>UNFCCC: {geography.familyCounts?.UNFCCC || 0}</p>}
       {geography.familyCounts?.MCF > 0 && <p>MCF: {geography.familyCounts?.MCF || 0}</p>}
       <p>
         <LinkWithQuery href={`/geographies/${geography.slug}`}>View more</LinkWithQuery>

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -104,7 +104,7 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}
       {geography.familyCounts?.UNFCCC > 0 && <p>UNFCCC: {geography.familyCounts?.UNFCCC || 0}</p>}
-      {geography.familyCounts?.MCF > 0 && <p>MCF: {geography.familyCounts?.MCF || 0}</p>}
+      {geography.familyCounts?.MCF > 0 && <p>MCF projects: {geography.familyCounts?.MCF || 0}</p>}
       <p>
         <LinkWithQuery href={`/geographies/${geography.slug}`}>View more</LinkWithQuery>
       </p>
@@ -231,7 +231,7 @@ export default function MapChart() {
           >
             <option value="lawsPolicies">Laws and policies</option>
             <option value="unfccc">UNFCCC</option>
-            <option value="mcf">Multilateral Climate Funds</option>
+            <option value="mcf">Multilateral Climate Fund projects</option>
           </select>
         </div>
         <div>

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -26,6 +26,7 @@ type TGeoFamilyCounts = {
   UNFCCC: number;
   EXECUTIVE: number;
   LEGISLATIVE: number;
+  MCF: number;
 };
 
 type TGeoMarkers = {
@@ -103,6 +104,7 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}
       {geography.familyCounts?.UNFCCC > 0 && <p>Intl. agreements: {geography.familyCounts?.UNFCCC || 0}</p>}
+      {geography.familyCounts?.MCF > 0 && <p>MCF: {geography.familyCounts?.MCF || 0}</p>}
       <p>
         <LinkWithQuery href={`/geographies/${geography.slug}`}>View more</LinkWithQuery>
       </p>
@@ -229,6 +231,7 @@ export default function MapChart() {
           >
             <option value="lawsPolicies">Laws and policies</option>
             <option value="unfccc">Intl. agreements</option>
+            <option value="mcf">Multilateral Climate Funds</option>
           </select>
         </div>
         <div>

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -231,7 +231,7 @@ export default function MapChart() {
           >
             <option value="lawsPolicies">Laws and policies</option>
             <option value="unfccc">UNFCCC</option>
-            <option value="mcf">Multilateral Climate Fund projects</option>
+            <option value="mcf">MCF projects</option>
           </select>
         </div>
         <div>


### PR DESCRIPTION
# What's changed

Show MCF on world map

![image](https://github.com/user-attachments/assets/2e25e27f-88b7-4793-88e1-0deb65e70d61)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
