### PR TITLE
Dont show xa geos on world map for MCF

### DIFF
--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -131,8 +131,8 @@ export default function MapChart() {
     const maxLawsPolicies = mapDataRaw.length
       ? Math.max(...mapDataRaw.map((g) => (g.family_counts?.EXECUTIVE || 0) + (g.family_counts?.LEGISLATIVE || 0)))
       : 0;
-    const maxMcf = mapDataRaw.length ? Math.max(...mapDataRaw.map((g) => g.family_counts?.MCF || 0)) : 0;
-    // Only take UNFCCC counts for countries that are not XAA or XAB (international, no geography)
+    // Only take UNFCCC and MCF counts for countries that are not XAA or XAB (international, no geography)
+    const maxMcf = mapDataRaw.length ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.MCF || 0))) : 0;
     const maxUnfccc = mapDataRaw.length
       ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.UNFCCC || 0)))
       : 0;

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -158,8 +158,10 @@ export default function MapChart() {
     mapDataConstructor.geographies = configCountries.reduce((acc, country) => {
       const geoStats = mapDataRaw.find((geo) => geo.slug === country.slug);
       const lawsPoliciesCount = (geoStats?.family_counts?.EXECUTIVE || 0) + (geoStats?.family_counts?.LEGISLATIVE || 0);
-      const unfcccCount = ["XAA", "XAB"].includes(country.value) ? 0 : geoStats?.family_counts?.UNFCCC || 0;
-      const mcfCount = ["XAA", "XAB"].includes(country.value) ? 0 : geoStats?.family_counts?.MCF || 0;
+
+      // As the map has no where to display XAA or XAB data we don't need to fiddle with the count.
+      const unfcccCount = geoStats?.family_counts?.UNFCCC || 0;
+      const mcfCount = geoStats?.family_counts?.MCF || 0;
 
       acc[country.value] = {
         ...country,

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -159,7 +159,7 @@ export default function MapChart() {
       const geoStats = mapDataRaw.find((geo) => geo.slug === country.slug);
       const lawsPoliciesCount = (geoStats?.family_counts?.EXECUTIVE || 0) + (geoStats?.family_counts?.LEGISLATIVE || 0);
       const unfcccCount = ["XAA", "XAB"].includes(country.value) ? 0 : geoStats?.family_counts?.UNFCCC || 0;
-      const mcfCount = geoStats?.family_counts?.MCF || 0;
+      const mcfCount = ["XAA", "XAB"].includes(country.value) ? 0 : geoStats?.family_counts?.MCF || 0;
 
       acc[country.value] = {
         ...country,


### PR DESCRIPTION
# What's changed

Dont show xa geos

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
