### PR TITLE
fix: use lowercase reports for Reports filter

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -44,7 +44,7 @@
       },
       {
         "label": "Reports",
-        "slug": "Reports",
+        "slug": "reports",
         "value": ["OEP.corpus.i00000001.n0000"]
       },
       {


### PR DESCRIPTION
# What's changed
As the querystring param `c` is autocreated on the tab to `c=reports` we then need to ensure that the slug in the config is case-matching.

`c=reports` is then transformed into the search query `corpus_import_ids: "OEP.corpus.i00000001.n0000"]`.


`/search?l=brazil&c=reports`
| before (unfiltered) | after (filtered) |
|---|---|
| ![Screenshot 2025-01-30 at 16 17 46](https://github.com/user-attachments/assets/161b1541-af2d-409b-8ae1-7c548e954d73) | ![Screenshot 2025-01-30 at 16 18 06](https://github.com/user-attachments/assets/2a1cc700-a58f-4734-81d8-1746e46782e1) |



## Proposed version

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version
