### PR TITLE
Add error handling for concepts S3 GET

### DIFF
--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -347,7 +347,7 @@ export const ConceptsDocumentViewer = ({
                   <>
                     {selectedConcepts.length > 0 && (
                       <>
-                        <div className="my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
+                        <div className="border-gray-200 my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
                           <div className="mb-2">{state.totalNoOfMatches} matches in this document</div>
                         </div>
                         <div

--- a/src/components/documents/EmptyPassages.tsx
+++ b/src/components/documents/EmptyPassages.tsx
@@ -5,7 +5,7 @@ type TProps = {
 };
 
 export const EmptyPassages = ({ hasQueryString }: TProps) => (
-  <div className="flex flex-col gap-4 flex-1 mt-4 pt-10 border-t text-center text-gray-600 px-4">
+  <div className="border-gray-200 flex flex-col gap-4 flex-1 mt-4 pt-10 border-t text-center text-gray-600 px-4">
     <div className="text-blue-800 flex justify-center items-center">
       <div className="rounded-full bg-blue-50 p-6 mb-2">
         <FindInDocIcon width="48" height="48" />

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -47,7 +47,7 @@ import { EXAMPLE_SEARCHES } from "@constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { rootLevelConceptsIds } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
@@ -207,19 +207,47 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     /** Get `rootConcepts` */
     const rootConceptsS3Promises = rootLevelConceptsIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch((error) => {
+          // Return a minimal object to allow partial processing
+          return {
+            wikibase_id: conceptId,
+            preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Other",
+            description: "Concept data unavailable",
+            subconcept_of: [],
+          };
+        });
     });
 
     /** Get concepts associated with the family */
     const conceptsS3Promises = conceptIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch((error) => {
+          // Return null to allow filtering out failed fetches
+          return null;
+        });
     });
 
     /** Get `rootConcepts` and `concepts` from S3 */
     Promise.all([...rootConceptsS3Promises, ...conceptsS3Promises]).then((allConcepts) => {
-      const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
-      const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
+      // Filter out any null results from concept fetches
+      const filteredConcepts = allConcepts.filter(Boolean);
+
+      const rootConceptsResults = filteredConcepts.slice(0, rootConceptsS3Promises.length);
+      const conceptsResults = filteredConcepts.slice(rootConceptsS3Promises.length);
 
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);
@@ -434,7 +462,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           </SingleCol>
           {/* TODO: use a panel for this */}
           {concepts.length > 0 && (
-            <div className="grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
+            <div className="border-gray-200 grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
               <ConceptsHead></ConceptsHead>
               {rootConcepts.map((rootConcept) => {
                 const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -28,7 +28,7 @@ import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 
 import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TConcept } from "@types";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { rootLevelConceptsIds } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsDocumentViewer } from "@components/documents/ConceptsDocumentViewer";
 
@@ -264,7 +264,22 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     /** Get `rootConcepts` */
     const rootConceptsS3Promises = rootLevelConceptsIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch(() => {
+          // Return a minimal object to allow partial processing
+          return {
+            wikibase_id: conceptId,
+            preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Unknown Concept",
+            description: "Concept data unavailable",
+            subconcept_of: [],
+          };
+        });
     });
 
     /** Get concepts associated with the family */
@@ -272,13 +287,26 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       // the concept ID is in the shape of `Q100:concept name`
       const conceptId = conceptKey.split(":")[0];
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch(() => {
+          // Return null to allow filtering out failed fetches
+          return null;
+        });
     });
 
     /** Get `rootConcepts` and `concepts` from S3 */
     Promise.all([...rootConceptsS3Promises, ...conceptsS3Promises]).then((allConcepts) => {
-      const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
-      const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
+      // Filter out any null results from concept fetches
+      const filteredConcepts = allConcepts.filter(Boolean);
+
+      const rootConceptsResults = filteredConcepts.slice(0, rootConceptsS3Promises.length);
+      const conceptsResults = filteredConcepts.slice(rootConceptsS3Promises.length);
 
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);


### PR DESCRIPTION
# What's changed

Some concepts have been removed from the concept store with redirects setup for them in wikibase so they don't have S3 objects attached to them. There was no error handling on this GET request, so if we tried to fetch concept data using a wikibase ID that no longer exists, the concept panel would not render. Have updated this so if we don't find data for a specific concept, we skip over it and still allow the concept panel to render.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
