### PR TITLE
Rename "Responses" to "Topics" in methodology

### DIFF
--- a/themes/cclw/constants/methodologyItems.tsx
+++ b/themes/cclw/constants/methodologyItems.tsx
@@ -97,7 +97,7 @@ export const METHODOLOGY: TDataListItem[] = [
           government guidance note.
         </p>
 
-        <h4>Responses</h4>
+        <h4>Topics</h4>
         <p>
           <b>Laws and policies are categorised according to the climate policy response to which they are most relevant</b>: mitigation, adaptation,
           loss and damage, or disaster risk management. Where appropriate, laws may be tagged as relevant to more than one policy response.


### PR DESCRIPTION
# What's changed
- Minor rename in the Climate Laws methodology

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
