### PR TITLE
fix: use main or other documents link on concepts link

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -491,10 +491,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                           return (
                             <li key={concept.wikibase_id}>
                               {conceptDocumentLink ? (
-                                <Link
-                                  className="capitalize hover:no-underline"
-                                  href={`/documents/${conceptDocumentLink}?cfn=${concept.preferred_label}`}
-                                >
+                                <Link className="capitalize hover:no-underline" href={`${conceptDocumentLink}?cfn=${concept.preferred_label}`}>
                                   <Button
                                     color="clear"
                                     data-cy="view-document-viewer-concept"

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -248,6 +248,13 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     });
   });
 
+  let conceptDocumentLink: string | undefined;
+  if (mainDocuments.length === 1) {
+    conceptDocumentLink = `/documents/${mainDocuments[0].slug}`;
+  } else if (mainDocuments.length === 0 && otherDocuments.length === 1) {
+    conceptDocumentLink = `/documents/${otherDocuments[0].slug}`;
+  }
+
   return (
     <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)} theme={theme}>
       <Script id="analytics">
@@ -483,7 +490,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                             <li key={concept.wikibase_id}>
                               <Link
                                 className="capitalize hover:no-underline"
-                                href={`/documents/${mainDocuments[0].slug}?cfn=${concept.preferred_label}`}
+                                href={`/documents/${conceptDocumentLink}?cfn=${concept.preferred_label}`}
                               >
                                 <Button
                                   color="clear"

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -249,10 +249,12 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   });
 
   let conceptDocumentLink: string | undefined;
-  if (mainDocuments.length === 1) {
+  if (mainDocuments.length > 0) {
     conceptDocumentLink = `/documents/${mainDocuments[0].slug}`;
-  } else if (mainDocuments.length === 0 && otherDocuments.length === 1) {
+  } else if (otherDocuments.length > 0) {
     conceptDocumentLink = `/documents/${otherDocuments[0].slug}`;
+  } else {
+    conceptDocumentLink = undefined;
   }
 
   return (
@@ -488,18 +490,29 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                         .map((concept) => {
                           return (
                             <li key={concept.wikibase_id}>
-                              <Link
-                                className="capitalize hover:no-underline"
-                                href={`/documents/${conceptDocumentLink}?cfn=${concept.preferred_label}`}
-                              >
+                              {conceptDocumentLink ? (
+                                <Link
+                                  className="capitalize hover:no-underline"
+                                  href={`/documents/${conceptDocumentLink}?cfn=${concept.preferred_label}`}
+                                >
+                                  <Button
+                                    color="clear"
+                                    data-cy="view-document-viewer-concept"
+                                    extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
+                                  >
+                                    {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
+                                  </Button>
+                                </Link>
+                              ) : (
                                 <Button
                                   color="clear"
                                   data-cy="view-document-viewer-concept"
                                   extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
+                                  disabled
                                 >
                                   {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
                                 </Button>
-                              </Link>
+                              )}
                             </li>
                           );
                         })}


### PR DESCRIPTION
# What's changed
- use either `mainDocument` || `otherDocument` slug for link through to document page filtered by concept

This is because there is not always a main document.
From what I can tell if there isn't, there will always be other documents.

We could probably do better typing here, but it fixes the bug for now.

> [!CAUTION]
> This is a really annoying area where our [`strict: false` in our tsconfig](https://github.com/climatepolicyradar/navigator-frontend/blob/main/tsconfig.json#L8) isn't catching things it should...


## To replicate
- turn on concepts-v1 feature flag
- visit https://app.climatepolicyradar.org/document/regulation-eu-2021-82-adaptation-strategy_ba42?q=Adaptation+strategy 

## Proposed version

- [x] Patch
