### PR TITLE
Feature/app 197 group concepts at family level by root concepts

### DIFF
--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -51,7 +51,10 @@ export const DocumentMeta = ({
             </span>
             {concepts.map((concept, index) => (
               <span key={concept.wikibase_id} className="flex items-center">
-                <LinkWithQuery className="capitalize text-blue-600 hover:underline" href={`/concepts/${concept.wikibase_id}`}>
+                <LinkWithQuery
+                  className="capitalize text-blue-600 hover:underline"
+                  href={`https://climatepolicyradar.wikibase.cloud/wiki/Item:${concept.wikibase_id}`}
+                >
                   {concept.preferred_label}
                 </LinkWithQuery>
                 {index < concepts.length - 1 && ", "}

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -226,11 +226,10 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     // Process concepts
     const processedConceptCounts = processConcepts(concepts);
 
-    // Sort concepts by count, descending (with 'Other' always at the end if present)
-    const sortedConcepts = Object.entries(processedConceptCounts).sort(([a], [b]) => {
-      if (a === "Other") return 1;
-      if (b === "Other") return -1;
-      return processedConceptCounts[b] - processedConceptCounts[a];
+    // Sort concepts by count, descending, and then alphabetically if counts are the same
+    const sortedConcepts = Object.entries(processedConceptCounts).sort(([conceptA, countA], [conceptB, countB]) => {
+      if (countB !== countA) return countB - countA;
+      return conceptA.localeCompare(conceptB);
     });
 
     setRootLevelConcepts(sortedConcepts);
@@ -406,11 +405,10 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
 
             {rootLevelConcepts.length > 0 && (
               <section className="mt-8">
-                <Heading level={4}>Root Level Concepts</Heading>
+                <Heading level={4}>Concepts</Heading>
                 <div className="flex text-sm">
                   <ul className="flex flex-wrap gap-2">
                     {rootLevelConcepts.map(([conceptName, count]) => {
-                      // For root level concepts
                       return (
                         <li key={conceptName}>
                           <LinkWithQuery
@@ -423,27 +421,6 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                           >
                             <Button color="clear" data-cy="view-source" extraClasses="flex items-center text-sm">
                               {conceptName} ({count})
-                            </Button>
-                          </LinkWithQuery>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </section>
-            )}
-
-            {concepts.length > 0 && (
-              <section className="mt-8">
-                <Heading level={4}>Concepts</Heading>
-                <div className="flex text-sm">
-                  <ul className="flex flex-wrap gap-2">
-                    {concepts.map((concept, i) => {
-                      return (
-                        <li key={i}>
-                          <LinkWithQuery className="capitalize" href={`/concepts/${concept.wikibase_id}`}>
-                            <Button color="clear" data-cy="view-source" extraClasses="flex items-center text-sm">
-                              {concept.preferred_label} ({concept.count})
                             </Button>
                           </LinkWithQuery>
                         </li>
@@ -525,7 +502,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
        *
        * TODO: undo this once the response from the API is fully implemented.
        */
-      const testingConceptCounts = { Q218: 1, Q100: 15, Q1651: 101, Q1652: 100 };
+      const testingConceptCounts = { Q218: 1, Q100: 15, Q1651: 101, Q1652: 100, Q638: 115 };
       vespaFamilyData = {
         ...vespaFamilyDataRepsonse,
         families: vespaFamilyDataRepsonse.families.map((family) => {

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -25,22 +25,22 @@ export const processConcepts = (concepts: (TConcept & { count: number })[]): { [
   concepts.forEach((concept) => {
     let isRootOrSubconcept = false;
 
-    // Check if it's a root level concept (no subconcepts, but has subconcept_of)
-    const isRootLevelConcept = concept.subconcept_of.length === 0 && concept.has_subconcept && concept.has_subconcept.length > 0;
-
+    // Check if concept is one of our preset root level concepts
+    const isRootLevelConcept = concept.wikibase_id in ROOT_LEVEL_CONCEPTS;
     if (isRootLevelConcept) {
-      conceptMap[concept.wikibase_id] = (conceptMap[concept.wikibase_id] || 0) + concept.count;
+      const rootConceptName = ROOT_LEVEL_CONCEPTS[concept.wikibase_id];
+      conceptMap[rootConceptName] = (conceptMap[rootConceptName] || 0) + concept.count;
       isRootOrSubconcept = true;
     }
 
-    // Check if any of its parent concepts are root level concepts
-    const hasRootLevelParent = concept.subconcept_of.some((parentId) => ROOT_LEVEL_CONCEPTS[parentId]);
-
+    // Check if any of the current concept's parent concepts are root level concepts
+    const hasRootLevelParent = concept.subconcept_of.some((parentId) => parentId in ROOT_LEVEL_CONCEPTS);
     if (hasRootLevelParent) {
       // Find and increment all root level parent concepts
       concept.subconcept_of.forEach((parentId) => {
         if (ROOT_LEVEL_CONCEPTS[parentId]) {
-          conceptMap[parentId] = (conceptMap[parentId] || 0) + concept.count;
+          const rootConceptName = ROOT_LEVEL_CONCEPTS[parentId];
+          conceptMap[rootConceptName] = (conceptMap[rootConceptName] || 0) + concept.count;
         }
       });
       isRootOrSubconcept = true;

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -1,0 +1,69 @@
+import { TConcept } from "@types";
+
+// Define the root level concepts
+const ROOT_LEVEL_CONCEPTS = {
+  Q1651: "Targets",
+  Q709: "Sectors",
+  Q975: "Climate risk",
+  Q638: "Fossil fuels",
+  Q672: "Impacted groups",
+  Q1337: "Finance",
+  Q1171: "Instruments",
+  Q218: "Greenhouse gases",
+};
+
+interface ProcessedConcept {
+  rootConcept: string;
+  count: number;
+  wikibaseId: string;
+}
+
+export const processConcepts = (concepts: (TConcept & { count: number })[]): { [key: string]: number } => {
+  const conceptMap: { [key: string]: number } = {};
+  let otherCount = 0;
+
+  concepts.forEach((concept) => {
+    let isRootOrSubconcept = false;
+
+    // Check if it's a root level concept (no subconcepts, but has subconcept_of)
+    const isRootLevelConcept = concept.subconcept_of.length === 0 && concept.has_subconcept && concept.has_subconcept.length > 0;
+
+    if (isRootLevelConcept) {
+      conceptMap[concept.wikibase_id] = (conceptMap[concept.wikibase_id] || 0) + concept.count;
+      isRootOrSubconcept = true;
+    }
+
+    // Check if any of its parent concepts are root level concepts
+    const hasRootLevelParent = concept.subconcept_of.some((parentId) => ROOT_LEVEL_CONCEPTS[parentId]);
+
+    if (hasRootLevelParent) {
+      // Find and increment all root level parent concepts
+      concept.subconcept_of.forEach((parentId) => {
+        if (ROOT_LEVEL_CONCEPTS[parentId]) {
+          conceptMap[parentId] = (conceptMap[parentId] || 0) + concept.count;
+        }
+      });
+      isRootOrSubconcept = true;
+    }
+
+    // If not a root or subconcept of a root, add to other
+    if (!isRootOrSubconcept) {
+      otherCount += concept.count;
+    }
+  });
+
+  // Add Other category if there are any other concepts
+  if (otherCount > 0) {
+    conceptMap["Other"] = otherCount;
+  }
+
+  return conceptMap;
+};
+
+export const ROOT_LEVEL_CONCEPT_LINKS = Object.entries(ROOT_LEVEL_CONCEPTS).reduce(
+  (acc, [qNum, name]) => {
+    acc[name] = `https://climatepolicyradar.wikibase.cloud/wiki/Item:${qNum}`;
+    return acc;
+  },
+  {} as { [key: string]: string }
+);


### PR DESCRIPTION
# What's changed

There are 8 root level concepts:
1. Targets (Q1651)
2. Sectors (Q709)
3. Climate risk (Q975)
4. Fossil fuels (Q638)
5. Impacted groups (Q672)
6. Finance (Q1337)
7. Instruments (Q1171)
8. Greenhouse gases (Q218)

The corresponding Q number refers to its ID on this website https://climatepolicyradar.wikibase.cloud/wiki/Main_Page. A concept's page on this website can be found using the link https://climatepolicyradar.wikibase.cloud/wiki/Item:Q_NUM where Q_NUM is the `wikibase_id` associated with the concept.

Instead of showing only the concepts directly associated with a family and its documents, we want to show:
- where a concept is either a root level concept or is directly a subconcept_of a root level concept
    - for each root level concept, show the root level concept name and the total sum of the concepts associated with that root level in the family/documents
    - if a root level concept has no associated concepts in that family/its documents, do not coalesce or show the root level concepts aren't associated with the family/its documents
    - some concepts may be subconcepts_of one or more root level concepts. where this is true, the concept count must be incremented for root level concepts directly associated with the concept
- where a concept is not a root level concept OR directly a subconcept_of one or more of the root level concepts, show `Other` and count the total sum of each of the concept hits where the parent concept is not directly one of the root level concepts

When displaying these root level concepts and their counts:
- We must only show unique concepts
- Concepts should be stack ranked most-least
- root level concepts (with the exception of the `Other` category) are clickable and will currently take you to the wikibase page associated with that root level concept

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
