### PR TITLE
Fix concepts viewer counts

### DIFF
--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -18,6 +18,8 @@ import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
+import { ROOT_LEVEL_CONCEPT_LINKS } from "@utils/processConcepts";
+import { ExternalLinkIcon } from "@components/svg/Icons";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -32,7 +34,6 @@ type TProps = {
   // Callback props for state changes
   onQueryTermChange?: (queryTerm: string) => void;
   onExactMatchChange?: (isExact: boolean) => void;
-  onPassageChange?: (passageIndex: number) => void;
   onConceptClick?: (conceptLabel: string) => void;
 };
 
@@ -58,7 +59,6 @@ export const ConceptsDocumentViewer = ({
   document,
   onQueryTermChange,
   onExactMatchChange,
-  onPassageChange,
   onConceptClick,
 }: TProps) => {
   const [showSearchOptions, setShowSearchOptions] = useState(false);
@@ -136,9 +136,8 @@ export const ConceptsDocumentViewer = ({
     (index: number) => {
       if (document.content_type !== "application/pdf") return;
       setState({ passageIndex: index });
-      onPassageChange?.(index);
     },
-    [document.content_type, onPassageChange]
+    [document.content_type]
   );
 
   const handleSearchInput = useCallback(
@@ -267,6 +266,16 @@ export const ConceptsDocumentViewer = ({
                         return (
                           <div key={rootConcept.wikibase_id} className="pt-6 pb-6">
                             <p className="mb-2 capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
+                            {ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label] && (
+                              <a
+                                href={ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label]}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-gray-500 hover:text-blue-600"
+                              >
+                                <ExternalLinkIcon height="12" width="12" />
+                              </a>
+                            )}
                             <p>{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -167,18 +167,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     [router, document.slug]
   );
 
-  const handlePassageChange = useCallback(
-    (passageIndex: number) => {
-      const queryObj = { ...router.query };
-      queryObj.passage = passageIndex.toString();
-      router.push({
-        pathname: `/documents/${document.slug}`,
-        query: queryObj,
-      });
-    },
-    [router, document.slug]
-  );
-
   useEffect(() => {
     let passageMatches: TPassage[] = [];
     let totalNoOfMatches = 0;
@@ -432,7 +420,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
             document={document}
             onQueryTermChange={handleQueryTermChange}
             onExactMatchChange={handleExactMatchChange}
-            onPassageChange={handlePassageChange}
             onConceptClick={handleConceptClick}
           />
         )}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -206,10 +206,24 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   /** Concepts: WIP */
   const [concepts, setConcepts] = useState<TConcept[]>([]);
   const [rootConcepts, setRootConcepts] = useState<TConcept[]>([]);
-  const [selectedConcepts, setSelectedConceptsFilter] = useState<TConcept[]>([]);
-  const conceptCounts: { conceptKey: string; count: number }[] = (vespaFamilyData?.families ?? [])
-    .flatMap((family) => family.hits.flatMap((hit) => Object.entries(hit.concept_counts ?? {}).map(([conceptKey, count]) => ({ conceptKey, count }))))
-    .sort((a, b) => b.count - a.count);
+
+  // Extract unique concept keys and their counts
+  const conceptCounts: { conceptKey: string; count: number }[] = useMemo(() => {
+    const uniqueConceptMap = new Map<string, number>();
+
+    (vespaFamilyData?.families ?? []).forEach((family) => {
+      family.hits.forEach((hit) => {
+        Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
+          const existingCount = uniqueConceptMap.get(conceptKey) || 0;
+          uniqueConceptMap.set(conceptKey, existingCount + count);
+        });
+      });
+    });
+
+    return Array.from(uniqueConceptMap.entries())
+      .map(([conceptKey, count]) => ({ conceptKey, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [vespaFamilyData]);
 
   const conceptFiltersQuery = router.query[QUERY_PARAMS["concept_filters.name"]];
   const conceptFilters = useMemo(
@@ -278,12 +292,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
       const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
 
-      /** Get the selected concept from the query string */
-      const conceptsFilterQuery = router.query[QUERY_PARAMS["concept_filters.name"]];
-      const conceptsFilters = conceptsFilterQuery ? (Array.isArray(conceptsFilterQuery) ? conceptsFilterQuery : [conceptsFilterQuery]) : undefined;
-      const selectedConcepts = conceptsResults.filter((concept) => conceptsFilters?.includes(concept.preferred_label));
-
-      setSelectedConceptsFilter(selectedConcepts);
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);
     });


### PR DESCRIPTION
# What's changed

Fix concepts viewer counts and add uniqueness clause for concept IDs to make sure we aggregate counts for concepts.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
