### PR TITLE
Render concepts on document page

### DIFF
--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -6,7 +6,8 @@ import { CountryLinksAsList } from "@components/CountryLinks";
 import { mapFamilyMetadata } from "@helpers/mapFamilyMetadata";
 import { getIcon } from "@helpers/getMetadataIcon";
 
-import { TFamilyMetadata, TMCFFamilyMetadata } from "@types";
+import { TConcept, TFamilyMetadata, TMCFFamilyMetadata } from "@types";
+import { LinkWithQuery } from "@components/LinkWithQuery";
 
 interface MetadataItemProps {
   label: string;
@@ -18,6 +19,7 @@ type TFamilyMetadataUnion = TFamilyMetadata | TMCFFamilyMetadata;
 
 interface McfFamilyMetaProps {
   metadata: TFamilyMetadataUnion;
+  concepts?: (TConcept & { count: number })[];
 }
 
 interface ListOfCountriesProps {
@@ -111,7 +113,7 @@ const MetadataItem = ({ label, icon, values }: MetadataItemProps) => {
   );
 };
 
-export const McfFamilyMeta = ({ metadata }: McfFamilyMetaProps) => {
+export const McfFamilyMeta = ({ metadata, concepts }: McfFamilyMetaProps) => {
   const mappedMetadata = mapFamilyMetadata(metadata);
 
   return (
@@ -121,6 +123,25 @@ export const McfFamilyMeta = ({ metadata }: McfFamilyMetaProps) => {
           <MetadataItem key={index} label={item.label} icon={item.iconLabel} values={item.value} />
         </div>
       ))}
+      {concepts && concepts.length > 0 && (
+        <>
+          <div className="flex items-center row">
+            <span className="pl-1">
+              <span className="text-sm font-bold">
+                <strong>Concepts</strong>
+              </span>
+            </span>
+            {concepts.map((concept, index) => (
+              <span key={concept.wikibase_id} className="flex items-center">
+                <LinkWithQuery className="pl-1 text-sm" href={`/concepts/${concept.wikibase_id}`}>
+                  {concept.preferred_label}
+                </LinkWithQuery>
+                {index < concepts.length - 1 && ", "}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -133,7 +133,7 @@ export const McfFamilyMeta = ({ metadata, concepts }: McfFamilyMetaProps) => {
             </span>
             {concepts.map((concept, index) => (
               <span key={concept.wikibase_id} className="flex items-center">
-                <LinkWithQuery className="pl-1 text-sm" href={`/concepts/${concept.wikibase_id}`}>
+                <LinkWithQuery className="capitalize pl-1 text-sm" href={`/concepts/${concept.wikibase_id}`}>
                   {concept.preferred_label}
                 </LinkWithQuery>
                 {index < concepts.length - 1 && ", "}

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -12,27 +12,30 @@ import { AlertCircleIcon } from "@components/svg/Icons";
 import { Alert } from "@components/Alert";
 import { ExternalLink } from "@components/ExternalLink";
 import { Heading } from "@components/typography/Heading";
+import { LinkWithQuery } from "@components/LinkWithQuery";
 
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { truncateString } from "@utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@constants/document";
 
-import { TDocumentPage, TFamilyPage } from "@types";
+import { TDocumentPage, TFamilyPage, TConcept, TSearchResponse } from "@types";
 import { DocumentMetaRenderer } from "./renderers/DocumentMetaRenderer";
+import { getFeatureFlags } from "@utils/featureFlags";
 
 type TProps = {
   document: TDocumentPage;
   family: TFamilyPage;
   handleViewOtherDocsClick: (e: React.FormEvent<HTMLButtonElement>) => void;
   handleViewSourceClick: (e: React.FormEvent<HTMLButtonElement>) => void;
+  concepts?: (TConcept & { count: number })[];
 };
 
 const containsNonEnglish = (languages: string[]) => {
   return languages.some((lang) => lang !== "eng");
 };
 
-export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handleViewSourceClick }: TProps) => {
+export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handleViewSourceClick, concepts }: TProps) => {
   const [showFullSummary, setShowFullSummary] = useState(false);
   const [summary, setSummary] = useState("");
 
@@ -74,7 +77,8 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
         <div className="flex flex-col justify-between md:flex-row flex-wrap">
           <div className="flex-1 my-4">
             <Heading level={1}>{document.title}</Heading>
-            <DocumentMetaRenderer family={family} isMain={isMain} document={document} />
+            <DocumentMetaRenderer family={family} isMain={isMain} document={document} concepts={concepts} />
+
             <div className="text-content" dangerouslySetInnerHTML={{ __html: summary }} />
             {family.summary.length > MAX_FAMILY_SUMMARY_LENGTH_BRIEF && (
               <div className="mt-4">

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -28,7 +28,7 @@ type TProps = {
   family: TFamilyPage;
   handleViewOtherDocsClick: (e: React.FormEvent<HTMLButtonElement>) => void;
   handleViewSourceClick: (e: React.FormEvent<HTMLButtonElement>) => void;
-  concepts?: (TConcept & { count: number })[];
+  concepts: (TConcept & { count: number })[];
 };
 
 const containsNonEnglish = (languages: string[]) => {

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -2,10 +2,24 @@ import useConfig from "@hooks/useConfig";
 
 import { getLanguage } from "@helpers/getLanguage";
 import { CountryLinks } from "@components/CountryLinks";
+import { TConcept } from "@types";
+import { LinkWithQuery } from "@components/LinkWithQuery";
+import { getIcon } from "@helpers/getMetadataIcon";
 
-export const DocumentMeta = ({ family, isMain, document }) => {
+export const DocumentMeta = ({
+  family,
+  isMain,
+  document,
+  concepts,
+}: {
+  family: any;
+  isMain: boolean;
+  document: any;
+  concepts?: (TConcept & { count: number })[];
+}) => {
   const configQuery = useConfig();
   const { data: { countries = [], languages = {} } = {} } = configQuery;
+
   return (
     <div className="py-4 my-4 md:my-2 md:flex justify-between items-center">
       <div className="flex text-sm items-center gap-2 middot-between flex-wrap">
@@ -17,6 +31,21 @@ export const DocumentMeta = ({ family, isMain, document }) => {
             {getLanguage(document.language, languages)}
             {!!document.variant && ` (${document.variant})`}
           </span>
+        )}
+        {concepts && concepts.length > 0 && (
+          <div className="flex items-center">
+            <span className="mr-1">
+              <strong>Concepts</strong>
+            </span>
+            {concepts.map((concept, index) => (
+              <span key={concept.wikibase_id} className="flex items-center">
+                <LinkWithQuery className="capitalize text-blue-600 hover:underline" href={`/concepts/${concept.wikibase_id}`}>
+                  {concept.preferred_label}
+                </LinkWithQuery>
+                {index < concepts.length - 1 && ", "}
+              </span>
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/src/components/documents/renderers/DocumentMetaRenderer.tsx
+++ b/src/components/documents/renderers/DocumentMetaRenderer.tsx
@@ -1,10 +1,21 @@
 import { McfFamilyMeta } from "@components/document/McfFamilyMeta";
 import { DocumentMeta } from "../DocumentMeta";
 import { getApprovedYearFromEvents } from "@helpers/getApprovedYearFromEvents";
+import { TConcept } from "@types";
 
 const MULTILATERALCLIMATEFUNDSCATEGORY = "MCF";
 
-export const DocumentMetaRenderer = ({ family, isMain, document }) => {
+export const DocumentMetaRenderer = ({
+  family,
+  isMain,
+  document,
+  concepts,
+}: {
+  family: any;
+  isMain: boolean;
+  document: any;
+  concepts?: (TConcept & { count: number })[];
+}) => {
   const { metadata, organisation, category, geographies } = family || {};
 
   const mcfFamilyMetadata = {
@@ -16,8 +27,8 @@ export const DocumentMetaRenderer = ({ family, isMain, document }) => {
   };
 
   if (category !== MULTILATERALCLIMATEFUNDSCATEGORY) {
-    return <DocumentMeta family={family} isMain={isMain} document={document} />;
+    return <DocumentMeta family={family} isMain={isMain} document={document} concepts={concepts} />;
   }
 
-  return <McfFamilyMeta metadata={mcfFamilyMetadata} />;
+  return <McfFamilyMeta metadata={mcfFamilyMetadata} concepts={concepts} />;
 };


### PR DESCRIPTION
# What's changed

Render concepts on the documents page.

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/ecc9f51f-2149-4c04-915f-48e75dfbc0c4" />

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/94bf8acd-441b-4005-9c9d-1b5027ca4727" />

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
