### PR TITLE
fix: don't re-fetch concept data on re-render

### DIFF
--- a/src/hooks/useEffectOnce.ts
+++ b/src/hooks/useEffectOnce.ts
@@ -1,0 +1,6 @@
+import { EffectCallback, useEffect } from "react";
+
+export function useEffectOnce(effect: EffectCallback) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- we do this as this effect explicitly runs things once
+  useEffect(effect, []);
+}


### PR DESCRIPTION
# What's changed
- uses useEffectOnce as we have multiple re-renders that kick of multiple fetches for concepts, which is non-performant

## Proposed version

- [x] Patch
