### PR TITLE
APP-166 OEP additions

### DIFF
--- a/themes/cpr/components/oep/Hero.tsx
+++ b/themes/cpr/components/oep/Hero.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import { SingleCol } from "@components/panels/SingleCol";
 import { SiteWidth } from "@components/panels/SiteWidth";
+import { ExternalLink } from "@components/ExternalLink";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 
@@ -49,8 +50,10 @@ export const Hero = () => {
         <SiteWidth>
           <SingleCol>
             <div className="relative z-10 pb-[100px] pt-[100px] md:pt-[218px]">
-              <div className="mb-6">
-                <Image src="/images/oep/OEP-logo-small.png" width={155} height={54} alt="Ocean Energy Pathway logo" data-cy="oep-logo" />
+              <div className="mb-6 flex">
+                <ExternalLink url="https://www.oceanenergypathway.org" className="flex">
+                  <Image src="/images/oep/OEP-logo-small.png" width={155} height={54} alt="Ocean Energy Pathway logo" data-cy="oep-logo" />
+                </ExternalLink>
               </div>
               <h1 className="font-['tenez'] font-bold italic text-oep-royal-blue tracking-[-0.96px] leading-[80%] text-7xl md:text-8xl">
                 <span className="not-italic">POWER</span> library

--- a/themes/cpr/pages/oep.tsx
+++ b/themes/cpr/pages/oep.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
 import Image from "next/image";
-import Link from "next/link";
 
 import Layout from "@components/layouts/LandingPage";
+import { ExternalLink } from "@components/ExternalLink";
 import { ColumnAndImage } from "@cpr/components/oep/ColumnAndImage";
 import { EqualColumn, EqualColumns } from "@cpr/components/oep/EqualColumns";
 import { Footer } from "@cpr/components/oep/Footer";
@@ -10,7 +10,6 @@ import { Header } from "@cpr/components/oep/Header";
 import { Hero } from "@cpr/components/oep/Hero";
 import { Narrow } from "@cpr/components/oep/Narrow";
 import { Section } from "@cpr/components/oep/Section";
-import { ExternalLink } from "@components/ExternalLink";
 
 const OceanEnergyPathwayPage = () => {
   return (
@@ -166,15 +165,19 @@ const OceanEnergyPathwayPage = () => {
                 </p>
               </EqualColumn>
               <EqualColumn extraClasses="mt-9 md:mt-0 md:self-end flex flex-row flex-wrap md:justify-end gap-y-4 gap-x-8">
-                <Image src="/images/cpr-logo-horizontal-dark.svg" width={215} height={35} alt="Climate Policy Radar logo" data-cy="cpr-logo" />
-                <Image
-                  src="/images/oep/OEP-logo.svg"
-                  width={155}
-                  height={100}
-                  alt="Ocean Energy Pathway logo"
-                  data-cy="oep-logo"
-                  className="invert"
-                />
+                <ExternalLink url="https://www.climatepolicyradar.org" className="flex">
+                  <Image src="/images/cpr-logo-horizontal-dark.svg" width={215} height={35} alt="Climate Policy Radar logo" data-cy="cpr-logo" />
+                </ExternalLink>
+                <ExternalLink url="https://www.oceanenergypathway.org" className="flex">
+                  <Image
+                    src="/images/oep/OEP-logo.svg"
+                    width={155}
+                    height={100}
+                    alt="Ocean Energy Pathway logo"
+                    data-cy="oep-logo"
+                    className="invert"
+                  />
+                </ExternalLink>
               </EqualColumn>
             </EqualColumns>
           </Section>

--- a/themes/cpr/pages/terms-of-use.tsx
+++ b/themes/cpr/pages/terms-of-use.tsx
@@ -329,6 +329,16 @@ const TermsOfUse = () => {
                     </td>
                   </tr>
                   <tr>
+                    <td>
+                      <ExternalLink url="https://www.oceanenergypathway.org">Ocean Energy Pathway</ExternalLink>
+                    </td>
+                    <td>Offshore Wind Reports</td>
+                    <td>January 2025</td>
+                    <td>
+                      <ExternalLink url="https://oceanenergypathway.org/terms-conditions/">View</ExternalLink>
+                    </td>
+                  </tr>
+                  <tr>
                     <td>Additional data sources will be added here as they are added to the CPR database and app</td>
                     <td></td>
                     <td></td>


### PR DESCRIPTION
# What's changed
- Updating CPR terms of use to include OEP
- Add links from OEP handshake page back to OEP site when clicking on logos

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
