### PR TITLE
Add concepts to family page behind feature flag

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -373,11 +373,13 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
               <section className="mt-8">
                 <Heading level={4}>Concepts</Heading>
                 <div className="flex text-sm">
-                  <ul>
+                  <ul className="flex flex-wrap gap-2">
                     {concepts.map((concept, i) => {
                       return (
                         <li key={i}>
-                          <LinkWithQuery href={`/concepts/${concept.wikibase_id}`}>{concept.preferred_label}</LinkWithQuery>
+                          <LinkWithQuery className="capitalize" href={`/concepts/${concept.wikibase_id}`}>
+                            <Button>{concept.preferred_label}</Button>
+                          </LinkWithQuery>
                         </li>
                       );
                     })}

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -184,15 +184,17 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   const [concepts, setConcepts] = useState<TConcept[]>([]);
 
   useEffect(() => {
-    // [conceptId, count]
-    const conceptsData: [string, number][] = vespaFamilyData
+    const conceptsData: { conceptId: string; count: number }[] = vespaFamilyData
       ? vespaFamilyData.families.flatMap((family) => {
           return family.hits.flatMap((hit) => {
-            return Object.entries(hit.concept_counts);
+            return Object.entries(hit.concept_counts).map(([conceptId, count]) => ({
+              conceptId,
+              count,
+            }));
           });
         })
       : [];
-    const conceptsS3Promises = conceptsData.map(([conceptId, count]) => {
+    const conceptsS3Promises = conceptsData.map(({ conceptId, count }) => {
       const url = `https://cdn.dev.climatepolicyradar.org/concepts/${conceptId}.json`;
       return fetch(url).then((response) => response.json());
     });

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -181,7 +181,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
    *
    * Not ideal, but we are working on getting more useful data on the family response.
    */
-  const [concepts, setConcepts] = useState<TConcept[]>([]);
+  const [concepts, setConcepts] = useState<(TConcept & { count: number })[]>([]);
 
   useEffect(() => {
     const conceptsData: { conceptId: string; count: number }[] = vespaFamilyData
@@ -199,7 +199,8 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
       return fetch(url).then((response) => response.json());
     });
     Promise.all(conceptsS3Promises).then((conceptsS3Data) => {
-      setConcepts(conceptsS3Data);
+      const conceptsWithCounts = conceptsS3Data.map((concept, i) => ({ ...concept, count: conceptsData[i].count }));
+      setConcepts(conceptsWithCounts);
     });
   }, [vespaFamilyData]);
 
@@ -380,7 +381,9 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                       return (
                         <li key={i}>
                           <LinkWithQuery className="capitalize" href={`/concepts/${concept.wikibase_id}`}>
-                            <Button>{concept.preferred_label}</Button>
+                            <Button color="clear" data-cy="view-source" extraClasses="flex items-center text-sm">
+                              {concept.preferred_label} ({concept.count})
+                            </Button>
                           </LinkWithQuery>
                         </li>
                       );

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -415,7 +415,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
       // fetch the families
-      const { vespaFamilyData: returnedData } = await client.get(`/families/${familyData.import_id}`);
+      const { data: vespaFamilyDataRepsonse } = await client.get(`/families/${familyData.import_id}`);
+      vespaFamilyData = vespaFamilyDataRepsonse;
     }
   } catch (error) {
     // TODO: handle error more elegantly

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -312,6 +312,14 @@ export type TCorpusTypeDictionary = TDictionary<TCorpusType>;
 export type TConcept = {
   preferred_label: string;
   wikibase_id: string;
+  alternative_labels: string[];
+  negative_labels: string[];
+  description: string;
+  subconcept_of: string[];
+  has_subconcept: string[];
+  related_concepts: string[];
+  definition?: string;
+  labelled_passages?: [];
 };
 
 export type TSearchResponse = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -310,14 +310,8 @@ export type TOrganisationDictionary = TDictionary<TOrganisation>;
 export type TCorpusTypeDictionary = TDictionary<TCorpusType>;
 
 export type TConcept = {
-  id: string;
-  name: string;
-  parent_concepts: Record<string, string>[];
-  parent_concept_ids_flat: string;
-  model: string;
-  end: number;
-  start: number;
-  timestamp: string;
+  preferred_label: string;
+  wikibase_id: string;
 };
 
 export type TSearchResponse = {
@@ -328,9 +322,9 @@ export type TSearchResponse = {
   families: {
     id: string;
     hits: (TFamily & {
-      concepts: TConcept[];
+      concept_counts: Record<string, number>;
     })[];
-  };
+  }[];
   continuation_token?: string;
   this_continuation_token: string;
   prev_continuation_token: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -309,7 +309,7 @@ export interface TDictionary<T> {
 export type TOrganisationDictionary = TDictionary<TOrganisation>;
 export type TCorpusTypeDictionary = TDictionary<TCorpusType>;
 
-export type Concept = {
+export type TConcept = {
   id: string;
   name: string;
   parent_concepts: Record<string, string>[];
@@ -328,7 +328,7 @@ export type TSearchResponse = {
   families: {
     id: string;
     hits: (TFamily & {
-      concepts: Concept[];
+      concepts: TConcept[];
     })[];
   };
   continuation_token?: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -308,3 +308,30 @@ export interface TDictionary<T> {
 
 export type TOrganisationDictionary = TDictionary<TOrganisation>;
 export type TCorpusTypeDictionary = TDictionary<TCorpusType>;
+
+export type Concept = {
+  id: string;
+  name: string;
+  parent_concepts: Record<string, string>[];
+  parent_concept_ids_flat: string;
+  model: string;
+  end: number;
+  start: number;
+  timestamp: string;
+};
+
+export type TSearchResponse = {
+  total_hits: number;
+  total_family_hits: number;
+  query_time_ms?: number;
+  total_time_ms?: number;
+  families: {
+    id: string;
+    hits: (TFamily & {
+      concepts: Concept[];
+    })[];
+  };
+  continuation_token?: string;
+  this_continuation_token: string;
+  prev_continuation_token: string;
+};


### PR DESCRIPTION
# What's changed

- if in concepts-v1 feature flag
- reads the endpoint [created here](https://github.com/climatepolicyradar/navigator-backend/pull/447)
- **[CLUDGE]:** as we are waiting for concepts to be added onto the family response, we just stick a hardcoded value in there for now
- **[CLUDGE]:** fetches full-data from S3 bucket for concepts
- renders a boring list of concepts on the page
- adds new `SearchResponse` type that is a replica of https://github.com/climatepolicyradar/cpr-sdk/blob/ef591a155b63de8680be91bfe4180bdace9c8692/src/cpr_sdk/models/search.py#L609

## Proposed version

- [x] Patch


## 👀 

<img width="897" alt="Screenshot 2025-01-27 at 16 18 30" src="https://github.com/user-attachments/assets/c81d77de-0b3d-4805-9556-3b37ea69a742" />

---

The design was lifted from the only place I could see where we had a label and count
e.g.
<img width="1426" alt="Screenshot 2025-01-27 at 16 23 23" src="https://github.com/user-attachments/assets/51abcdbb-e48a-41a3-9c6c-c2f295437bab" />


Part of https://linear.app/climate-policy-radar/issue/APP-170/enable-feature-switches-to-show-the-most-basic-version-of-concept
