### PR TITLE
Add MCF google tag manager script

### DIFF
--- a/themes/mcf/components/Analytics.tsx
+++ b/themes/mcf/components/Analytics.tsx
@@ -1,9 +1,31 @@
+import Script from "next/script";
+
 type TProps = {
   enableAnalytics: boolean;
 };
 
+const MCF_GA_ID = "G-4SHFJ172GL";
+
 const Analytics = ({ enableAnalytics }: TProps) => {
-  return null;
+  return (
+    <>
+      {enableAnalytics && (
+        <>
+          <Script async src={`https://www.googletagmanager.com/gtag/js?id=${MCF_GA_ID}`} />
+          <Script id="mcf-google-analytics" strategy="afterInteractive">
+            {`
+              (function(w,l,i) {
+                w[l] = w[l] || [];
+                function gtag(){w[l].push(arguments);}
+                gtag('js', new Date());
+                gtag('config', i);
+              })(window, "dataLayer", "${MCF_GA_ID}");
+            `}
+          </Script>
+        </>
+      )}
+    </>
+  );
 };
 
 export default Analytics;


### PR DESCRIPTION
# What's changed
- Adding MCF's google tag manager script onto the mcf theme

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
