### PR TITLE
fix: use permissions: write-all on merge_to_main

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+# trunk-ignore(checkov/CKV2_GHA_1)
+permissions: write-all
 env:
   NODE_ENV: production
 jobs:


### PR DESCRIPTION
# What's changed
Adds write-all on merge to main.

Currently our build is failing and I would like to rule out permissions.


## Proposed version


- [x] Patch
