### PR TITLE
feat: add new cpr related corpora to the frontend config

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -15,13 +15,25 @@
       {
         "label": "Policies",
         "slug": "policies",
-        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000"],
+        "value": [
+          "CCLW.corpus.i00000001.n0000",
+          "CPR.corpus.i00000001.n0000",
+          "CPR.corpus.i00000589.n0000",
+          "CPR.corpus.i00000591.n0000",
+          "CPR.corpus.i00000592.n0000"
+        ],
         "category": ["Executive"]
       },
       {
         "label": "Laws",
         "slug": "laws",
-        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000"],
+        "value": [
+          "CCLW.corpus.i00000001.n0000",
+          "CPR.corpus.i00000001.n0000",
+          "CPR.corpus.i00000589.n0000",
+          "CPR.corpus.i00000591.n0000",
+          "CPR.corpus.i00000592.n0000"
+        ],
         "category": ["Legislative"],
         "alias": "LAWS"
       },


### PR DESCRIPTION
# What's changed

we have new corpora entities that fall under laws and policy ( "CPR.corpus.i00000589.n0000", "CPR.corpus.i00000591.n0000", "CPR.corpus.i00000592.n0000") this new data will be coming through to the frontend app, to allow search to filter on this data we need to add these corpora into the frontend config

<img width="784" alt="Screenshot 2024-12-16 at 13 57 51" src="https://github.com/user-attachments/assets/1aef6f7d-62cd-4c22-910a-e1050564b334" />

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
