### PR TITLE
fix: remove hardcoded data from concepts lookup

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -334,7 +334,7 @@ export type TSearchResponse = {
   families: {
     id: string;
     hits: (TFamily & {
-      concept_counts: Record<string, number>;
+      concept_counts?: Record<string, number>;
     })[];
   }[];
   continuation_token?: string;


### PR DESCRIPTION
# What's changed
- removes hardcoded data
- make `concept_counts` optional as it is from the API
- splits `concept_counts` key by `:` as the key is now the `{id}:{name}`


https://github.com/user-attachments/assets/9d03a496-90ff-4089-84d4-e09fa3725137



## Proposed version

- [x] Patch