### PR TITLE
Add typed getConfig to ApiClient

### DIFF
--- a/src/api/http-common.ts
+++ b/src/api/http-common.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { TCorpusTypeDictionary, TDataNode, TGeography, TLanguages } from "@types";
 import axios, { AxiosInstance, AxiosResponse } from "axios";
 
 export async function getEnvFromServer() {
@@ -33,10 +34,10 @@ class ApiClient {
   /**
    * Submit a GET request and return the response as a mapped promise.
    */
-  get(url: string, params?: any): Promise<AxiosResponse> {
+  get<T = any>(url: string, params?: any): Promise<AxiosResponse<T>> {
     // console.log(`GET: ${this.baseUrl}${url}`);
     return this.axiosClient
-      .get(url, { params })
+      .get<T>(url, { params })
       .then((res: any) => res)
       .catch((err) => {
         console.log(err);
@@ -68,6 +69,10 @@ class ApiClient {
         console.log(err);
         return Promise.reject(err);
       });
+  }
+
+  getConfig() {
+    return this.get<{ geographies: TDataNode<TGeography>[]; corpus_types: TCorpusTypeDictionary; languages: TLanguages }>("/config");
   }
 }
 

--- a/src/helpers/getCorpusInfo.tsx
+++ b/src/helpers/getCorpusInfo.tsx
@@ -1,40 +1,24 @@
-/* eslint-disable no-console */
-import { TOrganisation, TOrganisationDictionary } from "@types";
+import { TCorpusTypeDictionary } from "@types";
 
 type TProps = {
-  organisations?: TOrganisationDictionary;
-  organisation?: string;
-  corpus_id?: string;
+  corpus_types: TCorpusTypeDictionary;
+  corpus_id: string;
 };
 
-export const getCorpusInfo = ({ organisations, organisation, corpus_id }: TProps) => {
-  if (!organisations) {
-    // No organisations means we're not yet ready
-    return { corpusImage: null, corpusAltImage: null, corpusNote: null };
-  }
-  const defaultResult = {
+export const getCorpusInfo = ({ corpus_types, corpus_id }: TProps) => {
+  const corpora = Object.values(corpus_types).flatMap((corpus_type) => corpus_type.corpora);
+  const selectedCorpus = corpora.find((corpus) => corpus.corpus_import_id === corpus_id);
+  const defaultCorpus = {
     corpusImage: null,
     corpusAltImage: "No corpus image found",
     corpusNote: "No corpus note found",
   };
 
-  if (!organisations || !organisation || !corpus_id) {
-    console.error(`getCorpusInfo(): Something isn't set - Organisation: ${organisation}, Corpus_id: ${corpus_id}`);
-    return defaultResult;
-  }
-
-  const orgConfig: TOrganisation = organisations[organisation];
-  const corpusFound = orgConfig?.corpora.filter((c) => c.corpus_import_id === corpus_id);
-
-  if (!corpusFound) {
-    console.error(`getCorpusInfo(): Couldn't find corpus - Organisation: ${organisation}, Corpus_id: ${corpus_id}`);
-    return defaultResult;
-  }
-  const corpusConfig = corpusFound[0];
-
-  return {
-    corpusImage: corpusConfig?.image_url,
-    corpusAltImage: corpusConfig?.description,
-    corpusNote: corpusConfig?.text,
-  };
+  return selectedCorpus
+    ? {
+        corpusImage: selectedCorpus.image_url,
+        corpusAltImage: selectedCorpus.title,
+        corpusNote: selectedCorpus.text,
+      }
+    : defaultCorpus;
 };

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,12 +1,7 @@
 import { useQuery } from "react-query";
 import { ApiClient, getEnvFromServer } from "../api/http-common";
 import { extractNestedData } from "@utils/extractNestedData";
-import { TGeography, TLanguages, TCorpusTypeDictionary } from "@types";
-
-type TDataNode<T> = {
-  node: T;
-  children: T[];
-};
+import { TGeography, TLanguages, TCorpusTypeDictionary, TDataNode } from "@types";
 
 type TQueryResponse = {
   geographies: TDataNode<TGeography>[];
@@ -22,7 +17,7 @@ export default function useConfig() {
     async () => {
       const { data } = await getEnvFromServer();
       const client = new ApiClient(data?.env?.api_url, data?.env?.app_token);
-      const query_response = await client.get("/config", null);
+      const query_response = await client.getConfig();
       const geographies = query_response.data.geographies;
       const response_geo = extractNestedData<TGeography>(geographies, 2, "");
       const regions = response_geo.level1;

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -377,7 +377,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   try {
     let countries: TGeography[] = [];
-    const configData = await client.get(`/config`, null);
+    const configData = await client.getConfig();
     const response_geo = extractNestedData<TGeography>(configData.data?.geographies, 2, "");
     countries = response_geo.level2;
     const country = getCountryCode(id as string, countries);

--- a/src/pages/sitemap.txt.ts
+++ b/src/pages/sitemap.txt.ts
@@ -1,27 +1,22 @@
 import { ApiClient } from "@api/http-common";
-import { TGeographyConfig } from "@types";
+import { TDataNode, TGeography } from "@types";
 
 function Sitemap() {}
 
-function extractGeographyIds(config: TGeographyConfig): number[] {
-  const children_ids: number[] = config.children.flatMap((node): number[] => extractGeographyIds(node));
-  return [config.node.id].concat(children_ids);
-}
-
-function extractGeographySlugs(config: TGeographyConfig): string[] {
+function extractGeographySlugs(config: TDataNode<TGeography>): string[] {
   const children_slugs: string[] = config.children.flatMap((node): string[] => extractGeographySlugs(node));
   return [config.node.slug].concat(children_slugs);
 }
 
-async function fetchGeographies(): Promise<TGeographyConfig[]> {
+async function fetchGeographies(): Promise<TDataNode<TGeography>[]> {
   const client = new ApiClient();
-  const { data: data } = await client.get(`/config`, null);
+  const { data: data } = await client.getConfig();
   return data.geographies;
 }
 
 async function getGeographyIds(): Promise<string[]> {
-  const geographyData: TGeographyConfig[] = await fetchGeographies();
-  return geographyData.flatMap((item: TGeographyConfig) => extractGeographySlugs(item));
+  const geographyData: TDataNode<TGeography>[] = await fetchGeographies();
+  return geographyData.flatMap((item: TDataNode<TGeography>) => extractGeographySlugs(item));
 }
 
 async function getGeographyPages(res: any, hostname: string): Promise<string[]> {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -268,6 +268,7 @@ export type TCorpus = {
 };
 
 export type TCorpusWithStats = {
+  corpus_import_id: string;
   title: string;
   description: string;
   image_url: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -40,6 +40,11 @@ export type TPassage = {
   text_block_page: number;
 };
 
+export type TDataNode<T> = {
+  node: T;
+  children: TDataNode<T>[];
+};
+
 export type TGeography = {
   id: number;
   display_value: string;
@@ -68,20 +73,6 @@ export type TTarget = {
   "Net zero target?": "TRUE" | "FALSE";
   "family-slug": string;
   "family-name": string;
-};
-
-export type TGeographyConfigNode = {
-  id: number;
-  display_value: string;
-  value: string;
-  type: string;
-  parent_id: number;
-  slug: string;
-};
-
-export type TGeographyConfig = {
-  node: TGeographyConfigNode;
-  children: TGeographyConfig[];
 };
 
 export type TGeographyStats = {

--- a/src/utils/extractNestedData.ts
+++ b/src/utils/extractNestedData.ts
@@ -1,9 +1,5 @@
+import { TDataNode } from "@types";
 import { removeDuplicates } from "@utils/removeDuplicates";
-
-type TDataNode<T> = {
-  node: T;
-  children: T[];
-};
 
 export function extractNestedData<T>(response: TDataNode<T>[], levels: number, filterProp: string): { level1: T[]; level2: T[] } {
   let level1 = [];


### PR DESCRIPTION
# What's changed
- adds `getConfig` to the api client
- implements this where we use client.get(`/config`)
- removes some redundant `Geography` types

## Testing
I haven't added e2e tests as tests wouldn't have caught this as this broke when we deployed `navigator-backend` which removed the `organisations` field.

The type system here catches the error we wanted to guard against.

We should still be thinking about how we test `navigator-frontend` when changes are made to `navigator-backend` (had a small thought of adding visual regression to NB).

## Proposed version

- [x] Patch
