### PR TITLE
concept_filters search

### DIFF
--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -23,4 +23,7 @@ export const QUERY_PARAMS: TQueryStrings = {
   sector: "sc",
   // Reports
   author_type: "at",
+  // Passthrough
+  "concept_filters.id": "concept_filters.id",
+  "concept_filters.name": "concept_filters.name",
 };

--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -15,4 +15,5 @@ export const initialSearchCriteria: TSearchCriteria = {
   offset: 0,
   corpus_import_ids: [],
   metadata: [],
+  concept_filters: [],
 };

--- a/src/types/queryStrings.ts
+++ b/src/types/queryStrings.ts
@@ -21,4 +21,7 @@ export type TQueryStrings = {
   sector: string;
   // Reports
   author_type: string;
+  // passthrough
+  "concept_filters.id": string;
+  "concept_filters.name": string;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -27,6 +27,7 @@ export type TSearchCriteria = {
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
   metadata: TSearchCriteriaMeta[];
+  concept_filters: { name: string }[];
   // for internal use
   runSearch?: boolean;
 };

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -52,6 +52,25 @@ export default function buildSearchQuery(
     }
   }
 
+  if (routerQuery[QUERY_PARAMS["concept_filters.id"]]) {
+    const conceptFilters = routerQuery[QUERY_PARAMS["concept_filters.id"]];
+    query.concept_filters = Array.isArray(conceptFilters)
+      ? conceptFilters.map((id) => ({
+          name: "id",
+          value: id,
+        }))
+      : [{ name: "id", value: conceptFilters }];
+  }
+  if (routerQuery[QUERY_PARAMS["concept_filters.name"]]) {
+    const conceptFilters = routerQuery[QUERY_PARAMS["concept_filters.name"]];
+    query.concept_filters = Array.isArray(conceptFilters)
+      ? conceptFilters.map((name) => ({
+          name: "name",
+          value: name,
+        }))
+      : [{ name: "name", value: conceptFilters }];
+  }
+
   if (routerQuery[QUERY_PARAMS.category]) {
     const qCategory = routerQuery[QUERY_PARAMS.category] as string;
     let category: string[];
@@ -184,5 +203,6 @@ export default function buildSearchQuery(
     ...query,
     keyword_filters,
   };
+
   return query;
 }


### PR DESCRIPTION
# What's changed

Based on [the documentation of the CPR SDK](https://github.com/climatepolicyradar/cpr-sdk/blob/main/README.md#filtering-for-concept-counts) - we should be able to send over `concept_filters` in the shape of ```{ name: "id", value: `${conceptId}` }```.

As
- the shape expected by `navigator-backend` ([`SearchResponseBody`](https://github.com/climatepolicyradar/navigator-backend/blob/main/app/models/search.py#L54)) - is actually just a subtype of the [SDK's `SearchParameters`](https://github.com/climatepolicyradar/cpr-sdk/blob/bdb3bfdc213923e6a580da1dd91fcc626f636cbb/src/cpr_sdk/models/search.py#L194)
- [and this is parsed at the route level](https://github.com/climatepolicyradar/navigator-backend/blob/main/app/api/api_v1/routers/search.py#L47)
- **We don't need to do any work on the `navigator-backend`**

## Screenshots

### Document page
![Screenshot 2025-02-03 at 16 20 40](https://github.com/user-attachments/assets/85d935e9-9c6e-4c25-bfa6-7f45fd558437)


## Semver
- [x] Patch