### PR TITLE
Feature/app 275 add concepts store links back to family/doc page

### DIFF
--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -1,0 +1,33 @@
+import { ExternalLink } from "@components/ExternalLink";
+
+export const ConceptsHead = ({}) => {
+  return (
+    <div className="mb-4">
+      <div className="h-20 flex-col justify-start items-start gap-3 inline-flex">
+        <div className="self-stretch h-6 flex-col justify-center items-start gap-4 flex">
+          <div className="self-stretch rounded-md justify-start items-center gap-2 inline-flex">
+            <div className="text-neutral-800 text-base font-medium font-['Inter Variable'] leading-normal">Climate concepts</div>
+            <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
+              <div className="text-white text-xs font-medium font-['Inter Variable'] leading-3">Beta</div>
+            </div>
+          </div>
+        </div>
+        <div className="self-stretch h-12 flex-col justify-start items-start gap-4 flex">
+          <div className="self-stretch pl-4 py-1 border-l-2 border-blue-600 justify-center items-center gap-2.5 inline-flex">
+            <div className="grow shrink basis-0">
+              <p className="text-neutral-600 text-sm font-normal font-['Inter Variable'] leading-tight">
+                This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+                <ExternalLink
+                  url="https://climatepolicyradar.org/concepts"
+                  className="text-gray-600 text-sm font-normal font-['Inter Variable'] underline leading-tight"
+                >
+                  Learn more
+                </ExternalLink>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -7,7 +7,6 @@ import Button from "@components/buttons/Button";
 import SearchForm from "@components/forms/SearchForm";
 import { MdOutlineTune } from "react-icons/md";
 import { AnimatePresence } from "framer-motion";
-import { Heading } from "@components/typography/Heading";
 import { ExternalLink } from "@components/ExternalLink";
 import PassageMatches from "@components/PassageMatches";
 import { SearchLimitTooltip } from "@components/tooltip/SearchLimitTooltip";
@@ -20,6 +19,7 @@ import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
 import { ROOT_LEVEL_CONCEPT_LINKS, ROOT_LEVEL_CONCEPTS } from "@utils/processConcepts";
 import { ExternalLinkIcon } from "@components/svg/Icons";
+import { ConceptsHead } from "@components/concepts/ConceptsHead";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -259,33 +259,7 @@ export const ConceptsDocumentViewer = ({
                   {selectedConcepts.length === 0 && !initialQueryTerm && (
                     <div className="pb-4">
                       <div className="mt-4 grow-0 shrink-0">
-                        <div className="mb-4">
-                          <div className="h-20 flex-col justify-start items-start gap-3 inline-flex">
-                            <div className="self-stretch h-6 flex-col justify-center items-start gap-4 flex">
-                              <div className="self-stretch rounded-md justify-start items-center gap-2 inline-flex">
-                                <div className="text-neutral-800 text-base font-medium font-['Inter Variable'] leading-normal">Climate concepts</div>
-                                <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
-                                  <div className="text-white text-xs font-medium font-['Inter Variable'] leading-3">Beta</div>
-                                </div>
-                              </div>
-                            </div>
-                            <div className="self-stretch h-12 flex-col justify-start items-start gap-4 flex">
-                              <div className="self-stretch pl-4 py-1 border-l-2 border-blue-600 justify-center items-center gap-2.5 inline-flex">
-                                <div className="grow shrink basis-0">
-                                  <p className="text-neutral-600 text-sm font-normal font-['Inter Variable'] leading-tight">
-                                    This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
-                                    <ExternalLink
-                                      url="https://climatepolicyradar.org/concepts"
-                                      className="text-gray-600 text-sm font-normal font-['Inter Variable'] underline leading-tight"
-                                    >
-                                      Learn more
-                                    </ExternalLink>
-                                  </p>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
+                        <ConceptsHead></ConceptsHead>
                       </div>
 
                       {rootConcepts.map((rootConcept) => {

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -251,7 +251,12 @@ export const ConceptsDocumentViewer = ({
                     <div className="pb-4">
                       <div className="mt-4 grow-0 shrink-0">
                         <div className="mb-4">
-                          <Heading level={4}>Climate concepts</Heading>
+                          <div className="h-6 rounded-md justify-start items-center gap-2 inline-flex">
+                            <div className="text-neutral-800 text-base font-medium leading-normal">Climate concepts</div>
+                            <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
+                              <div className="text-white text-xs font-medium leading-3">Beta</div>
+                            </div>
+                          </div>
                           <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
                             <p>
                               This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
@@ -268,7 +273,9 @@ export const ConceptsDocumentViewer = ({
                         return (
                           <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
                             <div className="flex items-center gap-2">
-                              <p className="capitalize text-[15px] font-bold flex-grow">{rootConcept.preferred_label}</p>
+                              <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">
+                                {rootConcept.preferred_label}
+                              </p>
                               {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
                                 <a
                                   href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
@@ -280,7 +287,7 @@ export const ConceptsDocumentViewer = ({
                                 </a>
                               )}
                             </div>
-                            <p>{rootConcept.description}</p>
+                            <p className="pt-1 pb-1">{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts
                                 .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))
@@ -298,9 +305,9 @@ export const ConceptsDocumentViewer = ({
                                         <Button
                                           color="clear"
                                           data-cy="view-document-viewer-concept"
-                                          extraClasses="capitalize flex items-center text-[14px] font-normal pt-1 pb-1"
+                                          extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
                                         >
-                                          {concept.preferred_label} ({conceptCountsById[concept.wikibase_id]})
+                                          {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
                                         </Button>
                                       </Link>
                                     </li>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -18,7 +18,7 @@ import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
-import { ROOT_LEVEL_CONCEPT_LINKS } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPT_LINKS, ROOT_LEVEL_CONCEPTS } from "@utils/processConcepts";
 import { ExternalLinkIcon } from "@components/svg/Icons";
 
 type TProps = {
@@ -265,17 +265,19 @@ export const ConceptsDocumentViewer = ({
                         if (hasConceptsInRootConcept.length === 0) return null;
                         return (
                           <div key={rootConcept.wikibase_id} className="pt-6 pb-6">
-                            <p className="mb-2 capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
-                            {ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label] && (
-                              <a
-                                href={ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label]}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-gray-500 hover:text-blue-600"
-                              >
-                                <ExternalLinkIcon height="12" width="12" />
-                              </a>
-                            )}
+                            <div className="flex items-center gap-2">
+                              <p className="capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
+                              {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
+                                <a
+                                  href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-gray-500 hover:text-blue-600 flex items-center"
+                                >
+                                  <ExternalLinkIcon height="12" width="12" />
+                                </a>
+                              )}
+                            </div>
                             <p>{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -168,6 +168,15 @@ export const ConceptsDocumentViewer = ({
     [onConceptClick]
   );
 
+  const handleClearSearch = useCallback(() => {
+    setState({
+      queryTerm: "",
+      isExactSearch: false,
+    });
+    onQueryTermChange?.("");
+    onExactMatchChange?.(false);
+  }, [onQueryTermChange, onExactMatchChange]);
+
   return (
     <>
       {concepts.length > 0 && (
@@ -194,7 +203,7 @@ export const ConceptsDocumentViewer = ({
                 <div id="document-search" className="flex flex-col gap-2 md:pl-4">
                   {(selectedConcepts.length > 0 || initialQueryTerm) && (
                     <div className="flex gap-2">
-                      <Link className="capitalize hover:no-underline" href={`/documents/${document.slug}`}>
+                      <Link className="capitalize hover:no-underline" href={`/documents/${document.slug}`} onClick={handleClearSearch}>
                         <Button
                           color="dark-dark"
                           data-cy="view-document-viewer-concept"

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -251,11 +251,13 @@ export const ConceptsDocumentViewer = ({
                     <div className="pb-4">
                       <div className="mt-4 grow-0 shrink-0">
                         <div className="mb-4">
-                          <Heading level={4}>Structured data</Heading>
+                          <Heading level={4}>Climate concepts</Heading>
                           <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
                             <p>
-                              Our AI, trained by our in-house climate policy experts and data scientists, has identified these concepts in this
-                              document. <ExternalLink url="https://climatepolicyradar.org/concepts">Learn more</ExternalLink>
+                              This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+                              <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-500 underline">
+                                Learn more
+                              </ExternalLink>
                             </p>
                           </div>
                         </div>
@@ -264,15 +266,15 @@ export const ConceptsDocumentViewer = ({
                         const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
                         if (hasConceptsInRootConcept.length === 0) return null;
                         return (
-                          <div key={rootConcept.wikibase_id} className="pt-6 pb-6">
+                          <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
                             <div className="flex items-center gap-2">
-                              <p className="capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
+                              <p className="capitalize text-[15px] font-bold flex-grow">{rootConcept.preferred_label}</p>
                               {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
                                 <a
                                   href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  className="text-gray-500 hover:text-blue-600 flex items-center"
+                                  className="text-gray-500 hover:text-blue-600 flex items-center absolute right-0 top-6"
                                 >
                                   <ExternalLinkIcon height="12" width="12" />
                                 </a>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -18,6 +18,8 @@ import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
+import { ROOT_LEVEL_CONCEPT_LINKS } from "@utils/processConcepts";
+import { ExternalLinkIcon } from "@components/svg/Icons";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -32,7 +34,6 @@ type TProps = {
   // Callback props for state changes
   onQueryTermChange?: (queryTerm: string) => void;
   onExactMatchChange?: (isExact: boolean) => void;
-  onPassageChange?: (passageIndex: number) => void;
   onConceptClick?: (conceptLabel: string) => void;
 };
 
@@ -58,7 +59,6 @@ export const ConceptsDocumentViewer = ({
   document,
   onQueryTermChange,
   onExactMatchChange,
-  onPassageChange,
   onConceptClick,
 }: TProps) => {
   const [showSearchOptions, setShowSearchOptions] = useState(false);
@@ -136,9 +136,8 @@ export const ConceptsDocumentViewer = ({
     (index: number) => {
       if (document.content_type !== "application/pdf") return;
       setState({ passageIndex: index });
-      onPassageChange?.(index);
     },
-    [document.content_type, onPassageChange]
+    [document.content_type]
   );
 
   const handleSearchInput = useCallback(
@@ -267,6 +266,16 @@ export const ConceptsDocumentViewer = ({
                         return (
                           <div key={rootConcept.wikibase_id} className="pt-6 pb-6">
                             <p className="mb-2 capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
+                            {ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label] && (
+                              <a
+                                href={ROOT_LEVEL_CONCEPT_LINKS[rootConcept.preferred_label]}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-gray-500 hover:text-blue-600"
+                              >
+                                <ExternalLinkIcon height="12" width="12" />
+                              </a>
+                            )}
                             <p>{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -219,7 +219,7 @@ export const ConceptsDocumentViewer = ({
                     <div className="flex gap-2">
                       <div className="flex-1">
                         <SearchForm
-                          placeholder="Search the full text of the document"
+                          placeholder="Search document text"
                           handleSearchInput={handleSearchInput}
                           input={state.queryTerm as string}
                           size="default"
@@ -260,22 +260,34 @@ export const ConceptsDocumentViewer = ({
                     <div className="pb-4">
                       <div className="mt-4 grow-0 shrink-0">
                         <div className="mb-4">
-                          <div className="h-6 rounded-md justify-start items-center gap-2 inline-flex">
-                            <div className="text-neutral-800 text-base font-medium leading-normal">Climate concepts</div>
-                            <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
-                              <div className="text-white text-xs font-medium leading-3">Beta</div>
+                          <div className="h-20 flex-col justify-start items-start gap-3 inline-flex">
+                            <div className="self-stretch h-6 flex-col justify-center items-start gap-4 flex">
+                              <div className="self-stretch rounded-md justify-start items-center gap-2 inline-flex">
+                                <div className="text-neutral-800 text-base font-medium font-['Inter Variable'] leading-normal">Climate concepts</div>
+                                <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
+                                  <div className="text-white text-xs font-medium font-['Inter Variable'] leading-3">Beta</div>
+                                </div>
+                              </div>
                             </div>
-                          </div>
-                          <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
-                            <p>
-                              This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
-                              <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-500 underline">
-                                Learn more
-                              </ExternalLink>
-                            </p>
+                            <div className="self-stretch h-12 flex-col justify-start items-start gap-4 flex">
+                              <div className="self-stretch pl-4 py-1 border-l-2 border-blue-600 justify-center items-center gap-2.5 inline-flex">
+                                <div className="grow shrink basis-0">
+                                  <p className="text-neutral-600 text-sm font-normal font-['Inter Variable'] leading-tight">
+                                    This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+                                    <ExternalLink
+                                      url="https://climatepolicyradar.org/concepts"
+                                      className="text-gray-600 text-sm font-normal font-['Inter Variable'] underline leading-tight"
+                                    >
+                                      Learn more
+                                    </ExternalLink>
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
+
                       {rootConcepts.map((rootConcept) => {
                         const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
                         if (hasConceptsInRootConcept.length === 0) return null;
@@ -296,7 +308,7 @@ export const ConceptsDocumentViewer = ({
                                 </a>
                               )}
                             </div>
-                            <p className="pt-1 pb-1">{rootConcept.description}</p>
+                            <p className="pt-1 pb-1 text-sm">{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts
                                 .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))
@@ -331,11 +343,13 @@ export const ConceptsDocumentViewer = ({
 
                   {selectedConcepts.length > 0 && (
                     <div className="pt-6 pb-6">
-                      <p className="mb-2 capitalize text-[15px] font-bold text-inputSelected">
+                      <p className="mb-2 capitalize text-[15px] font-bold text-inputSelected text-neutral-800 text-base font-medium leading-normal flex-grow">
                         {selectedConcepts.map((concept) => concept.preferred_label).join(", ")}
                       </p>
                       {selectedConcepts.map((concept) => (
-                        <p key={concept.wikibase_id}>{concept.description}</p>
+                        <p key={concept.wikibase_id} className="pt-1 pb-1">
+                          {concept.description}
+                        </p>
                       ))}
                     </div>
                   )}

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -20,7 +20,7 @@ import { ExternalLink } from "@components/ExternalLink";
 import { Targets } from "@components/Targets";
 import { ShowHide } from "@components/controls/ShowHide";
 import { Divider } from "@components/dividers/Divider";
-import { DownChevronIcon, AlertCircleIcon } from "@components/svg/Icons";
+import { DownChevronIcon, AlertCircleIcon, ExternalLinkIcon } from "@components/svg/Icons";
 import Button from "@components/buttons/Button";
 import { LinkWithQuery } from "@components/LinkWithQuery";
 import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
@@ -47,7 +47,7 @@ import { EXAMPLE_SEARCHES } from "@constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { rootLevelConceptsIds } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPTS, ROOT_LEVEL_CONCEPT_LINKS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 
@@ -427,11 +427,13 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           {concepts.length > 0 && (
             <div className="grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
               <div className="mb-4">
-                <Heading level={4}>Structured data</Heading>
+                <Heading level={4}>Climate concepts</Heading>
                 <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
                   <p>
-                    Our AI, trained by our in-house climate policy experts and data scientists, has identified these concepts in this document.{" "}
-                    <ExternalLink url="https://climatepolicyradar.org/concepts">Learn more</ExternalLink>
+                    This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+                    <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-500 underline">
+                      Learn more
+                    </ExternalLink>
                   </p>
                 </div>
               </div>
@@ -439,8 +441,20 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                 const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
                 if (hasConceptsInRootConcept.length === 0) return null;
                 return (
-                  <div key={rootConcept.wikibase_id} className="pt-6 pb-6">
-                    <p className="mb-2 capitalize text-[15px] font-bold">{rootConcept.preferred_label}</p>
+                  <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
+                    <div className="flex items-center gap-2">
+                      <p className="capitalize text-[15px] font-bold flex-grow">{rootConcept.preferred_label}</p>
+                      {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
+                        <a
+                          href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-gray-500 hover:text-blue-600 flex items-center absolute right-0 top-6"
+                        >
+                          <ExternalLinkIcon height="12" width="12" />
+                        </a>
+                      )}
+                    </div>
                     <p>{rootConcept.description}</p>
                     <ul className="flex flex-wrap gap-2 mt-4">
                       {concepts

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -50,6 +50,7 @@ import { getFeatureFlags } from "@utils/featureFlags";
 import { ROOT_LEVEL_CONCEPTS, ROOT_LEVEL_CONCEPT_LINKS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
+import { ConceptsHead } from "@components/concepts/ConceptsHead";
 
 type TProps = {
   page: TFamilyPage;
@@ -426,22 +427,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           {/* TODO: use a panel for this */}
           {concepts.length > 0 && (
             <div className="grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
-              <div className="mb-4">
-                <div className="h-6 rounded-md justify-start items-center gap-2 inline-flex">
-                  <div className="text-neutral-800 text-base font-medium leading-normal">Climate concepts</div>
-                  <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
-                    <div className="text-white text-xs font-medium leading-3">Beta</div>
-                  </div>
-                </div>
-                <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
-                  <p>
-                    This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
-                    <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-500 underline">
-                      Learn more
-                    </ExternalLink>
-                  </p>
-                </div>
-              </div>
+              <ConceptsHead></ConceptsHead>
               {rootConcepts.map((rootConcept) => {
                 const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
                 if (hasConceptsInRootConcept.length === 0) return null;

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -427,7 +427,12 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           {concepts.length > 0 && (
             <div className="grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
               <div className="mb-4">
-                <Heading level={4}>Climate concepts</Heading>
+                <div className="h-6 rounded-md justify-start items-center gap-2 inline-flex">
+                  <div className="text-neutral-800 text-base font-medium leading-normal">Climate concepts</div>
+                  <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
+                    <div className="text-white text-xs font-medium leading-3">Beta</div>
+                  </div>
+                </div>
                 <div className="border-l border-inputSelected border-l-2px pt-1 pb-1 pl-4">
                   <p>
                     This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
@@ -443,7 +448,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                 return (
                   <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
                     <div className="flex items-center gap-2">
-                      <p className="capitalize text-[15px] font-bold flex-grow">{rootConcept.preferred_label}</p>
+                      <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">{rootConcept.preferred_label}</p>
                       {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
                         <a
                           href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
@@ -455,7 +460,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                         </a>
                       )}
                     </div>
-                    <p>{rootConcept.description}</p>
+                    <p className="pt-1 pb-1">{rootConcept.description}</p>
                     <ul className="flex flex-wrap gap-2 mt-4">
                       {concepts
                         .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))
@@ -468,10 +473,10 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                               >
                                 <Button
                                   color="clear"
-                                  data-cy="view-family-concept"
-                                  extraClasses="capitalize flex items-center text-[14px] font-normal pt-1 pb-1"
+                                  data-cy="view-document-viewer-concept"
+                                  extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
                                 >
-                                  {concept.preferred_label} ({conceptCountsById[concept.wikibase_id]})
+                                  {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
                                 </Button>
                               </Link>
                             </li>

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -167,18 +167,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     [router, document.slug]
   );
 
-  const handlePassageChange = useCallback(
-    (passageIndex: number) => {
-      const queryObj = { ...router.query };
-      queryObj.passage = passageIndex.toString();
-      router.push({
-        pathname: `/documents/${document.slug}`,
-        query: queryObj,
-      });
-    },
-    [router, document.slug]
-  );
-
   useEffect(() => {
     let passageMatches: TPassage[] = [];
     let totalNoOfMatches = 0;
@@ -432,7 +420,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
             document={document}
             onQueryTermChange={handleQueryTermChange}
             onExactMatchChange={handleExactMatchChange}
-            onPassageChange={handlePassageChange}
             onConceptClick={handleConceptClick}
           />
         )}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -206,10 +206,24 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   /** Concepts: WIP */
   const [concepts, setConcepts] = useState<TConcept[]>([]);
   const [rootConcepts, setRootConcepts] = useState<TConcept[]>([]);
-  const [selectedConcepts, setSelectedConceptsFilter] = useState<TConcept[]>([]);
-  const conceptCounts: { conceptKey: string; count: number }[] = (vespaFamilyData?.families ?? [])
-    .flatMap((family) => family.hits.flatMap((hit) => Object.entries(hit.concept_counts ?? {}).map(([conceptKey, count]) => ({ conceptKey, count }))))
-    .sort((a, b) => b.count - a.count);
+
+  // Extract unique concept keys and their counts
+  const conceptCounts: { conceptKey: string; count: number }[] = useMemo(() => {
+    const uniqueConceptMap = new Map<string, number>();
+
+    (vespaFamilyData?.families ?? []).forEach((family) => {
+      family.hits.forEach((hit) => {
+        Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
+          const existingCount = uniqueConceptMap.get(conceptKey) || 0;
+          uniqueConceptMap.set(conceptKey, existingCount + count);
+        });
+      });
+    });
+
+    return Array.from(uniqueConceptMap.entries())
+      .map(([conceptKey, count]) => ({ conceptKey, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [vespaFamilyData]);
 
   const conceptFiltersQuery = router.query[QUERY_PARAMS["concept_filters.name"]];
   const conceptFilters = useMemo(
@@ -278,12 +292,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
       const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
 
-      /** Get the selected concept from the query string */
-      const conceptsFilterQuery = router.query[QUERY_PARAMS["concept_filters.name"]];
-      const conceptsFilters = conceptsFilterQuery ? (Array.isArray(conceptsFilterQuery) ? conceptsFilterQuery : [conceptsFilterQuery]) : undefined;
-      const selectedConcepts = conceptsResults.filter((concept) => conceptsFilters?.includes(concept.preferred_label));
-
-      setSelectedConceptsFilter(selectedConcepts);
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);
     });

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -1,7 +1,7 @@
 import { TConcept } from "@types";
 
 // Define the root level concepts
-const ROOT_LEVEL_CONCEPTS = {
+export const ROOT_LEVEL_CONCEPTS = {
   Q1651: "Targets",
   Q709: "Sectors",
   Q975: "Climate risk",


### PR DESCRIPTION
# What's changed

- Update styling to be more inline with Conor's designs
- Pop external links to the right
- Update copy

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
