### PR TITLE
Feature/app 299 update family page concepts styling

### DIFF
--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -11,7 +11,7 @@ export const ConceptsHead = () => {
           <Heading level={2} className="text-base font-medium text-neutral-800">
             Climate concepts
           </Heading>
-          <Label labelText="Beta"></Label>
+          <Label>Beta</Label>
         </div>
         <Quote>
           <>

--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -1,21 +1,26 @@
 import { ExternalLink } from "@components/ExternalLink";
+import { Heading } from "@components/typography/Heading";
+import { Label } from "@components/labels/Label";
+import { Quote } from "@components/typography/Quote";
 
 export const ConceptsHead = () => {
   return (
     <div className="mb-4">
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-base font-medium text-neutral-800">Climate concepts</h2>
-          <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">Beta</span>
+          <Heading level={2} className="text-base font-medium text-neutral-800">
+            Climate concepts
+          </Heading>
+          <Label labelText="Beta"></Label>
         </div>
-        <div className="pl-4 border-l-2 border-blue-600">
-          <p className="text-sm text-neutral-600">
+        <Quote>
+          <>
             This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
             <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-600 underline">
               Learn more
             </ExternalLink>
-          </p>
-        </div>
+          </>
+        </Quote>
       </div>
     </div>
   );

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -1,0 +1,99 @@
+import { ExternalLink } from "@components/ExternalLink";
+import { Heading } from "@components/typography/Heading";
+import { Label } from "@components/labels/Label";
+import { Quote } from "@components/typography/Quote";
+import { ConceptsHead } from "./ConceptsHead";
+import { HiOutlineDotsHorizontal } from "react-icons/hi";
+import { ConceptsPopover } from "@components/popover/ConceptsPopover";
+import Button from "@components/buttons/Button";
+import Link from "next/link";
+import { TConcept } from "@types";
+import { useCallback, useState } from "react";
+
+type TProps = {
+  concepts: TConcept[];
+  rootConcepts: TConcept[];
+  conceptCountsById: Record<string, number>;
+  onConceptClick?: (conceptLabel: string) => void;
+};
+
+export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onConceptClick }: TProps) => {
+  const [openPopoverIds, setOpenPopoverIds] = useState<string[]>([]);
+
+  const handleConceptClick = useCallback(
+    (conceptLabel: string) => {
+      onConceptClick?.(conceptLabel);
+    },
+    [onConceptClick]
+  );
+
+  return (
+    <div className="pb-4">
+      <div className="mt-4 grow-0 shrink-0">
+        <ConceptsHead></ConceptsHead>
+      </div>
+
+      {rootConcepts.map((rootConcept) => {
+        const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
+        if (hasConceptsInRootConcept.length === 0) return null;
+        return (
+          <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative group">
+            <div className="flex items-center gap-2">
+              <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">{rootConcept.preferred_label}</p>
+              <div className="relative pr-3">
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setOpenPopoverIds(
+                      openPopoverIds.includes(rootConcept.wikibase_id)
+                        ? openPopoverIds.filter((id) => id !== rootConcept.wikibase_id)
+                        : [...openPopoverIds, rootConcept.wikibase_id]
+                    );
+                  }}
+                  className="text-neutral-500 flex items-center z-50"
+                >
+                  <HiOutlineDotsHorizontal className="text-xl group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
+                </button>
+
+                {openPopoverIds.includes(rootConcept.wikibase_id) && (
+                  <div className="absolute z-50 top-full right-3 mt-2">
+                    <ConceptsPopover
+                      concept={rootConcept}
+                      onClose={() => setOpenPopoverIds(openPopoverIds.filter((id) => id !== rootConcept.wikibase_id))}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+            <ul className="flex flex-wrap gap-2 mt-4">
+              {concepts
+                .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))
+                .map((concept) => {
+                  return (
+                    <li key={concept.wikibase_id}>
+                      <Link
+                        className="capitalize hover:no-underline"
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleConceptClick?.(concept.preferred_label);
+                        }}
+                      >
+                        <Button
+                          color="clear-blue"
+                          data-cy="view-document-viewer-concept"
+                          extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
+                        >
+                          {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
+                        </Button>
+                      </Link>
+                    </li>
+                  );
+                })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -19,6 +19,7 @@ import useSearch from "@hooks/useSearch";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
 import { HiOutlineDotsHorizontal } from "react-icons/hi";
 import { ConceptsPopover } from "@components/popover/ConceptsPopover";
+import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -161,14 +162,6 @@ export const ConceptsDocumentViewer = ({
     [onExactMatchChange]
   );
 
-  const handleConceptClick = useCallback(
-    (conceptLabel: string) => {
-      setState({ passageIndex: 0 });
-      onConceptClick?.(conceptLabel);
-    },
-    [onConceptClick]
-  );
-
   const handleClearSearch = useCallback(() => {
     setState({
       queryTerm: "",
@@ -258,75 +251,12 @@ export const ConceptsDocumentViewer = ({
                   )}
 
                   {selectedConcepts.length === 0 && !initialQueryTerm && (
-                    <div className="pb-4">
-                      <div className="mt-4 grow-0 shrink-0">
-                        <ConceptsHead></ConceptsHead>
-                      </div>
-
-                      {rootConcepts.map((rootConcept) => {
-                        const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));
-                        if (hasConceptsInRootConcept.length === 0) return null;
-                        return (
-                          <div key={rootConcept.wikibase_id} className="pt-6 pb-6 relative group">
-                            <div className="flex items-center gap-2">
-                              <p className="capitalize text-neutral-800 text-base font-medium leading-normal flex-grow">
-                                {rootConcept.preferred_label}
-                              </p>
-                              <div className="relative pr-3">
-                                <button
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    setOpenPopoverIds(
-                                      openPopoverIds.includes(rootConcept.wikibase_id)
-                                        ? openPopoverIds.filter((id) => id !== rootConcept.wikibase_id)
-                                        : [...openPopoverIds, rootConcept.wikibase_id]
-                                    );
-                                  }}
-                                  className="text-neutral-500 flex items-center z-50"
-                                >
-                                  <HiOutlineDotsHorizontal className="text-xl group-hover:border-neutral-200 border-transparent border-1 rounded-full p-0.5" />
-                                </button>
-
-                                {openPopoverIds.includes(rootConcept.wikibase_id) && (
-                                  <div className="absolute z-50 top-full right-3 mt-2">
-                                    <ConceptsPopover
-                                      concept={rootConcept}
-                                      onClose={() => setOpenPopoverIds(openPopoverIds.filter((id) => id !== rootConcept.wikibase_id))}
-                                    />
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                            <ul className="flex flex-wrap gap-2 mt-4">
-                              {concepts
-                                .filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id))
-                                .map((concept) => {
-                                  return (
-                                    <li key={concept.wikibase_id}>
-                                      <Link
-                                        className="capitalize hover:no-underline"
-                                        href="#"
-                                        onClick={(e) => {
-                                          e.preventDefault();
-                                          handleConceptClick?.(concept.preferred_label);
-                                        }}
-                                      >
-                                        <Button
-                                          color="clear-blue"
-                                          data-cy="view-document-viewer-concept"
-                                          extraClasses="capitalize flex items-center text-neutral-600 text-sm font-normal leading-tight"
-                                        >
-                                          {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
-                                        </Button>
-                                      </Link>
-                                    </li>
-                                  );
-                                })}
-                            </ul>
-                          </div>
-                        );
-                      })}
-                    </div>
+                    <ConceptsPanel
+                      rootConcepts={rootConcepts}
+                      concepts={concepts}
+                      conceptCountsById={conceptCountsById}
+                      onConceptClick={onConceptClick}
+                    ></ConceptsPanel>
                   )}
 
                   {selectedConcepts.length > 0 && (

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -347,7 +347,7 @@ export const ConceptsDocumentViewer = ({
                   <>
                     {selectedConcepts.length > 0 && (
                       <>
-                        <div className="my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
+                        <div className="border-gray-200 my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
                           <div className="mb-2">{state.totalNoOfMatches} matches in this document</div>
                         </div>
                         <div

--- a/src/components/documents/EmptyPassages.tsx
+++ b/src/components/documents/EmptyPassages.tsx
@@ -5,7 +5,7 @@ type TProps = {
 };
 
 export const EmptyPassages = ({ hasQueryString }: TProps) => (
-  <div className="flex flex-col gap-4 flex-1 mt-4 pt-10 border-t text-center text-gray-600 px-4">
+  <div className="border-gray-200 flex flex-col gap-4 flex-1 mt-4 pt-10 border-t text-center text-gray-600 px-4">
     <div className="text-blue-800 flex justify-center items-center">
       <div className="rounded-full bg-blue-50 p-6 mb-2">
         <FindInDocIcon width="48" height="48" />

--- a/src/components/labels/Label.tsx
+++ b/src/components/labels/Label.tsx
@@ -1,12 +1,12 @@
 type TProps = {
-  labelText: string;
+  children: React.ReactNode;
   extraClasses?: string;
 };
 
-export const Label = ({ labelText, extraClasses = "" }: TProps) => {
+export const Label = ({ children, extraClasses = "" }: TProps) => {
   return (
     <>
-      <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">{labelText}</span>
+      <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">{children}</span>
     </>
   );
 };

--- a/src/components/labels/Label.tsx
+++ b/src/components/labels/Label.tsx
@@ -1,0 +1,12 @@
+type TProps = {
+  labelText: string;
+  extraClasses?: string;
+};
+
+export const Label = ({ labelText, extraClasses = "" }: TProps) => {
+  return (
+    <>
+      <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">{labelText}</span>
+    </>
+  );
+};

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from "@components/ExternalLink";
+import { Heading } from "@components/typography/Heading";
 import { TConcept } from "@types";
 import { getConceptStoreLink } from "@utils/getConceptStoreLink";
 
@@ -12,7 +13,9 @@ export const ConceptsPopover = ({ concept, onClose }: TProps) => {
     <div className="w-64 p-4 bg-white rounded-lg shadow-md border border-gray-200 flex items-start">
       <div className="space-y-6 w-full">
         <div className="space-y-1">
-          <h3 className="text-xs font-medium text-neutral-500">Description</h3>
+          <Heading level={3} className="text-xs font-medium text-neutral-500">
+            Description
+          </Heading>
           <p className="text-sm text-neutral-800">{concept?.description || "No description available"}</p>
         </div>
         <div className="space-y-1">

--- a/src/components/typography/Quote.tsx
+++ b/src/components/typography/Quote.tsx
@@ -1,0 +1,11 @@
+type TProps = {
+  children: React.ReactNode;
+};
+
+export const Quote = ({ children }: TProps) => {
+  return (
+    <div className="pl-4 border-l-2 border-blue-600">
+      <p className="text-sm text-neutral-600">{children}</p>
+    </div>
+  );
+};

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -47,7 +47,7 @@ import { EXAMPLE_SEARCHES } from "@constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { rootLevelConceptsIds } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
@@ -207,19 +207,47 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     /** Get `rootConcepts` */
     const rootConceptsS3Promises = rootLevelConceptsIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch((error) => {
+          // Return a minimal object to allow partial processing
+          return {
+            wikibase_id: conceptId,
+            preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Other",
+            description: "Concept data unavailable",
+            subconcept_of: [],
+          };
+        });
     });
 
     /** Get concepts associated with the family */
     const conceptsS3Promises = conceptIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch((error) => {
+          // Return null to allow filtering out failed fetches
+          return null;
+        });
     });
 
     /** Get `rootConcepts` and `concepts` from S3 */
     Promise.all([...rootConceptsS3Promises, ...conceptsS3Promises]).then((allConcepts) => {
-      const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
-      const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
+      // Filter out any null results from concept fetches
+      const filteredConcepts = allConcepts.filter(Boolean);
+
+      const rootConceptsResults = filteredConcepts.slice(0, rootConceptsS3Promises.length);
+      const conceptsResults = filteredConcepts.slice(rootConceptsS3Promises.length);
 
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);
@@ -434,7 +462,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           </SingleCol>
           {/* TODO: use a panel for this */}
           {concepts.length > 0 && (
-            <div className="grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
+            <div className="border-gray-200 grow-0 shrink-0 px-5 border-l pt-5 w-[460px] text-sm">
               <ConceptsHead></ConceptsHead>
               {rootConcepts.map((rootConcept) => {
                 const hasConceptsInRootConcept = concepts.filter((concept) => concept.subconcept_of.includes(rootConcept.wikibase_id));

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -209,9 +209,6 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
       return fetch(url)
         .then((response) => {
-          if (!response.ok) {
-            return null;
-          }
           return response.json();
         })
         .catch((error) => {
@@ -230,9 +227,6 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
       return fetch(url)
         .then((response) => {
-          if (!response.ok) {
-            return null;
-          }
           return response.json();
         })
         .catch((error) => {

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -47,11 +47,12 @@ import { EXAMPLE_SEARCHES } from "@constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
+import { fetchAndProcessConcepts, ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsHead } from "@components/concepts/ConceptsHead";
 import { getConceptStoreLink } from "@utils/getConceptStoreLink";
+import { fetchConcepts } from "@utils/processConcepts";
 
 type TProps = {
   page: TFamilyPage;
@@ -204,47 +205,12 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   }, {});
 
   useEffectOnce(() => {
-    /** Get `rootConcepts` */
-    const rootConceptsS3Promises = rootLevelConceptsIds.map((conceptId) => {
+    fetchAndProcessConcepts(conceptIds, (conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url)
-        .then((response) => {
-          return response.json();
-        })
-        .catch((error) => {
-          // Return a minimal object to allow partial processing
-          return {
-            wikibase_id: conceptId,
-            preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Other",
-            description: "Concept data unavailable",
-            subconcept_of: [],
-          };
-        });
-    });
-
-    /** Get concepts associated with the family */
-    const conceptsS3Promises = conceptIds.map((conceptId) => {
-      const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url)
-        .then((response) => {
-          return response.json();
-        })
-        .catch((error) => {
-          // Return null to allow filtering out failed fetches
-          return null;
-        });
-    });
-
-    /** Get `rootConcepts` and `concepts` from S3 */
-    Promise.all([...rootConceptsS3Promises, ...conceptsS3Promises]).then((allConcepts) => {
-      // Filter out any null results from concept fetches
-      const filteredConcepts = allConcepts.filter(Boolean);
-
-      const rootConceptsResults = filteredConcepts.slice(0, rootConceptsS3Promises.length);
-      const conceptsResults = filteredConcepts.slice(rootConceptsS3Promises.length);
-
-      setRootConcepts(rootConceptsResults);
-      setConcepts(conceptsResults);
+      return fetch(url).then((response) => response.json());
+    }).then(({ rootConcepts, concepts }) => {
+      setRootConcepts(rootConcepts);
+      setConcepts(concepts);
     });
   });
 

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -28,7 +28,7 @@ import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 
 import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TConcept } from "@types";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { rootLevelConceptsIds } from "@utils/processConcepts";
+import { ROOT_LEVEL_CONCEPTS, rootLevelConceptsIds } from "@utils/processConcepts";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import { ConceptsDocumentViewer } from "@components/documents/ConceptsDocumentViewer";
 
@@ -264,7 +264,22 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     /** Get `rootConcepts` */
     const rootConceptsS3Promises = rootLevelConceptsIds.map((conceptId) => {
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch(() => {
+          // Return a minimal object to allow partial processing
+          return {
+            wikibase_id: conceptId,
+            preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Unknown Concept",
+            description: "Concept data unavailable",
+            subconcept_of: [],
+          };
+        });
     });
 
     /** Get concepts associated with the family */
@@ -272,13 +287,26 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       // the concept ID is in the shape of `Q100:concept name`
       const conceptId = conceptKey.split(":")[0];
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
+      return fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .catch(() => {
+          // Return null to allow filtering out failed fetches
+          return null;
+        });
     });
 
     /** Get `rootConcepts` and `concepts` from S3 */
     Promise.all([...rootConceptsS3Promises, ...conceptsS3Promises]).then((allConcepts) => {
-      const rootConceptsResults = allConcepts.slice(0, rootConceptsS3Promises.length);
-      const conceptsResults = allConcepts.slice(rootConceptsS3Promises.length);
+      // Filter out any null results from concept fetches
+      const filteredConcepts = allConcepts.filter(Boolean);
+
+      const rootConceptsResults = filteredConcepts.slice(0, rootConceptsS3Promises.length);
+      const conceptsResults = filteredConcepts.slice(rootConceptsS3Promises.length);
 
       setRootConcepts(rootConceptsResults);
       setConcepts(conceptsResults);

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -266,9 +266,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
       return fetch(url)
         .then((response) => {
-          if (!response.ok) {
-            return null;
-          }
           return response.json();
         })
         .catch(() => {
@@ -289,9 +286,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
       return fetch(url)
         .then((response) => {
-          if (!response.ok) {
-            return null;
-          }
           return response.json();
         })
         .catch(() => {


### PR DESCRIPTION
# What's changed

- Make family page concepts look like document viewer concepts
- Add new concepts panel component

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
