### PR TITLE
Feature flags powered by cachable cookies

### DIFF
--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,8 +1,11 @@
-"use client";
+import Button from "@components/buttons/Button";
+import { deleteCookie, setCookie } from "@utils/cookies";
+import getDomain from "@utils/getDomain";
 import { usePostHog } from "posthog-js/react";
 
-function FeatureFlags() {
+export default function FeatureFlags() {
   const posthog = usePostHog();
+
   /**
    * This key is a public key.
    * @see: https://posthog.com/docs/privacy#is-it-ok-for-my-api-key-to-be-exposed-and-public
@@ -13,10 +16,25 @@ function FeatureFlags() {
   });
 
   return (
-    <div>
-      <button id="beta-button">Public Betas</button>
+    <div className="h-screen flex items-center justify-center">
+      <Button id="beta-button">Feature Flags</Button>
+      <Button
+        onClick={() => {
+          posthog.getEarlyAccessFeatures((featureFlags) => {
+            featureFlags.map((featureFlag) => {
+              const { flagKey } = featureFlag;
+              const enabled = posthog.isFeatureEnabled(flagKey);
+              if (enabled) {
+                setCookie(`feature_flag_${flagKey}`, "true", getDomain());
+              } else {
+                deleteCookie(`feature_flag_${flagKey}`, getDomain());
+              }
+            });
+          });
+        }}
+      >
+        Save
+      </Button>
     </div>
   );
 }
-
-export default FeatureFlags;

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,6 +1,5 @@
 import Button from "@components/buttons/Button";
-import { deleteCookie, setCookie } from "@utils/cookies";
-import getDomain from "@utils/getDomain";
+import { deleteFeatureFlagCookie, enableFeatureFlagCookie } from "@utils/featureFlags";
 import { usePostHog } from "posthog-js/react";
 
 export default function FeatureFlags() {
@@ -24,10 +23,11 @@ export default function FeatureFlags() {
             featureFlags.map((featureFlag) => {
               const { flagKey } = featureFlag;
               const enabled = posthog.isFeatureEnabled(flagKey);
+
               if (enabled) {
-                setCookie(`feature_flag_${flagKey}`, "true", getDomain());
+                enableFeatureFlagCookie(flagKey);
               } else {
-                deleteCookie(`feature_flag_${flagKey}`, getDomain());
+                deleteFeatureFlagCookie(flagKey);
               }
             });
           });

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,5 +1,5 @@
 import Button from "@components/buttons/Button";
-import { deleteFeatureFlagCookie, enableFeatureFlagCookie } from "@utils/featureFlags";
+import { setFeatureFlags } from "@utils/featureFlags";
 import { usePostHog } from "posthog-js/react";
 
 export default function FeatureFlags() {
@@ -19,17 +19,17 @@ export default function FeatureFlags() {
       <Button id="beta-button">Feature Flags</Button>
       <Button
         onClick={() => {
-          posthog.getEarlyAccessFeatures((featureFlags) => {
-            featureFlags.map((featureFlag) => {
-              const { flagKey } = featureFlag;
+          posthog.getEarlyAccessFeatures((posthogFeatureFlags) => {
+            const featureFlags = {};
+            posthogFeatureFlags.map((posthogFeatureFlag) => {
+              const { flagKey } = posthogFeatureFlag;
               const enabled = posthog.isFeatureEnabled(flagKey);
 
               if (enabled) {
-                enableFeatureFlagCookie(flagKey);
-              } else {
-                deleteFeatureFlagCookie(flagKey);
+                featureFlags[flagKey] = true;
               }
             });
+            setFeatureFlags(featureFlags);
           });
         }}
       >

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -22,10 +22,7 @@ export function setCookie(cname: string, cvalue: string, domain: string) {
 }
 
 export function deleteCookie(cname: string, domain: string) {
-  let ca = document.cookie.split(";");
-  if (!!cname && ca.includes(cname)) {
-    document.cookie = `${cname}=; domain=${domain}; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
-  }
+  document.cookie = `${cname}=; domain=${domain}; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 }
 
 export function deleteCookies() {

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,11 +1,8 @@
 import { deleteCookie, setCookie } from "./cookies";
 import getDomain from "./getDomain";
 
-export function enableFeatureFlagCookie(flagKey: string) {
-  setCookie(`feature_flag_${flagKey}`, "true", getDomain());
-}
-export function deleteFeatureFlagCookie(flagKey: string) {
-  deleteCookie(`feature_flag_${flagKey}`, getDomain());
+export function setFeatureFlags(featureFlags: Partial<{ [key: string]: true }>) {
+  setCookie(`feature_flags`, JSON.stringify(featureFlags), getDomain());
 }
 
 export async function getFeatureFlags(
@@ -14,15 +11,15 @@ export async function getFeatureFlags(
     [key: string]: string | string[];
   }>
 ) {
-  const flags: Partial<{ [key: string]: true }> = {};
-
-  Object.entries(cookies).map(([key, value]) => {
-    if (key.startsWith("feature_flag_")) {
-      const flagKey = key.replace("feature_flag_", "");
-      if (value === "true") {
-        flags[flagKey] = true;
-      }
+  let featureFlags: Partial<{ [key: string]: true }> = {};
+  if (cookies.feature_flags) {
+    try {
+      const featureFlagsCookie = Array.isArray(cookies.feature_flags) ? cookies.feature_flags[0] : cookies.feature_flags;
+      featureFlags = JSON.parse(featureFlagsCookie);
+    } catch (e) {
+      /** it would be nice to alert to a beacon service, but we have none 😢 */
     }
-  });
-  return flags;
+  }
+
+  return featureFlags;
 }

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -2,7 +2,12 @@ import { deleteCookie, setCookie } from "./cookies";
 import getDomain from "./getDomain";
 
 export function setFeatureFlags(featureFlags: Partial<{ [key: string]: true }>) {
-  setCookie(`feature_flags`, JSON.stringify(featureFlags), getDomain());
+  if (Object.keys(featureFlags).length === 0) {
+    deleteCookie(`feature_flags`, getDomain());
+    return;
+  } else {
+    setCookie(`feature_flags`, JSON.stringify(featureFlags), getDomain());
+  }
 }
 
 export async function getFeatureFlags(


### PR DESCRIPTION
# What's changed

- Uses Posthog's [Early access app](https://posthog.com/docs/feature-flags/early-access-feature-management) to allow a user to opt-into feature flags
- Sets those values on a CPR specific cookie

In combo with https://github.com/climatepolicyradar/navigator-infra/pull/967

![Screenshot 2025-01-22 at 20 58 01](https://github.com/user-attachments/assets/27a46926-8426-4bf7-b4b2-c2ad21293204)


## Proposed version

- [x] Patch

Part of https://linear.app/climate-policy-radar/issue/APP-170/enable-feature-switches-to-show-the-most-basic-version-of-concept