### PR TITLE
Display "Guidance" for MCF reports

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -12,8 +12,17 @@ type TProps = {
 };
 
 export const FamilyListItem: FC<TProps> = ({ family, children }) => {
-  const { corpus_type_name, family_slug, family_geographies, family_description, family_name, family_date, family_category, family_metadata } =
-    family;
+  const {
+    corpus_type_name,
+    family_slug,
+    family_geographies,
+    family_description,
+    family_name,
+    family_date,
+    family_category,
+    family_metadata,
+    family_source,
+  } = family;
 
   return (
     <div className="family-list-item relative">
@@ -29,6 +38,7 @@ export const FamilyListItem: FC<TProps> = ({ family, children }) => {
         <FamilyMeta
           category={family_category}
           corpus_type_name={corpus_type_name}
+          source={family_source}
           date={family_date}
           geographies={family_geographies}
           {...(corpus_type_name === "Reports" ? { author: (family_metadata as { author: string[] }).author } : {})}

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -7,6 +7,7 @@ import { CountryLinks } from "@components/CountryLinks";
 type TProps = {
   category: TCategory;
   corpus_type_name: TCorpusTypeSubCategory;
+  source?: string;
   date: string;
   geographies: string[];
   topics?: string[];
@@ -14,7 +15,7 @@ type TProps = {
   document_type?: string;
 };
 
-export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name, document_type }: TProps) => {
+export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name, document_type, source }: TProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
 
@@ -37,7 +38,7 @@ export const FamilyMeta = ({ category, date, geographies, topics, author, corpus
       )}
       {category && (
         <span className="capitalize" data-cy="family-metadata-category">
-          {getCategoryName(category, corpus_type_name)}
+          {getCategoryName(category, corpus_type_name, source)}
         </span>
       )}
       {document_type && (

--- a/src/helpers/getCategoryName.ts
+++ b/src/helpers/getCategoryName.ts
@@ -1,14 +1,12 @@
 import { TCategory, TCorpusTypeSubCategory } from "@types";
 
-const reportSubCategories: Record<TCorpusTypeSubCategory | "OEP", string> = {
+const reportSubCategories = {
   AF: "Guidance",
   CIF: "Guidance",
   GCF: "Guidance",
   GEF: "Guidance",
   Reports: "Reports",
   OEP: "Reports",
-  "Intl. agreements": "Intl. agreements",
-  "Laws and Policies": "Laws and Policies",
 };
 
 const subCategories: Record<TCorpusTypeSubCategory, string> = {
@@ -32,8 +30,8 @@ const categories: Record<TCategory, string> = {
   Reports: "Reports",
 };
 
-const getReportsCategory = (source: TCorpusTypeSubCategory): string => {
-  return reportSubCategories[source];
+const getReportsCategory = (source: string): string => {
+  return reportSubCategories[source] || "Reports";
 };
 
 export const getSubCategoryName = (subCategory: TCorpusTypeSubCategory): string => {
@@ -43,7 +41,7 @@ export const getSubCategoryName = (subCategory: TCorpusTypeSubCategory): string 
 export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory, source?: string): string => {
   const name = categories[category as TCategory];
   if (category === "Reports" && source) {
-    return getReportsCategory(source as TCorpusTypeSubCategory);
+    return getReportsCategory(source);
   }
   return category === "MCF" && subCategory ? getSubCategoryName(subCategory) : name;
 };

--- a/src/helpers/getCategoryName.ts
+++ b/src/helpers/getCategoryName.ts
@@ -1,5 +1,16 @@
 import { TCategory, TCorpusTypeSubCategory } from "@types";
 
+const reportSubCategories: Record<TCorpusTypeSubCategory | "OEP", string> = {
+  AF: "Guidance",
+  CIF: "Guidance",
+  GCF: "Guidance",
+  GEF: "Guidance",
+  Reports: "Reports",
+  OEP: "Reports",
+  "Intl. agreements": "Intl. agreements",
+  "Laws and Policies": "Laws and Policies",
+};
+
 const subCategories: Record<TCorpusTypeSubCategory, string> = {
   AF: "Adaptation Fund",
   CIF: "Climate Investment Funds",
@@ -7,7 +18,7 @@ const subCategories: Record<TCorpusTypeSubCategory, string> = {
   GEF: "Global Environment Facility",
   "Intl. agreements": "Intl. agreements",
   "Laws and Policies": "Laws and Policies",
-  Reports: "Reports",
+  Reports: "Guidance",
 };
 
 const categories: Record<TCategory, string> = {
@@ -21,11 +32,18 @@ const categories: Record<TCategory, string> = {
   Reports: "Reports",
 };
 
+const getReportsCategory = (source: TCorpusTypeSubCategory): string => {
+  return reportSubCategories[source];
+};
+
 export const getSubCategoryName = (subCategory: TCorpusTypeSubCategory): string => {
   return subCategories[subCategory as TCorpusTypeSubCategory];
 };
 
-export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory): string => {
+export const getCategoryName = (category: TCategory, subCategory?: TCorpusTypeSubCategory, source?: string): string => {
   const name = categories[category as TCategory];
+  if (category === "Reports" && source) {
+    return getReportsCategory(source as TCorpusTypeSubCategory);
+  }
   return category === "MCF" && subCategory ? getSubCategoryName(subCategory) : name;
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -205,6 +205,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     handleSearchChange(QUERY_PARAMS.query_string, term);
   };
 
+  // When we change category we don't want to keep the previous filters which are not applicable
   const handleDocumentCategoryClick = (category: string) => {
     // Reset pagination and continuation tokens
     delete router.query[QUERY_PARAMS.offset];
@@ -215,6 +216,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     delete router.query[QUERY_PARAMS.fund];
     delete router.query[QUERY_PARAMS.status];
     delete router.query[QUERY_PARAMS.implementing_agency];
+    delete router.query[QUERY_PARAMS.fund_doc_type];
     // Law and policy filters
     delete router.query[QUERY_PARAMS.framework_laws];
     // Reports filters


### PR DESCRIPTION
# What's changed
- Update the category render code to support checking for MCF as a source and displaying the label "Guidance"

🚨 This is a debatable solution because I am creating a workaround to use the source and casting as a sub category type in order to check against the fund acronym. Really keen to hear people's thoughts on if this is acceptable or not.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
