### PR TITLE
APP-238: Adjust text on OEP handshake page

### DIFF
--- a/themes/cpr/components/oep/Hero.tsx
+++ b/themes/cpr/components/oep/Hero.tsx
@@ -56,7 +56,7 @@ export const Hero = () => {
                 </ExternalLink>
               </div>
               <h1 className="font-['tenez'] font-bold italic text-oep-royal-blue tracking-[-0.96px] leading-[80%] text-7xl md:text-8xl">
-                <span className="not-italic">POWER</span> library
+                <span className="not-italic">POWER</span> Library
               </h1>
               <p className="my-6 text-xl text-textDark md:text-2xl">Helping the offshore wind sector design effective strategies</p>
               <div className="relative z-1 mb-4">


### PR DESCRIPTION
# What's changed

- Title cased "library" to "Library" in one instance.

<img width="892" alt="Screenshot 2025-02-12 at 09 58 49" src="https://github.com/user-attachments/assets/565a22e0-7e0d-4dd3-a1c7-1db06b9b4e98" />

## Proposed version

- [x] Patch

Resolves [APP-238](https://linear.app/climate-policy-radar/issue/APP-238/adjust-text-on-oep-handshake-page).