### PR TITLE
fix: use actual version of theme-factory v21

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: write
     secrets: inherit
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@testing
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@v21
     with:
       repo-name: navigator-frontend
       theme: ${{ matrix.theme }}


### PR DESCRIPTION
# What's changed
an accidental auto-merge merged in a `testing` tag - which we shouldn't be using.

🤦 - apologies for the extra review effort.

## Proposed version
- [x] Patch
