### PR TITLE
Remove guidance corpora IDs from 'Reports' category

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -45,13 +45,7 @@
       {
         "label": "Reports",
         "slug": "Reports",
-        "value": [
-          "OEP.corpus.i00000001.n0000",
-          "MCF.corpus.AF.Guidance",
-          "MCF.corpus.CIF.Guidance",
-          "MCF.corpus.GEF.Guidance",
-          "MCF.corpus.GCF.Guidance"
-        ]
+        "value": ["OEP.corpus.i00000001.n0000"]
       },
       {
         "label": "Litigation",
@@ -153,13 +147,7 @@
       "taxonomyKey": "author_type",
       "apiMetaDataKey": "family.author_type",
       "type": "radio",
-      "category": [
-        "OEP.corpus.i00000001.n0000",
-        "MCF.corpus.AF.Guidance",
-        "MCF.corpus.CIF.Guidance",
-        "MCF.corpus.GEF.Guidance",
-        "MCF.corpus.GCF.Guidance"
-      ],
+      "category": ["OEP.corpus.i00000001.n0000"],
       "corporaKey": "Reports"
     }
   ],


### PR DESCRIPTION
# What's changed
- Removes the MCF Guidance corpus IDs from the config for 'Reports' category

We added this initially to test we could see new reports, but going forward this isn't where we will display them.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
