### PR TITLE
chore(deps): upgrade node types lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@types/cypress": "^1.1.3",
         "@types/gtag.js": "^0.0.14",
         "@types/jest": "^29.5.12",
-        "@types/node": "^12.12.21",
+        "@types/node": "^22.10.5",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^17.0.1",
         "@types/react-leaflet": "^3.0.0",
@@ -3422,10 +3422,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -13399,6 +13402,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/cypress": "^1.1.3",
     "@types/gtag.js": "^0.0.14",
     "@types/jest": "^29.5.12",
-    "@types/node": "^12.12.21",
+    "@types/node": "^22.10.5",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^17.0.1",
     "@types/react-leaflet": "^3.0.0",


### PR DESCRIPTION
# What's changed

- upgrade node version to latest LTS

This should be a no-op as Typescript is static.

- [x] Patch
