### PR TITLE
Add concepts popover

### DIFF
--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-type TButtonColours = "light" | "clear" | "ghost" | "secondary" | "dark" | "dark-dark" | "clear-underline";
+type TButtonColours = "light" | "clear" | "clear-blue" | "ghost" | "secondary" | "dark" | "dark-dark" | "clear-underline";
 
 interface ButtonProps {
   children: React.ReactNode;
@@ -46,6 +46,11 @@ export const getButtonClasses = (
     case "clear":
       classes += !disabled
         ? "clear bg-transparent border border-gray-300 hover:border-gray-600 text-gray-600 disabled:border-gray-300 disabled:text-gray-300 disabled:hover:bg-white"
+        : "";
+      break;
+    case "clear-blue":
+      classes += !disabled
+        ? "clear bg-transparent border border-gray-300 hover:border-blue-600 hover:bg-blue-600 hover:text-white text-gray-600 disabled:border-gray-300 disabled:text-gray-300 disabled:hover:bg-white"
         : "";
       break;
     case "clear-underline":

--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -1,31 +1,20 @@
 import { ExternalLink } from "@components/ExternalLink";
 
-export const ConceptsHead = ({}) => {
+export const ConceptsHead = () => {
   return (
     <div className="mb-4">
-      <div className="h-20 flex-col justify-start items-start gap-3 inline-flex">
-        <div className="self-stretch h-6 flex-col justify-center items-start gap-4 flex">
-          <div className="self-stretch rounded-md justify-start items-center gap-2 inline-flex">
-            <div className="text-neutral-800 text-base font-medium font-['Inter Variable'] leading-normal">Climate concepts</div>
-            <div className="p-1 bg-blue-600 rounded-sm justify-center items-center gap-2 flex">
-              <div className="text-white text-xs font-medium font-['Inter Variable'] leading-3">Beta</div>
-            </div>
-          </div>
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-medium text-neutral-800">Climate concepts</h2>
+          <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">Beta</span>
         </div>
-        <div className="self-stretch h-12 flex-col justify-start items-start gap-4 flex">
-          <div className="self-stretch pl-4 py-1 border-l-2 border-blue-600 justify-center items-center gap-2.5 inline-flex">
-            <div className="grow shrink basis-0">
-              <p className="text-neutral-600 text-sm font-normal font-['Inter Variable'] leading-tight">
-                This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
-                <ExternalLink
-                  url="https://climatepolicyradar.org/concepts"
-                  className="text-gray-600 text-sm font-normal font-['Inter Variable'] underline leading-tight"
-                >
-                  Learn more
-                </ExternalLink>
-              </p>
-            </div>
-          </div>
+        <div className="pl-4 border-l-2 border-blue-600">
+          <p className="text-sm text-neutral-600">
+            This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+            <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-600 underline">
+              Learn more
+            </ExternalLink>
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -298,7 +298,7 @@ export const ConceptsDocumentViewer = ({
                                         }}
                                       >
                                         <Button
-                                          color="clear"
+                                          color="clear-blue"
                                           data-cy="view-document-viewer-concept"
                                           extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
                                         >

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -7,7 +7,6 @@ import Button from "@components/buttons/Button";
 import SearchForm from "@components/forms/SearchForm";
 import { MdOutlineTune } from "react-icons/md";
 import { AnimatePresence } from "framer-motion";
-import { ExternalLink } from "@components/ExternalLink";
 import PassageMatches from "@components/PassageMatches";
 import { SearchLimitTooltip } from "@components/tooltip/SearchLimitTooltip";
 import { EmptyPassages } from "./EmptyPassages";
@@ -17,8 +16,6 @@ import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
-import { ROOT_LEVEL_CONCEPT_LINKS, ROOT_LEVEL_CONCEPTS } from "@utils/processConcepts";
-import { ExternalLinkIcon } from "@components/svg/Icons";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
 import { HiOutlineDotsHorizontal } from "react-icons/hi";
 import { ConceptsPopover } from "@components/popover/ConceptsPopover";
@@ -181,10 +178,6 @@ export const ConceptsDocumentViewer = ({
     onExactMatchChange?.(false);
   }, [onQueryTermChange, onExactMatchChange]);
 
-  const togglePopover = useCallback((wikibaseId: string) => {
-    setOpenPopoverIds((current) => (current.includes(wikibaseId) ? current.filter((id) => id !== wikibaseId) : [...current, wikibaseId]));
-  }, []);
-
   return (
     <>
       {concepts.length > 0 && (
@@ -283,7 +276,11 @@ export const ConceptsDocumentViewer = ({
                                 <button
                                   onClick={(e) => {
                                     e.preventDefault();
-                                    togglePopover(rootConcept.wikibase_id);
+                                    setOpenPopoverIds(
+                                      openPopoverIds.includes(rootConcept.wikibase_id)
+                                        ? openPopoverIds.filter((id) => id !== rootConcept.wikibase_id)
+                                        : [...openPopoverIds, rootConcept.wikibase_id]
+                                    );
                                   }}
                                   className="text-neutral-500 flex items-center z-50"
                                 >
@@ -291,8 +288,11 @@ export const ConceptsDocumentViewer = ({
                                 </button>
 
                                 {openPopoverIds.includes(rootConcept.wikibase_id) && (
-                                  <div className="absolute z-50 top-full right-0 mt-2">
-                                    <ConceptsPopover concept={rootConcept} onClose={() => togglePopover(rootConcept.wikibase_id)} />
+                                  <div className="absolute z-50 top-full right-3 mt-2">
+                                    <ConceptsPopover
+                                      concept={rootConcept}
+                                      onClose={() => setOpenPopoverIds(openPopoverIds.filter((id) => id !== rootConcept.wikibase_id))}
+                                    />
                                   </div>
                                 )}
                               </div>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -20,6 +20,7 @@ import useSearch from "@hooks/useSearch";
 import { ROOT_LEVEL_CONCEPT_LINKS, ROOT_LEVEL_CONCEPTS } from "@utils/processConcepts";
 import { ExternalLinkIcon } from "@components/svg/Icons";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
+import { HiOutlineDotsHorizontal } from "react-icons/hi";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -266,7 +267,7 @@ export const ConceptsDocumentViewer = ({
                         const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
                         if (hasConceptsInRootConcept.length === 0) return null;
                         return (
-                          <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
+                          <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative group">
                             <div className="flex items-center gap-2">
                               <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">
                                 {rootConcept.preferred_label}
@@ -276,9 +277,11 @@ export const ConceptsDocumentViewer = ({
                                   href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  className="text-gray-500 hover:text-blue-600 flex items-center absolute right-3 top-6"
+                                  className="text-neutral-500 flex items-center absolute right-3 top-6"
                                 >
-                                  <ExternalLinkIcon height="12" width="12" />
+                                  <div className="text-xl">
+                                    <HiOutlineDotsHorizontal className="group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
+                                  </div>
                                 </a>
                               )}
                             </div>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -21,6 +21,7 @@ import { ROOT_LEVEL_CONCEPT_LINKS, ROOT_LEVEL_CONCEPTS } from "@utils/processCon
 import { ExternalLinkIcon } from "@components/svg/Icons";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
 import { HiOutlineDotsHorizontal } from "react-icons/hi";
+import { ConceptsPopover } from "@components/popover/ConceptsPopover";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -63,6 +64,8 @@ export const ConceptsDocumentViewer = ({
   onConceptClick,
 }: TProps) => {
   const [showSearchOptions, setShowSearchOptions] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
   const [state, setState] = useReducer((prev: any, next: Partial<any>) => ({ ...prev, ...next }), {
     passageIndex: initialPassage,
     isExactSearch: initialExactMatch,
@@ -273,16 +276,24 @@ export const ConceptsDocumentViewer = ({
                                 {rootConcept.preferred_label}
                               </p>
                               {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
-                                <a
-                                  href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-neutral-500 flex items-center absolute right-3 top-6"
-                                >
-                                  <div className="text-xl">
-                                    <HiOutlineDotsHorizontal className="group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
-                                  </div>
-                                </a>
+                                <>
+                                  <a
+                                    href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-neutral-500 flex items-center absolute right-3 top-6"
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      setIsPopoverOpen(true);
+                                    }}
+                                  >
+                                    <div className="text-xl">
+                                      <HiOutlineDotsHorizontal className="group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
+                                    </div>
+                                  </a>
+
+                                  {isPopoverOpen && <ConceptsPopover concept={rootConcept} onClose={() => setIsPopoverOpen(false)} />}
+                                </>
                               )}
                             </div>
                             <p className="pt-1 pb-1 text-sm">{rootConcept.description}</p>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -64,7 +64,7 @@ export const ConceptsDocumentViewer = ({
   onConceptClick,
 }: TProps) => {
   const [showSearchOptions, setShowSearchOptions] = useState(false);
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [openPopoverIds, setOpenPopoverIds] = useState<string[]>([]);
 
   const [state, setState] = useReducer((prev: any, next: Partial<any>) => ({ ...prev, ...next }), {
     passageIndex: initialPassage,
@@ -181,6 +181,10 @@ export const ConceptsDocumentViewer = ({
     onExactMatchChange?.(false);
   }, [onQueryTermChange, onExactMatchChange]);
 
+  const togglePopover = useCallback((wikibaseId: string) => {
+    setOpenPopoverIds((current) => (current.includes(wikibaseId) ? current.filter((id) => id !== wikibaseId) : [...current, wikibaseId]));
+  }, []);
+
   return (
     <>
       {concepts.length > 0 && (
@@ -275,28 +279,24 @@ export const ConceptsDocumentViewer = ({
                               <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">
                                 {rootConcept.preferred_label}
                               </p>
-                              {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
-                                <>
-                                  <a
-                                    href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-neutral-500 flex items-center absolute right-3 top-6"
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      setIsPopoverOpen(true);
-                                    }}
-                                  >
-                                    <div className="text-xl">
-                                      <HiOutlineDotsHorizontal className="group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
-                                    </div>
-                                  </a>
+                              <div className="relative pr-3">
+                                <button
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    togglePopover(rootConcept.wikibase_id);
+                                  }}
+                                  className="text-neutral-500 flex items-center z-50"
+                                >
+                                  <HiOutlineDotsHorizontal className="text-xl group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
+                                </button>
 
-                                  {isPopoverOpen && <ConceptsPopover concept={rootConcept} onClose={() => setIsPopoverOpen(false)} />}
-                                </>
-                              )}
+                                {openPopoverIds.includes(rootConcept.wikibase_id) && (
+                                  <div className="absolute z-50 top-full right-0 mt-2">
+                                    <ConceptsPopover concept={rootConcept} onClose={() => togglePopover(rootConcept.wikibase_id)} />
+                                  </div>
+                                )}
+                              </div>
                             </div>
-                            <p className="pt-1 pb-1 text-sm">{rootConcept.description}</p>
                             <ul className="flex flex-wrap gap-2 mt-4">
                               {concepts
                                 .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -7,19 +7,21 @@ type TProps = {
 
 export const ConceptsPopover = ({ concept, onClose }: TProps) => {
   return (
-    <div className="w-64 h-64 p-4 bg-white rounded-lg shadow-[0px_4px_36px_0px_rgba(0,0,0,0.08)] border border-gray-200 justify-start items-center gap-2.5 inline-flex">
+    <div className="w-64 p-4 bg-white rounded-lg shadow-[0px_4px_36px_0px_rgba(0,0,0,0.08)] border border-gray-200 justify-start items-center gap-2.5 inline-flex">
       <div className="grow shrink basis-0 flex-col justify-start items-start gap-6 inline-flex">
-        <div className="self-stretch h-56 flex-col justify-start items-start gap-6 flex">
-          <div className="self-stretch h-40 flex-col justify-start items-start gap-1 flex">
+        <div className="self-stretch flex-col justify-start items-start gap-6 flex">
+          <div className="self-stretch flex-col justify-start items-start gap-1 flex">
             <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Description</div>
-            <div className="self-stretch text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight">{concept.description}</div>
+            <div className="self-stretch text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight">
+              {concept?.description || "No description available"}
+            </div>
           </div>
           <div className="self-stretch h-10 flex-col justify-start items-start gap-1 flex">
             <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Learn more</div>
             <div className="self-stretch">
-              <span class="text-neutral-800 text-sm font-normal font-['Inter Variable'] underline leading-tight">View the structured data</span>
-              <span class="text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight"> </span>
-              <span class="text-neutral-500 text-sm font-normal font-['Inter Variable'] leading-tight">↗</span>
+              <span className="text-neutral-800 text-sm font-normal font-['Inter Variable'] underline leading-tight">View the structured data</span>
+              <span className="text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight"> </span>
+              <span className="text-neutral-500 text-sm font-normal font-['Inter Variable'] leading-tight">↗</span>
             </div>
           </div>
         </div>

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@components/ExternalLink";
 import { TConcept } from "@types";
 import { getConceptStoreLink } from "@utils/getConceptStoreLink";
 
@@ -17,10 +18,10 @@ export const ConceptsPopover = ({ concept, onClose }: TProps) => {
         <div className="space-y-1">
           <h3 className="text-xs font-medium text-neutral-500">Learn more</h3>
           <div className="text-sm">
-            <a href={getConceptStoreLink(concept.wikibase_id)} className="text-neutral-800 underline" target="_blank">
+            <ExternalLink url={getConceptStoreLink(concept.wikibase_id)} className="text-neutral-800 underline">
               View the structured data
               <span className="text-neutral-500 ml-1">↗</span>
-            </a>
+            </ExternalLink>
           </div>
         </div>
       </div>

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,4 +1,5 @@
 import { TConcept } from "@types";
+import { getConceptStoreLink } from "@utils/getConceptStoreLink";
 
 type TProps = {
   concept?: TConcept;
@@ -16,7 +17,7 @@ export const ConceptsPopover = ({ concept, onClose }: TProps) => {
         <div className="space-y-1">
           <h3 className="text-xs font-medium text-neutral-500">Learn more</h3>
           <div className="text-sm">
-            <a href="#" className="text-neutral-800 underline">
+            <a href={getConceptStoreLink(concept.wikibase_id)} className="text-neutral-800 underline" target="_blank">
               View the structured data
               <span className="text-neutral-500 ml-1">↗</span>
             </a>

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,0 +1,29 @@
+import { TConcept } from "@types";
+
+type TProps = {
+  concept?: TConcept;
+  onClose: () => void;
+};
+
+export const ConceptsPopover = ({ concept, onClose }: TProps) => {
+  return (
+    <div className="w-64 h-64 p-4 bg-white rounded-lg shadow-[0px_4px_36px_0px_rgba(0,0,0,0.08)] border border-gray-200 justify-start items-center gap-2.5 inline-flex">
+      <div className="grow shrink basis-0 flex-col justify-start items-start gap-6 inline-flex">
+        <div className="self-stretch h-56 flex-col justify-start items-start gap-6 flex">
+          <div className="self-stretch h-40 flex-col justify-start items-start gap-1 flex">
+            <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Description</div>
+            <div className="self-stretch text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight">{concept.description}</div>
+          </div>
+          <div className="self-stretch h-10 flex-col justify-start items-start gap-1 flex">
+            <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Learn more</div>
+            <div className="self-stretch">
+              <span class="text-neutral-800 text-sm font-normal font-['Inter Variable'] underline leading-tight">View the structured data</span>
+              <span class="text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight"> </span>
+              <span class="text-neutral-500 text-sm font-normal font-['Inter Variable'] leading-tight">↗</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -7,22 +7,19 @@ type TProps = {
 
 export const ConceptsPopover = ({ concept, onClose }: TProps) => {
   return (
-    <div className="w-64 p-4 bg-white rounded-lg shadow-[0px_4px_36px_0px_rgba(0,0,0,0.08)] border border-gray-200 justify-start items-center gap-2.5 inline-flex">
-      <div className="grow shrink basis-0 flex-col justify-start items-start gap-6 inline-flex">
-        <div className="self-stretch flex-col justify-start items-start gap-6 flex">
-          <div className="self-stretch flex-col justify-start items-start gap-1 flex">
-            <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Description</div>
-            <div className="self-stretch text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight">
-              {concept?.description || "No description available"}
-            </div>
-          </div>
-          <div className="self-stretch h-10 flex-col justify-start items-start gap-1 flex">
-            <div className="self-stretch text-neutral-500 text-xs font-medium font-['Inter Variable'] leading-none">Learn more</div>
-            <div className="self-stretch">
-              <span className="text-neutral-800 text-sm font-normal font-['Inter Variable'] underline leading-tight">View the structured data</span>
-              <span className="text-neutral-800 text-sm font-normal font-['Inter Variable'] leading-tight"> </span>
-              <span className="text-neutral-500 text-sm font-normal font-['Inter Variable'] leading-tight">↗</span>
-            </div>
+    <div className="w-64 p-4 bg-white rounded-lg shadow-md border border-gray-200 flex items-start">
+      <div className="space-y-6 w-full">
+        <div className="space-y-1">
+          <h3 className="text-xs font-medium text-neutral-500">Description</h3>
+          <p className="text-sm text-neutral-800">{concept?.description || "No description available"}</p>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-xs font-medium text-neutral-500">Learn more</h3>
+          <div className="text-sm">
+            <a href="#" className="text-neutral-800 underline">
+              View the structured data
+              <span className="text-neutral-500 ml-1">↗</span>
+            </a>
           </div>
         </div>
       </div>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -51,6 +51,7 @@ import { ROOT_LEVEL_CONCEPTS, ROOT_LEVEL_CONCEPT_LINKS, rootLevelConceptsIds } f
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
+import { getConceptStoreLink } from "@utils/getConceptStoreLink";
 
 type TProps = {
   page: TFamilyPage;
@@ -439,9 +440,9 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                   <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative">
                     <div className="flex items-center gap-2">
                       <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">{rootConcept.preferred_label}</p>
-                      {ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]] && (
+                      {getConceptStoreLink(rootConcept.wikibase_id) && (
                         <a
-                          href={ROOT_LEVEL_CONCEPT_LINKS[ROOT_LEVEL_CONCEPTS[rootConcept.wikibase_id]]}
+                          href={getConceptStoreLink(rootConcept.wikibase_id)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-gray-500 hover:text-blue-600 flex items-center absolute right-0 top-6"

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -441,14 +441,12 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                     <div className="flex items-center gap-2">
                       <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">{rootConcept.preferred_label}</p>
                       {getConceptStoreLink(rootConcept.wikibase_id) && (
-                        <a
-                          href={getConceptStoreLink(rootConcept.wikibase_id)}
-                          target="_blank"
-                          rel="noopener noreferrer"
+                        <ExternalLink
+                          url={getConceptStoreLink(rootConcept.wikibase_id)}
                           className="text-gray-500 hover:text-blue-600 flex items-center absolute right-0 top-6"
                         >
                           <ExternalLinkIcon height="12" width="12" />
-                        </a>
+                        </ExternalLink>
                       )}
                     </div>
                     <p className="pt-1 pb-1">{rootConcept.description}</p>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -47,7 +47,7 @@ import { EXAMPLE_SEARCHES } from "@constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { ROOT_LEVEL_CONCEPTS, ROOT_LEVEL_CONCEPT_LINKS, rootLevelConceptsIds } from "@utils/processConcepts";
+import { rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";

--- a/src/utils/getConceptStoreLink.ts
+++ b/src/utils/getConceptStoreLink.ts
@@ -1,0 +1,3 @@
+export function getConceptStoreLink(wikibase_id: string) {
+  return `https://climatepolicyradar.wikibase.cloud/wiki/Item:${wikibase_id}`;
+}

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -85,11 +85,3 @@ export const processConcepts = (concepts: (TConcept & { count: number })[]): Roo
 
   return conceptMap;
 };
-
-export const ROOT_LEVEL_CONCEPT_LINKS = Object.entries(ROOT_LEVEL_CONCEPTS).reduce(
-  (acc, [qNum, name]) => {
-    acc[name] = `https://climatepolicyradar.wikibase.cloud/wiki/Item:${qNum}`;
-    return acc;
-  },
-  {} as { [key: string]: string }
-);


### PR DESCRIPTION
# What's changed

Add concepts popover as per this [figma board](https://www.figma.com/design/FHu4NDZiDiCBnpbtD5JxXm/Knowledge-Graph-Feb-25-release?node-id=2103-590&t=Kcylcu6SUR3rNeKm-1)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
