### PR TITLE
feature/app-158-counts-on-country-pages-and-search-do-not-add-u

### DIFF
--- a/themes/cclw/config.json
+++ b/themes/cclw/config.json
@@ -15,13 +15,13 @@
       {
         "label": "Policies",
         "slug": "policies",
-        "value": ["CCLW.corpus.i00000001.n0000"],
+        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
         "category": ["Executive"]
       },
       {
         "label": "Laws",
         "slug": "laws",
-        "value": ["CCLW.corpus.i00000001.n0000"],
+        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
         "category": ["Legislative"],
         "alias": "LAWS"
       }


### PR DESCRIPTION
# What's changed

fix: add prevention web and cpd to the filter query we were sending to the vespa db in the cclw theme app.

- we were missing these corpora ids when searching the vespa laws and policies so it would only return the cclw docs, and would create a mismatch between the geo pages and search pages

As per the master sheet, cclw should contain, cpd,cclw,unfcc &. prevention web
<img width="521" alt="Screenshot 2025-02-10 at 15 51 20" src="https://github.com/user-attachments/assets/03b26015-2dfc-4eca-9499-5040d77574f7" />

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
