### PR TITLE
PDCT-1721 geo mcf tab

### DIFF
--- a/src/components/nav/TabbedNav.tsx
+++ b/src/components/nav/TabbedNav.tsx
@@ -44,7 +44,7 @@ const TabbedNav = ({ handleTabClick, items, activeIndex = 0, showBorder = true }
           />
         ))}
       </div>
-      {helpText(activeIndex) && <div className="pl-2 text-sm my-1 text-gray-600">{helpText(activeIndex)}</div>}
+      {helpText(activeIndex) && <div className="pl-2 text-sm my-1">{helpText(activeIndex)}</div>}
     </>
   );
 };

--- a/src/components/nav/TabbedNav.tsx
+++ b/src/components/nav/TabbedNav.tsx
@@ -1,9 +1,13 @@
 import { useState, useEffect } from "react";
+
 import TabbedNavItem from "./TabbedNavItem";
+
 import { getCategoryTooltip } from "@helpers/getCategoryTooltip";
 
+import { TDocumentCategory } from "@types";
+
 type TTabItems = {
-  title: string;
+  title: TDocumentCategory;
   count?: number;
 };
 

--- a/src/components/nav/TabbedNavItem.tsx
+++ b/src/components/nav/TabbedNavItem.tsx
@@ -17,7 +17,7 @@ const TabbedNavItem = ({ title, count, index, activeTab, onClick }: TabbedNavIte
   const tooltipId = `${index}-tooltip`;
   const tooltipText = getCategoryTooltip(title);
   const isActive = activeTab === index;
-  const cssClass = `flex items-center gap-2 text-left mt-4 text-sm hover:text-blue-600 md:px-4 md:mt-0 ${isActive && "tabbed-nav__active"} ${
+  const cssClass = `flex items-center gap-2 text-textDark text-left mt-4 text-sm transition hover:text-blue-600 md:px-4 md:mt-0 ${isActive && "tabbed-nav__active"} ${
     index === 0 && "md:pl-3"
   }`;
 

--- a/src/components/nav/TabbedNavItem.tsx
+++ b/src/components/nav/TabbedNavItem.tsx
@@ -1,8 +1,11 @@
 import { ToolTipSSR } from "@components/tooltip/TooltipSSR";
+
 import { getCategoryTooltip } from "@helpers/getCategoryTooltip";
 
+import { TDocumentCategory } from "@types";
+
 interface TabbedNavItemProps {
-  title: string;
+  title: TDocumentCategory;
   count?: number;
   index: number;
   activeTab: number;
@@ -17,9 +20,9 @@ const TabbedNavItem = ({ title, count, index, activeTab, onClick }: TabbedNavIte
   const tooltipId = `${index}-tooltip`;
   const tooltipText = getCategoryTooltip(title);
   const isActive = activeTab === index;
-  const cssClass = `flex items-center gap-2 text-textDark text-left mt-4 text-sm transition hover:text-blue-600 md:px-4 md:mt-0 ${isActive && "tabbed-nav__active"} ${
-    index === 0 && "md:pl-3"
-  }`;
+  const cssClass = `flex items-center gap-2 text-textDark text-left mt-4 text-sm transition hover:text-blue-600 md:px-4 md:mt-0 ${
+    isActive && "tabbed-nav__active"
+  } ${index === 0 && "md:pl-3"}`;
 
   return (
     <>

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,10 +1,10 @@
 import { ExternalLink } from "@components/ExternalLink";
 import SearchResult from "./SearchResult";
 
-import { TDocumentCategory, TMatchedFamily } from "@types";
+import { TMatchedFamily } from "@types";
 
 type TProps = {
-  category?: TDocumentCategory;
+  category?: string;
   families: TMatchedFamily[];
   activeFamilyIndex?: number | boolean;
   onClick?: (index: number) => void;

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -10,19 +10,19 @@ type TProps = {
   onClick?: (index: number) => void;
 };
 
+const renderEmptyMessage = (category: string) => {
+  if (category !== "UNFCCC") {
+    category = category.toLowerCase();
+  }
+
+  return (
+    <div className="h-96 mt-4 md:mt-0">
+      Your search returned no results from documents in the {category} category. Please try a different category, or conduct a new search.
+    </div>
+  );
+};
+
 const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TProps) => {
-  const emptyMessage = (category: string) => {
-    if (category !== "UNFCCC") {
-      category = category.toLowerCase();
-    }
-
-    return (
-      <div className="h-96 mt-4 md:mt-0">
-        Your search returned no results from documents in the {category} category. Please try a different category, or conduct a new search.
-      </div>
-    );
-  };
-
   if (category && category === "Litigation") {
     return (
       <>
@@ -44,16 +44,16 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
     );
   }
   if (category && category === "Laws" && families.length === 0) {
-    return emptyMessage(category);
+    return renderEmptyMessage(category);
   }
   if (category && category === "Policies" && families.length === 0) {
-    return emptyMessage(category);
+    return renderEmptyMessage(category);
   }
   if (category && category === "UNFCCC" && families.length === 0) {
-    return emptyMessage(category);
+    return renderEmptyMessage(category);
   }
   if (category && category === "MCF" && families.length === 0) {
-    return emptyMessage("multilateral climate funds");
+    return renderEmptyMessage("multilateral climate funds");
   }
   if (families.length === 0) {
     return <div className="h-96 mt-4 md:mt-0">Your search returned no results.</div>;

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,12 +1,10 @@
 import { ExternalLink } from "@components/ExternalLink";
 import SearchResult from "./SearchResult";
 
-import { TMatchedFamily } from "@types";
-
-import { DOCUMENT_CATEGORIES } from "@constants/documentCategories";
+import { TDocumentCategory, TMatchedFamily } from "@types";
 
 type TProps = {
-  category?: (typeof DOCUMENT_CATEGORIES)[number];
+  category?: TDocumentCategory;
   families: TMatchedFamily[];
   activeFamilyIndex?: number | boolean;
   onClick?: (index: number) => void;
@@ -45,7 +43,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
       </>
     );
   }
-  if (category && category === "Legislation" && families.length === 0) {
+  if (category && category === "Laws" && families.length === 0) {
     return emptyMessage(category);
   }
   if (category && category === "Policies" && families.length === 0) {
@@ -53,6 +51,9 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TP
   }
   if (category && category === "UNFCCC" && families.length === 0) {
     return emptyMessage(category);
+  }
+  if (category && category === "MCF" && families.length === 0) {
+    return emptyMessage("multilateral climate funds");
   }
   if (families.length === 0) {
     return <div className="h-96 mt-4 md:mt-0">Your search returned no results.</div>;

--- a/src/constants/documentCategories.ts
+++ b/src/constants/documentCategories.ts
@@ -1,6 +1,0 @@
-export const DOCUMENT_CATEGORIES = ["All", "Legislation", "Policies", "UNFCCC", "Litigation"];
-
-// For now all individual fund documents are returning as MCF, so we do not need separate categories
-export const MCF_DOCUMENT_CATEGORIES = ["All"];
-
-export type TDocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];

--- a/src/helpers/getCategoryTooltip.ts
+++ b/src/helpers/getCategoryTooltip.ts
@@ -1,4 +1,4 @@
-import { TDocumentCategory } from "@constants/documentCategories";
+import { TDocumentCategory } from "@types";
 
 export const getCategoryTooltip = (category: TDocumentCategory): string => {
   switch (category) {

--- a/src/helpers/getCategoryTooltip.ts
+++ b/src/helpers/getCategoryTooltip.ts
@@ -4,7 +4,7 @@ export const getCategoryTooltip = (category: TDocumentCategory): string => {
   switch (category) {
     case "All":
       return "";
-    case "Legislation":
+    case "Laws":
       return "For example: Laws, Acts, Constitutions (legislative branch)";
     case "Policies":
       return "For example: Policies, strategies, decrees, action plans (from executive branch)";
@@ -12,6 +12,8 @@ export const getCategoryTooltip = (category: TDocumentCategory): string => {
       return "For example: Court cases and tribunal proceedings";
     case "UNFCCC":
       return "Documents submitted to the UNFCCC (including NDCs)";
+    case "MCF":
+      return "Multilateral climate fund projects and policies";
     default:
       return "";
   }

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -72,8 +72,6 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
   const hasTargets = !!publishedTargets && publishedTargets?.length > 0;
   const allDocumentsCount = Object.values(summary.family_counts).reduce((acc, count) => acc + (count || 0), 0);
 
-  const isMCFTheme = theme === "mcf";
-
   const documentCategories = themeConfig.documentCategories.map((category) => {
     let count = null;
     switch (category) {
@@ -159,56 +157,54 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
           );
       });
     }
-    if (!isMCFTheme) {
-      // Legislative
-      if (selectedCategoryIndex === 1) {
-        return summary.top_families.Legislative.length === 0
-          ? renderEmpty("Legislative")
-          : summary.top_families.Legislative.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mb-10">
-                <FamilyListItem family={family} />
-              </div>
-            ));
-      }
-      // Executive
-      if (selectedCategoryIndex === 2) {
-        return summary.top_families.Executive.length === 0
-          ? renderEmpty("Executive")
-          : summary.top_families.Executive.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mb-10">
-                <FamilyListItem family={family} />
-              </div>
-            ));
-      }
-      // UNFCCC
-      if (selectedCategoryIndex === 3) {
-        return summary.top_families.UNFCCC.length === 0
-          ? renderEmpty("UNFCCC")
-          : summary.top_families.UNFCCC.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mb-10">
-                <FamilyListItem family={family} />
-              </div>
-            ));
-      }
-      // Litigation
-      if (selectedCategoryIndex === 4) {
-        return (
-          <div className="mt-4 pb-4 border-b">
-            Climate litigation case documents are coming soon. In the meantime, visit the Sabin Center’s{" "}
-            <ExternalLink url="http://climatecasechart.com/">Climate Change Litigation Databases</ExternalLink>.
-          </div>
-        );
-      }
-      // MCF
-      if (selectedCategoryIndex === 5) {
-        return summary.top_families.MCF.length === 0
-          ? renderEmpty("multilateral climate funds")
-          : summary.top_families.MCF.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-              <div key={family.family_slug} className="mb-10">
-                <FamilyListItem family={family} />
-              </div>
-            ));
-      }
+    // Legislative
+    if (selectedCategoryIndex === 1) {
+      return summary.top_families.Legislative.length === 0
+        ? renderEmpty("Legislative")
+        : summary.top_families.Legislative.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+            <div key={family.family_slug} className="mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          ));
+    }
+    // Executive
+    if (selectedCategoryIndex === 2) {
+      return summary.top_families.Executive.length === 0
+        ? renderEmpty("Executive")
+        : summary.top_families.Executive.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+            <div key={family.family_slug} className="mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          ));
+    }
+    // UNFCCC
+    if (selectedCategoryIndex === 3) {
+      return summary.top_families.UNFCCC.length === 0
+        ? renderEmpty("UNFCCC")
+        : summary.top_families.UNFCCC.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+            <div key={family.family_slug} className="mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          ));
+    }
+    // Litigation
+    if (selectedCategoryIndex === 4) {
+      return (
+        <div className="mt-4 pb-4 border-b">
+          Climate litigation case documents are coming soon. In the meantime, visit the Sabin Center’s{" "}
+          <ExternalLink url="http://climatecasechart.com/">Climate Change Litigation Databases</ExternalLink>.
+        </div>
+      );
+    }
+    // MCF
+    if (selectedCategoryIndex === 5) {
+      return summary.top_families.MCF.length === 0
+        ? renderEmpty("multilateral climate funds")
+        : summary.top_families.MCF.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+            <div key={family.family_slug} className="mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          ));
     }
   };
 
@@ -331,7 +327,7 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
                   </Timeline>
                 </section>
               )}
-              {geography.legislative_process && !isMCFTheme && (
+              {geography.legislative_process && theme !== "mcf" && (
                 <section className="mt-10" data-cy="legislative-process">
                   <Heading level={2} extraClasses="flex items-center gap-2">
                     <LegislativeIcon width="20" height="20" /> Legislative Process
@@ -399,28 +395,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const isMCFTheme = theme === "mcf";
-
-  const filterSummaryData = (summaryInformation: TGeographySummary) => {
-    if (isMCFTheme) {
-      return {
-        family_counts: { MCF: summaryInformation.family_counts.MCF },
-        top_families: { MCF: summaryInformation.top_families.MCF },
-        targets: [],
-      };
-    } else {
-      // const { MCF, ...familyCountsWithoutMCF } = summaryInformation.family_counts;
-      // const { MCF: mcfTopFamilies, ...topFamiliesWithoutMCF } = summaryInformation.top_families;
-      return {
-        family_counts: summaryInformation.family_counts,
-        top_families: summaryInformation.top_families,
-        targets: summaryInformation.targets,
-      };
-    }
-  };
-
-  const filteredTargetsData = isMCFTheme ? [] : targetsData;
-
   try {
     themeConfig = await readConfigFile(theme);
   } catch {
@@ -430,8 +404,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       geography: geographyData,
-      summary: filterSummaryData(summaryData),
-      targets: filteredTargetsData,
+      summary: summaryData,
+      targets: theme === "mcf" ? [] : targetsData,
       theme: theme,
       themeConfig,
     },

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -31,7 +31,6 @@ import { extractNestedData } from "@utils/extractNestedData";
 import { sortFilterTargets } from "@utils/sortFilterTargets";
 import { readConfigFile } from "@utils/readConfigFile";
 
-import { DOCUMENT_CATEGORIES, MCF_DOCUMENT_CATEGORIES } from "@constants/documentCategories";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { systemGeoNames } from "@constants/systemGeos";
 
@@ -46,12 +45,14 @@ type TProps = {
   themeConfig: TThemeConfig;
 };
 
+// Mapping of category index to category name in search
 const categoryByIndex = {
   0: "All",
   1: "laws",
   2: "policies",
   3: "UNFCCC",
   4: "laws",
+  5: "multilateral-climate-funds",
 };
 
 const MAX_NUMBER_OF_FAMILIES = 3;
@@ -73,15 +74,13 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
 
   const isMCFTheme = theme === "mcf";
 
-  const filteredCategoryArray = isMCFTheme ? MCF_DOCUMENT_CATEGORIES : DOCUMENT_CATEGORIES;
-
-  const documentCategories = filteredCategoryArray.map((category) => {
+  const documentCategories = themeConfig.documentCategories.map((category) => {
     let count = null;
     switch (category) {
       case "All":
         count = allDocumentsCount;
         break;
-      case "Legislation":
+      case "Laws":
         count = summary.family_counts.Legislative;
         break;
       case "Policies":
@@ -199,6 +198,16 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
             <ExternalLink url="http://climatecasechart.com/">Climate Change Litigation Databases</ExternalLink>.
           </div>
         );
+      }
+      // MCF
+      if (selectedCategoryIndex === 5) {
+        return summary.top_families.MCF.length === 0
+          ? renderEmpty("multilateral climate funds")
+          : summary.top_families.MCF.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+              <div key={family.family_slug} className="mb-10">
+                <FamilyListItem family={family} />
+              </div>
+            ));
       }
     }
   };
@@ -400,11 +409,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         targets: [],
       };
     } else {
-      const { MCF, ...familyCountsWithoutMCF } = summaryInformation.family_counts;
-      const { MCF: mcfTopFamilies, ...topFamiliesWithoutMCF } = summaryInformation.top_families;
+      // const { MCF, ...familyCountsWithoutMCF } = summaryInformation.family_counts;
+      // const { MCF: mcfTopFamilies, ...topFamiliesWithoutMCF } = summaryInformation.top_families;
       return {
-        family_counts: familyCountsWithoutMCF,
-        top_families: topFamiliesWithoutMCF,
+        family_counts: summaryInformation.family_counts,
+        top_families: summaryInformation.top_families,
         targets: summaryInformation.targets,
       };
     }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -481,7 +481,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 <section data-cy="search-results">
                   <h2 className="sr-only">Search results</h2>
                   <SearchResultList
-                    category={router.query[QUERY_PARAMS.category]?.toString() as TDocumentCategory}
+                    category={router.query[QUERY_PARAMS.category]?.toString()}
                     families={families}
                     onClick={handleMatchesButtonClick}
                     activeFamilyIndex={drawerFamily}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -38,7 +38,7 @@ import { getThemeConfigLink } from "@utils/getThemeConfigLink";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 
-import { TTheme, TThemeConfig } from "@types";
+import { TDocumentCategory, TTheme, TThemeConfig } from "@types";
 import { readConfigFile } from "@utils/readConfigFile";
 
 type TProps = {
@@ -481,7 +481,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 <section data-cy="search-results">
                   <h2 className="sr-only">Search results</h2>
                   <SearchResultList
-                    category={router.query[QUERY_PARAMS.category]?.toString()}
+                    category={router.query[QUERY_PARAMS.category]?.toString() as TDocumentCategory}
                     families={families}
                     onClick={handleMatchesButtonClick}
                     activeFamilyIndex={drawerFamily}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -309,6 +309,8 @@ export type TQueryStrings = {
   implementing_agency: string;
 };
 
+export type TDocumentCategory = "All" | "Laws" | "Policies" | "UNFCCC" | "Litigation" | "MCF";
+
 // Theme configuration types
 export type TLabelVariation = {
   category: string[];
@@ -360,4 +362,5 @@ export type TThemeConfig = {
   labelVariations: TLabelVariation[];
   links: TThemeLink[];
   metadata: TThemeMetadata[];
+  documentCategories: TDocumentCategory[];
 };

--- a/themes/cclw/config.json
+++ b/themes/cclw/config.json
@@ -50,5 +50,6 @@
       "title": "Law and Policy Search",
       "description": "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country."
     }
-  ]
+  ],
+  "documentCategories": ["All", "Laws", "Policies", "UNFCCC", "Litigation"]
 }

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -117,5 +117,6 @@
       "title": "Law and Policy Search",
       "description": "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country."
     }
-  ]
+  ],
+  "documentCategories": ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF"]
 }

--- a/themes/mcf/config.json
+++ b/themes/mcf/config.json
@@ -82,5 +82,6 @@
       "title": "Climate Project Search",
       "description": "Quickly and easily search through the complete text of thousands of project documents."
     }
-  ]
+  ],
+  "documentCategories": ["All"]
 }


### PR DESCRIPTION
# What's changed
- Adding MCF tab on the geography pages
- Moving the document categories constant into the theme config rather than in code
- This only controls the tabs on the geography page at the moment

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
