### PR TITLE
APP 164 - reports category

### DIFF
--- a/e2e/cypress/e2e/cclw/pages/document.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/document.cy.js
@@ -29,7 +29,7 @@ describe("Document Page", () => {
 
   it("should display the page elements", () => {
     pageSelectors.forEach((selector) => {
-      cy.get(selector).should("be.visible");
+      cy.get(selector, { timeout: 10000 }).should("be.visible");
     });
   });
 
@@ -40,7 +40,7 @@ describe("Document Page", () => {
   });
 
   it("should display the matches heading", () => {
-    cy.get("[data-cy='document-matches-description']").should("be.visible").should("contain", "Sorted by search relevance");
+    cy.get("[data-cy='document-matches-description']", { timeout: 10000 }).should("be.visible").should("contain", "Sorted by search relevance");
   });
 
   it("should contain at least 1 passage match", () => {

--- a/e2e/cypress/e2e/cclw/pages/homepage.cy.js
+++ b/e2e/cypress/e2e/cclw/pages/homepage.cy.js
@@ -40,7 +40,7 @@ describe("Homepage", () => {
 
   it("should display correct page elements", () => {
     pageSelectors.forEach((selector) => {
-      cy.get(selector).should("be.visible");
+      cy.get(selector, { timeout: 10000 }).should("be.visible");
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "framer-motion": "^11.11.7",
         "jwt-decode": "^4.0.0",
         "next": "15.1.4",
-        "react": "^18.3.1",
+        "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hook-form": "^7.33.1",
         "react-icons": "^5.3.0",

--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -23,6 +23,17 @@ type TProps = {
   themeConfig: TThemeConfig;
 };
 
+const filterIsSelected = (queryValue: string | string[] | undefined, option: string) => {
+  if (!queryValue) {
+    return false;
+  }
+  if (typeof queryValue === "string") {
+    return queryValue === option;
+  } else {
+    return queryValue.includes(option);
+  }
+};
+
 export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types, themeConfig }: TProps) => {
   const [search, setSearch] = useState("");
 
@@ -35,7 +46,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
             <InputRadio
               key={option.slug}
               label={option.label}
-              checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option.slug)}
+              checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option.slug)}
               onChange={() => null} // supress normal radio behaviour to allow to deselection
               onClick={() => {
                 handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option.slug, true);
@@ -46,7 +57,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
             <InputCheck
               key={option.slug}
               label={option.label}
-              checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option.slug)}
+              checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option.slug)}
               onChange={() => {
                 handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option.slug);
               }}
@@ -102,7 +113,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputRadio
         key={option}
         label={option}
-        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]] === option}
+        checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option)}
         onChange={() => null} // supress normal radio behaviour to allow to deselection
         onClick={() => {
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option, true);
@@ -113,7 +124,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputCheck
         key={option}
         label={option}
-        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]] === option}
+        checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option)}
         onChange={() => {
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option);
         }}

--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -102,7 +102,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputRadio
         key={option}
         label={option}
-        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
+        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]] === option}
         onChange={() => null} // supress normal radio behaviour to allow to deselection
         onClick={() => {
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option, true);
@@ -113,7 +113,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputCheck
         key={option}
         label={option}
-        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]].includes(option)}
+        checked={query && query[QUERY_PARAMS[filter.taxonomyKey]] && query[QUERY_PARAMS[filter.taxonomyKey]] === option}
         onChange={() => {
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option);
         }}

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -76,6 +76,7 @@ const handleFilterDisplay = (
     case "implementing_agency":
     case "topic":
     case "sector":
+    case "author_type":
       filterLabel = value.length > MAX_FILTER_CHARACTERS ? `${decodeURI(value).substring(0, MAX_FILTER_CHARACTERS)}...` : decodeURI(value);
       break;
     case "fund":

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -21,4 +21,6 @@ export const QUERY_PARAMS: TQueryStrings = {
   framework_laws: "fl",
   topic: "tp",
   sector: "sc",
+  // Reports
+  author_type: "at",
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -217,6 +217,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     delete router.query[QUERY_PARAMS.implementing_agency];
     // Law and policy filters
     delete router.query[QUERY_PARAMS.framework_laws];
+    // Reports filters
+    delete router.query[QUERY_PARAMS.author_type];
     // Only reset the topic and sector filters if we are not moving between laws or policies categories
     if (category !== "policies" && category !== "laws") {
       delete router.query[QUERY_PARAMS.topic];

--- a/src/types/queryStrings.ts
+++ b/src/types/queryStrings.ts
@@ -19,4 +19,6 @@ export type TQueryStrings = {
   framework_laws: string;
   topic: string;
   sector: string;
+  // Reports
+  author_type: string;
 };

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -1,6 +1,8 @@
 import { initialSearchCriteria } from "@constants/searchCriteria";
 import { QUERY_PARAMS } from "@constants/queryParams";
 
+import { buildSearchQueryMetadata } from "./buildSearchQueryMetadata";
+
 import { TSearchCriteria, TSearchKeywordFilters, TThemeConfig } from "@types";
 
 export type TRouterQuery = {
@@ -130,43 +132,15 @@ export default function buildSearchQuery(
     }
   }
   if (routerQuery[QUERY_PARAMS.topic]) {
-    let topicsForApi: string[];
-    const topics = routerQuery[QUERY_PARAMS.topic];
-    const configTopics = themeConfig.filters.find((f) => f.taxonomyKey === "topic");
-    if (configTopics) {
-      // remove existing topic filters from the metadata
-      query.metadata = query.metadata.filter((m) => m.name !== configTopics.apiMetaDataKey);
-      if (Array.isArray(topics)) {
-        topicsForApi = topics;
-      } else {
-        topicsForApi = [topics];
-      }
-      topicsForApi.map((t) => {
-        query.metadata.push({ name: configTopics.apiMetaDataKey, value: decodeURI(t) });
-      });
-    }
+    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.topic], "topic", themeConfig);
   }
   if (routerQuery[QUERY_PARAMS.sector]) {
-    let sectorsForApi: string[];
-    const sectors = routerQuery[QUERY_PARAMS.sector];
-    const configSectors = themeConfig.filters.find((f) => f.taxonomyKey === "sector");
-    if (configSectors) {
-      // remove existing sector filters from the metadata
-      query.metadata = query.metadata.filter((m) => m.name !== configSectors.apiMetaDataKey);
-      if (Array.isArray(sectors)) {
-        sectorsForApi = sectors;
-      } else {
-        sectorsForApi = [sectors];
-      }
-      sectorsForApi.map((t) => {
-        query.metadata.push({ name: configSectors.apiMetaDataKey, value: decodeURI(t) });
-      });
-    }
+    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.sector], "sector", themeConfig);
   }
   // ---- End of Laws and Policies specific ----
 
   // ---- MCF specific ----
-  // These are the filters that are specific to the MCF theme
+  // These are the filters that are specific to the MCFs corpus types
   // TODO: handle this more elegantly and scaleably
   if (themeConfig.defaultCorpora) {
     query.corpus_import_ids = themeConfig.defaultCorpora;
@@ -192,41 +166,19 @@ export default function buildSearchQuery(
   }
 
   if (routerQuery[QUERY_PARAMS.status]) {
-    let statusForApi: string[];
-    const statuses = routerQuery[QUERY_PARAMS.status];
-    const configStatus = themeConfig.filters.find((f) => f.taxonomyKey === "status");
-    if (configStatus) {
-      // remove existing status filters from the metadata
-      query.metadata = query.metadata.filter((m) => m.name !== configStatus.apiMetaDataKey);
-      if (Array.isArray(statuses)) {
-        statusForApi = statuses;
-      } else {
-        statusForApi = [statuses];
-      }
-      statusForApi.map((s) => {
-        query.metadata.push({ name: configStatus.apiMetaDataKey, value: decodeURI(s) });
-      });
-    }
+    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.status], "status", themeConfig);
   }
 
   if (routerQuery[QUERY_PARAMS.implementing_agency]) {
-    let implementingAgencyForApi: string[];
-    const implementingAgencies = routerQuery[QUERY_PARAMS.implementing_agency];
-    const configIplementingAgency = themeConfig.filters.find((f) => f.taxonomyKey === "implementing_agency");
-    if (configIplementingAgency) {
-      // remove existing status filters from the metadata
-      query.metadata = query.metadata.filter((m) => m.name !== configIplementingAgency.apiMetaDataKey);
-      if (Array.isArray(implementingAgencies)) {
-        implementingAgencyForApi = implementingAgencies;
-      } else {
-        implementingAgencyForApi = [implementingAgencies];
-      }
-      implementingAgencyForApi.map((ia) => {
-        query.metadata.push({ name: configIplementingAgency.apiMetaDataKey, value: decodeURI(ia) });
-      });
-    }
+    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.implementing_agency], "implementing_agency", themeConfig);
   }
   // ---- End of MCF specific ----
+
+  // ---- Reports specific ----
+  // These are the filters that are specific to the Reports corpus type
+  if (routerQuery[QUERY_PARAMS.author_type]) {
+    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig);
+  }
 
   query = {
     ...query,

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -132,10 +132,10 @@ export default function buildSearchQuery(
     }
   }
   if (routerQuery[QUERY_PARAMS.topic]) {
-    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.topic], "topic", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.topic], "topic", themeConfig);
   }
   if (routerQuery[QUERY_PARAMS.sector]) {
-    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.sector], "sector", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.sector], "sector", themeConfig);
   }
   // ---- End of Laws and Policies specific ----
 
@@ -166,18 +166,18 @@ export default function buildSearchQuery(
   }
 
   if (routerQuery[QUERY_PARAMS.status]) {
-    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.status], "status", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.status], "status", themeConfig);
   }
 
   if (routerQuery[QUERY_PARAMS.implementing_agency]) {
-    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.implementing_agency], "implementing_agency", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.implementing_agency], "implementing_agency", themeConfig);
   }
   // ---- End of MCF specific ----
 
   // ---- Reports specific ----
   // These are the filters that are specific to the Reports corpus type
   if (routerQuery[QUERY_PARAMS.author_type]) {
-    buildSearchQueryMetadata(query, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig);
   }
 
   query = {

--- a/src/utils/buildSearchQueryMetadata.test.ts
+++ b/src/utils/buildSearchQueryMetadata.test.ts
@@ -1,0 +1,70 @@
+import { TThemeConfig } from "@types";
+import { buildSearchQueryMetadata } from "./buildSearchQueryMetadata";
+
+const testThemeConfig: TThemeConfig = {
+  filters: [
+    {
+      label: "Status",
+      taxonomyKey: "status",
+      apiMetaDataKey: "family.status",
+      type: "radio",
+      category: ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000", "MCF.corpus.CIF.n0000"],
+      dependentFilterKey: "fund",
+    },
+  ],
+  labelVariations: [],
+  links: [],
+  documentCategories: [],
+  metadata: [],
+};
+
+describe("buildSearchQueryMetadata: ", () => {
+  it("should return an array of a single value if the metadata is previously empty", () => {
+    const metadata = "Test Status";
+
+    const searchQueryMetadata = buildSearchQueryMetadata([], metadata, "status", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([{ name: "family.status", value: "Test Status" }]);
+  });
+
+  it("should return an array of two values if we provide 2 and the metadata is previously empty", () => {
+    const metadata = ["Test Status 1", "Test Status 2"];
+
+    const searchQueryMetadata = buildSearchQueryMetadata([], metadata, "status", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([
+      { name: "family.status", value: "Test Status 1" },
+      { name: "family.status", value: "Test Status 2" },
+    ]);
+  });
+
+  it("should return the new value if we provide one value and the metadata previously contains a different value", () => {
+    const metadata = "Test Status";
+
+    const searchQueryMetadata = buildSearchQueryMetadata([{ name: "family.status", value: "Existing Status" }], metadata, "status", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([{ name: "family.status", value: "Test Status" }]);
+  });
+
+  it("should not add the new value, if the options is not present in our config", () => {
+    const metadata = "Test Status";
+
+    const searchQueryMetadata = buildSearchQueryMetadata([], metadata, "valueNotPresent", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([]);
+  });
+
+  it("should return empty if we provide nothing", () => {
+    const searchQueryMetadata = buildSearchQueryMetadata([], "", "status", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([]);
+  });
+
+  it("should return empty if we provide an empty string", () => {
+    const metadata = "";
+
+    const searchQueryMetadata = buildSearchQueryMetadata([], metadata, "status", testThemeConfig);
+
+    expect(searchQueryMetadata).toEqual([]);
+  });
+});

--- a/src/utils/buildSearchQueryMetadata.ts
+++ b/src/utils/buildSearchQueryMetadata.ts
@@ -1,0 +1,24 @@
+import { TSearchCriteria, TThemeConfig } from "@types";
+
+export const buildSearchQueryMetadata = (
+  query: TSearchCriteria,
+  metadataValue: string | string[],
+  taxonomyKey: string,
+  themeConfig: TThemeConfig
+) => {
+  let metadataForApi: string[];
+  const configMetadata = themeConfig.filters.find((f) => f.taxonomyKey === taxonomyKey);
+  if (configMetadata) {
+    // remove existing metadata filters from the metadata
+    query.metadata = query.metadata.filter((m) => m.name !== configMetadata.apiMetaDataKey);
+    if (Array.isArray(metadataValue)) {
+      metadataForApi = metadataValue;
+    } else {
+      metadataForApi = [metadataValue];
+    }
+    metadataForApi.map((m) => {
+      query.metadata.push({ name: configMetadata.apiMetaDataKey, value: decodeURI(m) });
+    });
+  }
+  return null;
+};

--- a/src/utils/buildSearchQueryMetadata.ts
+++ b/src/utils/buildSearchQueryMetadata.ts
@@ -1,24 +1,27 @@
-import { TSearchCriteria, TThemeConfig } from "@types";
+import { TSearchCriteriaMeta, TThemeConfig } from "@types";
 
 export const buildSearchQueryMetadata = (
-  query: TSearchCriteria,
+  metadata: TSearchCriteriaMeta[],
   metadataValue: string | string[],
   taxonomyKey: string,
   themeConfig: TThemeConfig
 ) => {
   let metadataForApi: string[];
+  let newMetadata: TSearchCriteriaMeta[] = [...metadata];
   const configMetadata = themeConfig.filters.find((f) => f.taxonomyKey === taxonomyKey);
   if (configMetadata) {
     // remove existing metadata filters from the metadata
-    query.metadata = query.metadata.filter((m) => m.name !== configMetadata.apiMetaDataKey);
+    newMetadata = newMetadata.filter((m) => m.name !== configMetadata.apiMetaDataKey);
     if (Array.isArray(metadataValue)) {
       metadataForApi = metadataValue;
     } else {
       metadataForApi = [metadataValue];
     }
     metadataForApi.map((m) => {
-      query.metadata.push({ name: configMetadata.apiMetaDataKey, value: decodeURI(m) });
+      if (decodeURI(m).trim().length > 0) {
+        newMetadata.push({ name: configMetadata.apiMetaDataKey, value: decodeURI(m) });
+      }
     });
   }
-  return null;
+  return newMetadata;
 };

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -40,16 +40,7 @@
       {
         "label": "Multilateral Climate Funds",
         "slug": "multilateral-climate-funds",
-        "value": [
-          "MCF.corpus.GCF.n0000",
-          "MCF.corpus.GEF.n0000",
-          "MCF.corpus.AF.n0000",
-          "MCF.corpus.CIF.n0000",
-          "MCF.corpus.AF.Guidance",
-          "MCF.corpus.CIF.Guidance",
-          "MCF.corpus.GEF.Guidance",
-          "MCF.corpus.GCF.Guidance"
-        ]
+        "value": ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000", "MCF.corpus.CIF.n0000"]
       },
       {
         "label": "Reports",
@@ -156,6 +147,20 @@
       "showFade": "true",
       "corporaKey": "Laws and Policies",
       "quickSearch": "true"
+    },
+    {
+      "label": "Author Type",
+      "taxonomyKey": "author_type",
+      "apiMetaDataKey": "family.author_type",
+      "type": "radio",
+      "category": [
+        "OEP.corpus.i00000001.n0000",
+        "MCF.corpus.AF.Guidance",
+        "MCF.corpus.CIF.Guidance",
+        "MCF.corpus.GEF.Guidance",
+        "MCF.corpus.GCF.Guidance"
+      ],
+      "corporaKey": "Reports"
     }
   ],
   "labelVariations": [

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -52,6 +52,17 @@
         ]
       },
       {
+        "label": "Reports",
+        "slug": "Reports",
+        "value": [
+          "OEP.corpus.i00000001.n0000",
+          "MCF.corpus.AF.Guidance",
+          "MCF.corpus.CIF.Guidance",
+          "MCF.corpus.GEF.Guidance",
+          "MCF.corpus.GCF.Guidance"
+        ]
+      },
+      {
         "label": "Litigation",
         "slug": "Litigation",
         "category": ["Litigation"]


### PR DESCRIPTION
# What's changed
- Adding "Reports" category
- Adding sub filter for "Author Type"
- Fixing issues with selected state on filters that were not selected but the names were similar

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
