### PR TITLE
feat: auto-deploy on merge to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,3 +88,71 @@ jobs:
     permissions:
       contents: write
     uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v6
+
+  # everything below here is moving towards a new workflow
+  # and will superscede `release`
+  deploy:
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [cpr, cclw, mcf]
+    steps:
+      - name: Build
+        run: |
+          export THEME=${{ matrix.theme }}
+          make build
+      # TODO: We need to run a test phase here - but for now we're relying on the previous deploy steps that run the tests
+      - name: Release
+        uses: climatepolicyradar/retag-and-push-to-ecr@v1
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          # This is then used in navigator-infra
+          repo-name: navigator-frontend-${{ matrix.theme }}
+          semver-tag: ${{ github.sha }}
+      # TODO:👇 remove this block once we are happy with test coverage
+      # Checks to see if the commit was from a PR merge
+      # and that that PR was labelled `deploy`
+      - name: Get PR information
+        id: pr-info
+        run: |
+          PR_NUMBER=$(curl -s ${{ github.event.repository.url }}/commits/${{ github.sha }}/pulls \
+            -H "Accept: application/vnd.github.groot-preview+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            | jq '.[0].number')
+
+          if [ "$PR_NUMBER" != "null" ]; then
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "was_pr_merge=true" >> $GITHUB_OUTPUT
+          else
+            echo "was_pr_merge=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Check PR labels
+        if: steps.pr-info.outputs.was_pr_merge == 'true'
+        id: check-deploy-on-merge-label
+        run: |
+          LABELS=$(curl -s ${{ github.event.repository.url }}/pulls/${{ steps.pr-info.outputs.pr_number }} \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            | jq '.labels[].name')
+
+          if echo "$LABELS" | grep -q '"deploy"'; then
+            echo "deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          fi
+      # TODO:👆 remove this block once we are happy with test coverage
+      - name: Deploy
+        if: steps.check-deploy-on-merge-label.outputs.deploy == 'true'
+        uses: ./.github/workflows/deploy.yml
+        with:
+          # This is currently from the user jamesgorrie
+          # TODO: use tech@climatepolicyradar.org user for this
+          github-token: ${{ secrets.NAVIGATOR_INFRA_GITHUB_PAT }}
+          environment: production
+          docker-tag: ${{ github.sha }}
+          theme: ${{ matrix.theme }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+# trunk-ignore-all(checkov)
+name: Deploy on merge
+on:
+  workflow_call:
+    inputs:
+      theme:
+        description: Theme
+        type: string
+        required: true
+      docker-tag:
+        description: Docker tag
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      theme:
+        description: Theme
+        type: string
+        required: true
+      docker-tag:
+        description: Docker tag
+        type: string
+        required: true
+permissions: read-all
+jobs:
+  deploy-on-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy
+        uses: actions/github-script@v7
+        with:
+          # This is currently from the user jamesgorrie
+          # TODO: use tech@climatepolicyradar.org user for this
+          github-token: ${{ secrets.NAVIGATOR_INFRA_GITHUB_PAT }}
+          script: |
+            // This is because we did not prefix CPR as it was theme no. 1
+            const stack = "${{ inputs.theme }}" === "cpr" ? "frontend/production" : "frontend/${{ inputs.theme }}-production";
+            const result = await github.rest.actions.createWorkflowDispatch({
+                owner: "climatepolicyradar",
+                repo: "navigator-infra",
+                workflow_id: "deploy.yml",
+                ref: "main",
+                inputs: {
+                    "docker-tag": `main-${{ inputs.docker-tag }}`,
+                    stack: stack
+                }
+            })
+            // TODO: extend logging and reporting
+            console.log(result)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -37,7 +37,7 @@ lint:
         - LICENSE.md
 
   enabled:
-    - actionlint@1.6.27
+    - actionlint@1.7.5
     - checkov@3.2.46
     - eslint@8.57.0
     - git-diff-check


### PR DESCRIPTION
# What's changed

We'd like to trigger a deploy in `navigator-infra` from this repo `navigator-frontend`.

We don't have enough confidence yet that we can do this on each merge, so this is an interim step to help us figure out where the largest holes in our coverage is by allowing us to opt-in to auto deploying via `workflow_call`, or trigger it manually via `workflow_dispatch`.

To auto deploy, you will need to add the label `deploy` to your PR. This is read on merge, and the auto-deploy step is run if `true`.

The process is a little convoluted. This is because we need to read the labels from the PR. This is only while we're in testing phase. It should be a lot easier once we don't have to read PR labels.

The flow is:
* Create PR
* Label PR with `deploy`
* Merge PR
* If labelled
  * The action reads the PR commit
  * Goes through the hoops to deploy

✨ This should also get us a little closer to using SHAs as versions and also CD.

## A diagram of current vs ideal, proposed workflows
```mermaid
flowchart TD
    nf["navigator-frontend"]
    test["test"]
    tf["theme-factory"]
    tag["tag / semver"]
    pr["get-next-tag-from-pr-body"]
    push["retag-and-push-to-ecr"]

    subgraph current
        subgraph ./
            nf-->tf
        end
        subgraph ./reusable-workflows
            tf-->build-->test-->tag
        end

        subgraph external actions
            tag-->pr-->push
        end

        subgraph navigator-infra
            push-->manualDeploy["Manual deploy"]
        end
    end

    nfLocal["navigator-frontend"]
    subgraph proposed
        subgraph ./2["./"]
            nfLocal-->buildLocal["build"]-->testLocal["test"]
            deployLocal
        end
        
        subgraph externalActions["external actions"]
            testLocal-->pushLocal["retag-and-push-to-ecr"]-->deployLocal
        end

        subgraph navigator-infra2["navigator-infra"]
            deployLocal["deploy"]-->niDeploy["deploy"]
        end
    end


    missing
    
    style missing stroke:red;
    style testLocal stroke:red;
    style proposed stroke:green,stroke-width:5px;
```

## Proposed version

- [x] Patch
