### PR TITLE
feat: add reports tab to geographies page

### DIFF
--- a/src/helpers/getCategoryTooltip.ts
+++ b/src/helpers/getCategoryTooltip.ts
@@ -14,6 +14,8 @@ export const getCategoryTooltip = (category: TDocumentCategory): string => {
       return "Documents submitted to the UNFCCC (including NDCs)";
     case "MCF":
       return "Multilateral climate fund projects and policies";
+    case "Reports":
+      return "For example: Documents from national bodies, corporations, NGOs, and academia";
     default:
       return "";
   }

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -53,6 +53,7 @@ const categoryByIndex = {
   3: "UNFCCC",
   4: "laws",
   5: "multilateral-climate-funds",
+  6: "reports",
 };
 
 const MAX_NUMBER_OF_FAMILIES = 3;
@@ -92,6 +93,9 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
         break;
       case "MCF":
         count = summary.family_counts.MCF;
+        break;
+      case "Reports":
+        count = summary.family_counts.Reports;
         break;
     }
 
@@ -201,6 +205,16 @@ const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ g
       return summary.top_families.MCF.length === 0
         ? renderEmpty("multilateral climate funds")
         : summary.top_families.MCF.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
+            <div key={family.family_slug} className="mb-10">
+              <FamilyListItem family={family} />
+            </div>
+          ));
+    }
+    // Reports
+    if (selectedCategoryIndex === 6) {
+      return summary.top_families.Reports.length === 0
+        ? renderEmpty("reports")
+        : summary.top_families.Reports.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
             <div key={family.family_slug} className="mb-10">
               <FamilyListItem family={family} />
             </div>

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -1,4 +1,4 @@
-export type TDocumentCategory = "All" | "Laws" | "Policies" | "UNFCCC" | "Litigation" | "MCF";
+export type TDocumentCategory = "All" | "Laws" | "Policies" | "UNFCCC" | "Litigation" | "MCF" | "Reports";
 
 export type TLabelVariation = {
   category: string[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -93,6 +93,7 @@ type TGeoFamilyCounts = {
   Executive: number;
   UNFCCC: number;
   MCF: number;
+  Reports: number;
 };
 
 type TGeoFamilys = {
@@ -100,6 +101,7 @@ type TGeoFamilys = {
   Executive: TFamily[];
   UNFCCC: TFamily[];
   MCF: TFamily[];
+  Reports: TFamily[];
 };
 
 export type TGeographySummary = {

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -181,5 +181,5 @@
       "description": "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country."
     }
   ],
-  "documentCategories": ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF"]
+  "documentCategories": ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"]
 }


### PR DESCRIPTION
# What's changed
- adds reports tab to geographies page

You can test this on [Brazil (staging)](https://app.dev.climatepolicyradar.org/geographies/brazil) where you should see 1 report. 

## screenshots
![Screenshot 2025-01-30 at 15 25 03](https://github.com/user-attachments/assets/d28478d3-def7-4435-a87e-9381de80b2a8)


## Proposed version

- [x] Patch
