### PR TITLE
Feature/app 195 add gold standard corpus

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -20,7 +20,8 @@
           "CPR.corpus.i00000001.n0000",
           "CPR.corpus.i00000589.n0000",
           "CPR.corpus.i00000591.n0000",
-          "CPR.corpus.i00000592.n0000"
+          "CPR.corpus.i00000592.n0000",
+          "CPR.corpus.Goldstandard.n0000"
         ],
         "category": ["Executive"]
       },
@@ -32,7 +33,8 @@
           "CPR.corpus.i00000001.n0000",
           "CPR.corpus.i00000589.n0000",
           "CPR.corpus.i00000591.n0000",
-          "CPR.corpus.i00000592.n0000"
+          "CPR.corpus.i00000592.n0000",
+          "CPR.corpus.Goldstandard.n0000"
         ],
         "category": ["Legislative"],
         "alias": "LAWS"

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -129,7 +129,7 @@
       "taxonomyKey": "topic",
       "apiMetaDataKey": "family.topic",
       "type": "radio",
-      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000"],
+      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000", "CPR.corpus.Goldstandard.n0000"],
       "dependentFilterKey": "",
       "corporaKey": "Laws and Policies"
     },
@@ -138,7 +138,7 @@
       "taxonomyKey": "sector",
       "apiMetaDataKey": "family.sector",
       "type": "radio",
-      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000"],
+      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000", "CPR.corpus.Goldstandard.n0000"],
       "dependentFilterKey": "",
       "showFade": "true",
       "corporaKey": "Laws and Policies",

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -129,7 +129,7 @@
       "taxonomyKey": "topic",
       "apiMetaDataKey": "family.topic",
       "type": "radio",
-      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000", "CPR.corpus.Goldstandard.n0000"],
+      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000"],
       "dependentFilterKey": "",
       "corporaKey": "Laws and Policies"
     },
@@ -138,7 +138,7 @@
       "taxonomyKey": "sector",
       "apiMetaDataKey": "family.sector",
       "type": "radio",
-      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000", "CPR.corpus.Goldstandard.n0000"],
+      "category": ["CPR.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000"],
       "dependentFilterKey": "",
       "showFade": "true",
       "corporaKey": "Laws and Policies",


### PR DESCRIPTION
# What's changed
- add Gold Standard corpus id to the CPR config

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
