### PR TITLE
wip: add strict: true to tsconfig

### DIFF
--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -46,9 +46,11 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
             <InputRadio
               key={option.slug}
               label={option.label}
+              // @ts-expect-error -- TODO(strict)
               checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option.slug)}
               onChange={() => null} // supress normal radio behaviour to allow to deselection
               onClick={() => {
+                // @ts-expect-error -- TODO(strict)
                 handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option.slug, true);
               }}
               name={`${filter.taxonomyKey}=${option.slug}`}
@@ -57,8 +59,10 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
             <InputCheck
               key={option.slug}
               label={option.label}
+              // @ts-expect-error -- TODO(strict)
               checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option.slug)}
               onChange={() => {
+                // @ts-expect-error -- TODO(strict)
                 handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option.slug);
               }}
               name={`${filter.taxonomyKey}=${option.slug}`}
@@ -81,23 +85,31 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
   } else if (filter.dependentFilterKey) {
     // Check whether the filter has a dependanct filter, if it does load the taxonomy values for the dependent filter
     const dependentFilter = themeConfig.filters.find((f) => f.taxonomyKey === filter.dependentFilterKey);
+    // @ts-expect-error -- TODO(strict)
     const queryDependentFilter = query[QUERY_PARAMS[dependentFilter?.taxonomyKey]] || [];
     // If no filter of a given dependency is selected, load all dependency taxonomy values
     if (queryDependentFilter.length === 0) {
+      // @ts-expect-error -- TODO(strict)
       for (let index = 0; index < dependentFilter.options.length; index++) {
+        // @ts-expect-error -- TODO(strict)
         const option = dependentFilter.options[index];
+        // @ts-expect-error -- TODO(strict)
         const taxonomyAllowedValues = getTaxonomyAllowedValues(option.corporaKey, filter.taxonomyKey, corpus_types);
         options = options.concat(taxonomyAllowedValues);
       }
     } else {
       // Otherwise, load the taxonomy values for the selected dependency filter(s)
       if (typeof queryDependentFilter === "string") {
+        // @ts-expect-error -- TODO(strict)
         const filterCorporaKey = dependentFilter.options.find((option) => option.slug === queryDependentFilter)?.corporaKey;
+        // @ts-expect-error -- TODO(strict)
         const taxonomyAllowedValues = getTaxonomyAllowedValues(filterCorporaKey, filter.taxonomyKey, corpus_types);
         options = options.concat(taxonomyAllowedValues);
       } else {
         for (let index = 0; index < queryDependentFilter.length; index++) {
+          // @ts-expect-error -- TODO(strict)
           const filterCorporaKey = dependentFilter.options.find((option) => option.slug === queryDependentFilter[index])?.corporaKey;
+          // @ts-expect-error -- TODO(strict)
           const taxonomyAllowedValues = getTaxonomyAllowedValues(filterCorporaKey, filter.taxonomyKey, corpus_types);
           options = options.concat(taxonomyAllowedValues);
         }
@@ -113,9 +125,11 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputRadio
         key={option}
         label={option}
+        // @ts-expect-error -- TODO(strict)
         checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option)}
         onChange={() => null} // supress normal radio behaviour to allow to deselection
         onClick={() => {
+          // @ts-expect-error -- TODO(strict)
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option, true);
         }}
         name={`${filter.taxonomyKey}=${option}`}
@@ -124,8 +138,10 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
       <InputCheck
         key={option}
         label={option}
+        // @ts-expect-error -- TODO(strict)
         checked={query && filterIsSelected(query[QUERY_PARAMS[filter.taxonomyKey]], option)}
         onChange={() => {
+          // @ts-expect-error -- TODO(strict)
           handleFilterChange(QUERY_PARAMS[filter.taxonomyKey], option);
         }}
         name={`${filter.taxonomyKey}=${option}`}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -67,6 +67,7 @@ const SearchFilters = ({
   const [showClear, setShowClear] = useState(false);
 
   const {
+    // @ts-expect-error -- TODO(strict)
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
   } = searchCriteria;
 
@@ -103,10 +104,12 @@ const SearchFilters = ({
       </div>
 
       <AppliedFilters filterChange={handleFilterChange} />
-
+      {/* @ts-expect-error -- TODO(strict) */}
       {themeConfigStatus === "success" && themeConfig.categories && (
+        // @ts-expect-error -- TODO(strict)
         <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} startOpen>
           <InputListContainer>
+            {/* @ts-expect-error -- TODO(strict) */}
             {themeConfig.categories?.options?.map((option) => (
               <InputRadio
                 key={option.slug}
@@ -115,6 +118,7 @@ const SearchFilters = ({
                 onChange={() => {
                   handleDocumentCategoryClick(option.slug);
                 }}
+                // @ts-expect-error -- TODO(strict)
                 name={`${themeConfig.categories.label}-${option.slug}`}
               />
             ))}
@@ -123,14 +127,17 @@ const SearchFilters = ({
       )}
 
       {themeConfigStatus === "success" &&
+        // @ts-expect-error -- TODO(strict)
         themeConfig.filters.map((filter) => {
           // If the filter is not in the selected category, don't display it
+          // @ts-expect-error -- TODO(strict)
           if (!canDisplayFilter(filter, query, themeConfig)) return;
           return (
             <Accordian
               title={filter.label}
               data-cy={filter.label}
               key={filter.label}
+              // @ts-expect-error -- TODO(strict)
               startOpen={filter.startOpen === "true" || !!query[QUERY_PARAMS[filter.taxonomyKey]]}
               showFade={filter.showFade}
             >
@@ -140,6 +147,7 @@ const SearchFilters = ({
                   query={query}
                   handleFilterChange={handleFilterChange}
                   corpus_types={corpus_types}
+                  // @ts-expect-error -- TODO(strict)
                   themeConfig={themeConfig}
                 />
               </InputListContainer>
@@ -148,6 +156,7 @@ const SearchFilters = ({
         })}
 
       <Accordian
+        // @ts-expect-error -- TODO(strict)
         title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="regions"
         startOpen={!!query[QUERY_PARAMS.region]}
@@ -168,6 +177,7 @@ const SearchFilters = ({
       </Accordian>
 
       <Accordian
+        // @ts-expect-error -- TODO(strict)
         title={getFilterLabel("Published jurisdiction", "country", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="countries"
         overflowOverride
@@ -186,6 +196,7 @@ const SearchFilters = ({
       </Accordian>
 
       <Accordian
+        // @ts-expect-error -- TODO(strict)
         title={getFilterLabel("Date", "date", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="date-range"
         startOpen={!!query[QUERY_PARAMS.year_range]}

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -98,7 +98,9 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   const breadcrumbGeography =
     page.geographies && page.geographies.length > 1 ? null : { label: geographyName, href: `/geographies/${geographySlug}` };
 
+  // @ts-expect-error -- TODO(strict)
   let searchFamily: TMatchedFamily = null;
+  // @ts-expect-error -- TODO(strict)
   const { status, families } = useSearch(router.query, page.import_id, null, !!router.query[QUERY_PARAMS.query_string], MAX_PASSAGES);
   if (!!router.query[QUERY_PARAMS.query_string]) {
     families.forEach((family) => {
@@ -161,6 +163,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   // Search handlers
   const handleSearchInput = (term: string) => {
     const queryObj = {};
+    // @ts-expect-error -- TODO(strict)
     queryObj[QUERY_PARAMS.query_string] = term;
     if (term === "") return false;
     // if the family only has one main document, redirect to that document
@@ -199,6 +202,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
 
   const conceptCountsById = conceptCounts.reduce((acc, { conceptKey, count }) => {
     const conceptId = conceptKey.split(":")[0];
+    // @ts-expect-error -- TODO(strict)
     acc[conceptId] = count;
     return acc;
   }, {});
@@ -215,6 +219,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           // Return a minimal object to allow partial processing
           return {
             wikibase_id: conceptId,
+            // @ts-expect-error -- TODO(strict)
             preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Other",
             description: "Concept data unavailable",
             subconcept_of: [],
@@ -249,6 +254,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   });
 
   return (
+    // @ts-expect-error -- TODO(strict)
     <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)} theme={theme}>
       <Script id="analytics">
         analytics.category = "{page.category}"; analytics.type = "{getDocumentCategories().join(",")}"; analytics.geography = "
@@ -261,6 +267,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
         data-analytics-geography={page.geographies?.join(",")}
       >
         <SubNav>
+          {/* @ts-expect-error -- TODO(strict) */}
           <BreadCrumbs geography={breadcrumbGeography} category={breadcrumbCategory} label={page.title} />
         </SubNav>
         <MultiCol>
@@ -490,6 +497,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                                   data-cy="view-document-viewer-concept"
                                   extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
                                 >
+                                  {/* @ts-expect-error -- TODO(strict) */}
                                   {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
                                 </Button>
                               </Link>
@@ -516,6 +524,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const featureFlags = await getFeatureFlags(context.req.cookies);
 
   const theme = process.env.THEME;
+  // @ts-expect-error -- TODO(strict)
   const id = context.params.id;
   const client = new ApiClient(process.env.API_URL);
 
@@ -539,6 +548,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     // TODO: handle error more elegantly
   }
 
+  // @ts-expect-error -- TODO(strict)
   if (familyData) {
     try {
       const targetsRaw = await axios.get<TTarget[]>(`${process.env.S3_PATH}/families/${familyData.import_id}.json`);
@@ -546,6 +556,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     } catch (error) {}
   }
 
+  // @ts-expect-error -- TODO(strict)
   if (familyData) {
     try {
       const configRaw = await client.getConfig();
@@ -554,7 +565,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       corpus_types = configRaw.data.corpus_types;
     } catch (error) {}
   }
-
+  // @ts-expect-error -- TODO(strict)
   if (!familyData) {
     return {
       notFound: true,
@@ -566,9 +577,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       page: familyData,
       targets: targetsData,
       countries: countriesData,
+      // @ts-expect-error -- TODO(strict)
       corpus_types,
       theme: theme,
       featureFlags,
+      // @ts-expect-error -- TODO(strict)
       vespaFamilyData: vespaFamilyData ?? null,
     },
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
# What's changed
- uses tsconfig `strict: true`. This is mainly to not ignore nullish values through the codebase which has allowed us to release bugs and is generally considered not safe.

This is more of an RFC to see if we like this approach as it does mucky the codebase a lot, but means we can confidently move forward with it on, and remove the `expect-errors` as we go.

It would also come with a commit hash in https://github.com/climatepolicyradar/navigator-frontend/blob/main/.git-blame-ignore-revs

- [x] Patch
