### PR TITLE
fix: run build on new theme factory

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: write
     secrets: inherit
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@v21
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@run-build-on-main
     with:
       repo-name: navigator-frontend
       theme: ${{ matrix.theme }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: write
     secrets: inherit
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@run-build-on-main
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/theme-factory.yml@main
     with:
       repo-name: navigator-frontend
       theme: ${{ matrix.theme }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ ENV THEME=$THEME
 # Make sure the latest npm is installed for speed and fixes.
 RUN npm i npm@latest -g
 
+# Switch to root user to copy files safely
+USER root
+
+WORKDIR /home/node/app
+COPY . .
+RUN chown -R node:node /home/node/app
+
+
 # The official Node image provides an unprivileged user as a security best
 # practice, but it needs to be manually enabled. We put it here so npm installs
 # dependencies as the same user who runs the app.
@@ -13,11 +21,9 @@ USER node
 
 # Create workdir and copy source code into it, giving the node user read and
 # execute permissions, but not alter permissions.
-WORKDIR /home/node/app
-COPY --chmod=0755  . .
 
 # Install dependencies.
-RUN npm ci && npm cache clean --force
+RUN npm install
 
 ENV PATH=/home/node/app/node_modules/.bin:$PATH
 


### PR DESCRIPTION
# What's changed
- changes the docker file a little around permissions as this seems to work. Not too sure why this has broken, but I'd rather have a green build and work it out later
- Changes the ref to reusable-actions to main to avoid a very slow workflow of updating, releasing, updating here, and then finding out it's broken. This should be fine as it's our repo

https://github.com/climatepolicyradar/reusable-workflows/pull/11

- [x] Patch
