### PR TITLE
fix: only run posthog clientside

### DIFF
--- a/snapshots.js
+++ b/snapshots.js
@@ -62,4 +62,8 @@ module.exports = [
       },
     },
   },
+  {
+    name: "Feature flags page",
+    url: "http://localhost:3000/_feature-flags",
+  },
 ];

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -6,16 +6,16 @@ import { useEffect } from "react";
 export default function FeatureFlags() {
   const posthog = usePostHog();
 
-  /**
-   * This key is a public key.
-   * @see: https://posthog.com/docs/privacy#is-it-ok-for-my-api-key-to-be-exposed-and-public
-   */
-  posthog.init("phc_zaZYaLxsAeMjCLPsU2YvFqu4oaXRJ8uAkgXY8DancyL", {
-    api_host: "https://eu.i.posthog.com",
-    opt_in_site_apps: true,
-  });
-
   useEffect(() => {
+    /**
+     * This key is a public key.
+     * @see: https://posthog.com/docs/privacy#is-it-ok-for-my-api-key-to-be-exposed-and-public
+     */
+    posthog.init("phc_zaZYaLxsAeMjCLPsU2YvFqu4oaXRJ8uAkgXY8DancyL", {
+      api_host: "https://eu.i.posthog.com",
+      opt_in_site_apps: true,
+    });
+
     posthog.onFeatureFlags((featureFlags) => {
       const newFeatureFlags = {};
       for (const featureFlag of featureFlags) {


### PR DESCRIPTION
# What's changed
- runs posthog on the client only
- [This is erroring on staging](https://app.dev.climatepolicyradar.org/_feature-flags)
- [But not on production](https://app.dev.climatepolicyradar.org/_feature-flags)
- adds a snapshot test to make sure the page is rendering

I can't seem to find the reason why as it's a diff of https://github.com/climatepolicyradar/navigator-frontend/compare/v2.0.88-beta...v2.0.90-beta - which doesn't seem to have any breaking changes.

This also seems to work locally (although it does error, then rectify itself) but I think this is because the module reloading forces a client render, which fixes it. In production we only server render.

In the name of expediency and wanting to have something for show-and-tell, this works - and I can dig into the reason later.

## Proposed version

- [x] Patch
