### PR TITLE
fix: add contents: write to merge_to_main workflow

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: write
 env:
   NODE_ENV: production
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,7 @@
 name: Pull request
 on: pull_request
 permissions: read-all
+
 jobs:
   check-auto-tagging-will-work:
     uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v17


### PR DESCRIPTION
# What's changed
- adds `contents: write` to `merge_to_main` workflow

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
