### PR TITLE
feature/app-155-preventionweb-is-missing-a-logo-on-appcpr-and-cclw-under

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -374,7 +374,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                 {corpusImage && (
                   <div className="relative max-w-[144px] mt-1 mr-2">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={`${corpusImage}`} alt={corpusAltImage} />
+                    <img src={`${corpusImage}`} alt={corpusAltImage} className="h-auto w-full" />
                   </div>
                 )}
                 <span dangerouslySetInnerHTML={{ __html: corpusNote }} className="" />


### PR DESCRIPTION
fix: no explicit setting of height and width means image not rendered
- the images for the prevent web logo was being rendered at 0 x 0 pixels



# What's changed

Before
<img width="1137" alt="Screenshot 2025-02-10 at 14 27 49" src="https://github.com/user-attachments/assets/9347d65a-3c2d-4a0c-97c6-97f22b099230" />

After

![Screenshot 2025-02-10 at 14 45 13](https://github.com/user-attachments/assets/d745ef1b-86cc-4582-b5c1-ba7b92fae8f1)


N.B - have tested to ensure that the other logos for other corpora is rendered properly
## Proposed version


Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
