### PR TITLE
APP-173: Make Jotform link for whole database download specific to custom app

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -157,7 +157,7 @@
   "links": [
     {
       "key": "download-database",
-      "url": "https://form.jotform.com/233131638610347"
+      "url": "https://form.jotform.com/250202141318339"
     }
   ],
   "metadata": [


### PR DESCRIPTION
# What's changed

- Corrected the `config.json` download database URL (Jotform) link for the CPR theme - it was incorrectly the CCLW one instead.
  - Manually tested that all 3 links are correct for their respective themes.

## Proposed version

- [x] Patch

Fixes [APP-173](https://linear.app/climate-policy-radar/issue/APP-173/make-jotform-link-for-whole-database-download-specific-to-custom-app)