### PR TITLE
Feature/app 296 single concept and text search in global search

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   percy:
     runs-on: ubuntu-latest
     env:
@@ -47,6 +48,11 @@ jobs:
       - uses: trunk-io/trunk-action@v1
         with:
           arguments: --ci
+    permissions:
+      # For trunk to post annotations
+      checks: write
+      # For repo checkout
+      contents: read
 
   test:
     timeout-minutes: 60

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,6 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+      - run: npm install
       - uses: trunk-io/trunk-action@v1
         with:
           arguments: --ci

--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -4,7 +4,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Heading } from "./Heading";
 
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
-import { Label } from "@components/labels/Label";
 
 type TProps = {
   title: string;
@@ -14,7 +13,7 @@ type TProps = {
   className?: string;
   showFade?: "true" | "false";
   fixedHeight?: string;
-  isBeta?: boolean;
+  headContent?: React.ReactNode;
 };
 
 export const Accordian = ({
@@ -24,7 +23,7 @@ export const Accordian = ({
   fixedHeight = "300px",
   children,
   showFade = "false",
-  isBeta = false,
+  headContent,
   ...props
 }: TProps) => {
   const [isOpen, setIsOpen] = useState(startOpen);
@@ -34,7 +33,7 @@ export const Accordian = ({
       <div className={`flex justify-between cursor-pointer group`} onClick={() => setIsOpen(!isOpen)} data-cy="accordian-control">
         <div className="flex items-center gap-2">
           <Heading>{title}</Heading>
-          {isBeta && <Label>Beta</Label>}
+          {headContent}
         </div>
         <span className={`text-textDark opacity-40 group-hover:opacity-100 ${isOpen ? "" : ""}`}>
           {isOpen ? <AiOutlineMinus /> : <AiOutlinePlus />}

--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Heading } from "./Heading";
 
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
+import { Label } from "@components/labels/Label";
 
 type TProps = {
   title: string;
@@ -13,15 +14,28 @@ type TProps = {
   className?: string;
   showFade?: "true" | "false";
   fixedHeight?: string;
+  isBeta?: boolean;
 };
 
-export const Accordian = ({ title, startOpen = false, overflowOverride, fixedHeight = "300px", children, showFade = "false", ...props }: TProps) => {
+export const Accordian = ({
+  title,
+  startOpen = false,
+  overflowOverride,
+  fixedHeight = "300px",
+  children,
+  showFade = "false",
+  isBeta = false,
+  ...props
+}: TProps) => {
   const [isOpen, setIsOpen] = useState(startOpen);
 
   return (
     <div {...props}>
       <div className={`flex justify-between cursor-pointer group`} onClick={() => setIsOpen(!isOpen)} data-cy="accordian-control">
-        <Heading>{title}</Heading>
+        <div className="flex items-center gap-2">
+          <Heading>{title}</Heading>
+          {isBeta && <Label>Beta</Label>}
+        </div>
         <span className={`text-textDark opacity-40 group-hover:opacity-100 ${isOpen ? "" : ""}`}>
           {isOpen ? <AiOutlineMinus /> : <AiOutlinePlus />}
         </span>

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -166,6 +166,7 @@ const SearchFilters = ({
           data-cy="concepts"
           key="Concepts"
           startOpen={!!query[QUERY_PARAMS["concept_filters.name"]]}
+          isBeta={!!conceptsData}
         >
           <InputListContainer>
             {conceptsData?.map((concept) => (

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { ParsedUrlQuery } from "querystring";
 
 import useGetThemeConfig from "@hooks/useThemeConfig";
@@ -38,15 +38,6 @@ const isCategoryChecked = (selectedCatgeory: string | undefined, themeConfigCate
   return false;
 };
 
-const isConceptChecked = (selectedConceptLabel: string | undefined, concept: TConcept) => {
-  if (selectedConceptLabel) {
-    if (selectedConceptLabel.toLowerCase() === concept.preferred_label.toLowerCase()) {
-      return true;
-    }
-  }
-  return false;
-};
-
 type TSearchFiltersProps = {
   searchCriteria: TSearchCriteria;
   query: ParsedUrlQuery;
@@ -57,6 +48,7 @@ type TSearchFiltersProps = {
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
   handleYearChange(values: string[], reset?: boolean): void;
   handleRegionChange(region: string): void;
+  handleConceptRemove(concept: string): void;
   handleConceptChange(concept: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
@@ -73,11 +65,13 @@ const SearchFilters = ({
   handleYearChange,
   handleRegionChange,
   handleConceptChange,
+  handleConceptRemove,
   handleClearSearch,
   handleDocumentCategoryClick,
 }: TSearchFiltersProps) => {
   const { status: themeConfigStatus, themeConfig } = useGetThemeConfig();
   const [showClear, setShowClear] = useState(false);
+  const [showConceptClear, setShowConceptClear] = useState(false);
 
   const {
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
@@ -99,6 +93,17 @@ const SearchFilters = ({
       } else setShowClear(true);
     } else {
       setShowClear(false);
+    }
+  }, [query]);
+
+  // Show clear button if there are concepts applied
+  useEffect(() => {
+    if (query && Object.keys(query).length > 0) {
+      if (query[QUERY_PARAMS["concept_filters.id"]] || query[QUERY_PARAMS["concept_filters.name"]]) {
+        setShowConceptClear(true);
+      } else setShowConceptClear(false);
+    } else {
+      setShowConceptClear(false);
     }
   }, [query]);
 
@@ -184,9 +189,12 @@ const SearchFilters = ({
                 }}
               />
             </InputListContainer>
-            {showClear && (
+            {showConceptClear && (
               <div className="flex justify-end mt-2">
-                <button className="anchor underline text-sm" onClick={handleClearSearch}>
+                <button
+                  className="anchor underline text-sm"
+                  onClick={() => handleConceptRemove(query[QUERY_PARAMS["concept_filters.name"]] as string)}
+                >
                   Clear
                 </button>
               </div>

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { ParsedUrlQuery } from "querystring";
 
 import useGetThemeConfig from "@hooks/useThemeConfig";
-
+import { Label } from "@components/labels/Label";
 import { DateRange } from "../filters/DateRange";
 import { Accordian } from "@components/accordian/Accordian";
 import { InputListContainer } from "@components/filters/InputListContainer";
@@ -72,7 +72,7 @@ const SearchFilters = ({
 
   const {
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
-    concept_filters: conceptFilters = [],
+    concept_filters: { names: conceptFilters = [] },
   } = searchCriteria;
 
   const thisYear = currentYear();
@@ -161,7 +161,7 @@ const SearchFilters = ({
             startOpen={!!query[QUERY_PARAMS.concept_name]}
             overflowOverride
             className="relative z-11"
-            isBeta={!!conceptsData}
+            headContent={!!conceptsData && <Label>Beta</Label>}
           >
             <InputListContainer>
               <TypeAhead

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -81,6 +81,7 @@ const SearchFilters = ({
 
   const {
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
+    concept_filters: conceptFilters = [],
   } = searchCriteria;
 
   const thisYear = currentYear();
@@ -161,28 +162,35 @@ const SearchFilters = ({
         })}
 
       {conceptsData && (
-        <Accordian
-          title={getFilterLabel("Concept", "concept", query[QUERY_PARAMS["concept_filters.name"]], themeConfig)}
-          data-cy="concepts"
-          key="Concepts"
-          startOpen={!!query[QUERY_PARAMS["concept_filters.name"]]}
-          isBeta={!!conceptsData}
-        >
-          <InputListContainer>
-            {conceptsData?.map((concept) => (
-              <InputRadio
-                key={concept.wikibase_id}
-                label={concept.preferred_label}
-                // checked={false}
-                checked={query && isConceptChecked(query[QUERY_PARAMS["concept_filters.name"]] as string, concept)}
-                onChange={() => {
-                  handleConceptChange(concept.preferred_label);
+        <>
+          <Accordian
+            title={getFilterLabel("Concept", "concept", query[QUERY_PARAMS["concept_filters.name"]], themeConfig)}
+            data-cy="concepts"
+            key="Concepts"
+            startOpen={!!query[QUERY_PARAMS["concept_filters.name"]]}
+            overflowOverride
+            className="relative z-11"
+            isBeta={!!conceptsData}
+          >
+            {showClear && (
+              <button className="anchor underline text-sm" onClick={handleClearSearch}>
+                Clear
+              </button>
+            )}
+            <InputListContainer>
+              <TypeAhead
+                list={conceptsData}
+                selectedList={conceptFilters}
+                keyField="preferred_label"
+                keyFieldDisplay="preferred_label"
+                filterType={QUERY_PARAMS["concept_filters.name"]}
+                handleFilterChange={(type, value) => {
+                  handleConceptChange(value);
                 }}
-                name={`concept-${concept.wikibase_id}`}
               />
-            ))}
-          </InputListContainer>
-        </Accordian>
+            </InputListContainer>
+          </Accordian>
+        </>
       )}
 
       <Accordian

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -72,7 +72,7 @@ const SearchFilters = ({
 
   const {
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
-    concept_filters: { names: conceptFilters = [] },
+    concept_filters: conceptFilters = [],
   } = searchCriteria;
 
   const thisYear = currentYear();
@@ -166,7 +166,7 @@ const SearchFilters = ({
             <InputListContainer>
               <TypeAhead
                 list={conceptsData}
-                selectedList={conceptFilters}
+                selectedList={conceptFilters.map((concept) => concept.value)}
                 keyField="preferred_label"
                 keyFieldDisplay="preferred_label"
                 filterType={QUERY_PARAMS.concept_name}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -155,10 +155,10 @@ const SearchFilters = ({
       {conceptsData && (
         <>
           <Accordian
-            title={getFilterLabel("Concept", "concept", query[QUERY_PARAMS["concept_filters.name"]], themeConfig)}
+            title={getFilterLabel("Concept", "concept", query[QUERY_PARAMS.concept_name], themeConfig)}
             data-cy="concepts"
             key="Concepts"
-            startOpen={!!query[QUERY_PARAMS["concept_filters.name"]]}
+            startOpen={!!query[QUERY_PARAMS.concept_name]}
             overflowOverride
             className="relative z-11"
             isBeta={!!conceptsData}
@@ -169,7 +169,7 @@ const SearchFilters = ({
                 selectedList={conceptFilters}
                 keyField="preferred_label"
                 keyFieldDisplay="preferred_label"
-                filterType={QUERY_PARAMS["concept_filters.name"]}
+                filterType={QUERY_PARAMS.concept_name}
                 handleFilterChange={(type, value) => {
                   handleConceptChange(value);
                 }}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { ParsedUrlQuery } from "querystring";
 
 import useGetThemeConfig from "@hooks/useThemeConfig";

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -21,7 +21,7 @@ import { getCountriesFromRegions } from "@helpers/getCountriesFromRegions";
 import { canDisplayFilter } from "@utils/canDisplayFilter";
 import { getFilterLabel } from "@utils/getFilterLabel";
 
-import { TCorpusTypeDictionary, TGeography, TSearchCriteria, TThemeConfigOption } from "@types";
+import { TConcept, TCorpusTypeDictionary, TGeography, TSearchCriteria, TThemeConfigOption } from "@types";
 import dynamic from "next/dynamic";
 
 const MethodologyLink = dynamic(() => import(`/themes/${process.env.THEME}/components/MethodologyLink`));
@@ -38,15 +38,26 @@ const isCategoryChecked = (selectedCatgeory: string | undefined, themeConfigCate
   return false;
 };
 
+const isConceptChecked = (selectedConceptLabel: string | undefined, concept: TConcept) => {
+  if (selectedConceptLabel) {
+    if (selectedConceptLabel.toLowerCase() === concept.preferred_label.toLowerCase()) {
+      return true;
+    }
+  }
+  return false;
+};
+
 type TSearchFiltersProps = {
   searchCriteria: TSearchCriteria;
   query: ParsedUrlQuery;
   regions: TGeography[];
   countries: TGeography[];
   corpus_types: TCorpusTypeDictionary;
+  conceptsData?: TConcept[];
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
   handleYearChange(values: string[], reset?: boolean): void;
   handleRegionChange(region: string): void;
+  handleConceptChange(concept: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
 };
@@ -57,9 +68,11 @@ const SearchFilters = ({
   regions,
   countries,
   corpus_types,
+  conceptsData,
   handleFilterChange,
   handleYearChange,
   handleRegionChange,
+  handleConceptChange,
   handleClearSearch,
   handleDocumentCategoryClick,
 }: TSearchFiltersProps) => {
@@ -146,6 +159,30 @@ const SearchFilters = ({
             </Accordian>
           );
         })}
+
+      {conceptsData && (
+        <Accordian
+          title={getFilterLabel("Concept", "concept", query[QUERY_PARAMS["concept_filters.name"]], themeConfig)}
+          data-cy="concepts"
+          key="Concepts"
+          startOpen={!!query[QUERY_PARAMS["concept_filters.name"]]}
+        >
+          <InputListContainer>
+            {conceptsData?.map((concept) => (
+              <InputRadio
+                key={concept.wikibase_id}
+                label={concept.preferred_label}
+                // checked={false}
+                checked={query && isConceptChecked(query[QUERY_PARAMS["concept_filters.name"]] as string, concept)}
+                onChange={() => {
+                  handleConceptChange(concept.preferred_label);
+                }}
+                name={`concept-${concept.wikibase_id}`}
+              />
+            ))}
+          </InputListContainer>
+        </Accordian>
+      )}
 
       <Accordian
         title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -71,7 +71,6 @@ const SearchFilters = ({
 }: TSearchFiltersProps) => {
   const { status: themeConfigStatus, themeConfig } = useGetThemeConfig();
   const [showClear, setShowClear] = useState(false);
-  const [showConceptClear, setShowConceptClear] = useState(false);
 
   const {
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
@@ -96,17 +95,6 @@ const SearchFilters = ({
     }
   }, [query]);
 
-  // Show clear button if there are concepts applied
-  useEffect(() => {
-    if (query && Object.keys(query).length > 0) {
-      if (query[QUERY_PARAMS["concept_filters.id"]] || query[QUERY_PARAMS["concept_filters.name"]]) {
-        setShowConceptClear(true);
-      } else setShowConceptClear(false);
-    } else {
-      setShowConceptClear(false);
-    }
-  }, [query]);
-
   return (
     <div id="search_filters" data-cy="seach-filters" className="text-sm text-textNormal flex flex-col gap-5">
       {themeConfigStatus === "loading" && <Loader size="20px" />}
@@ -121,7 +109,7 @@ const SearchFilters = ({
         )}
       </div>
 
-      <AppliedFilters filterChange={handleFilterChange} />
+      <AppliedFilters filterChange={handleFilterChange} concepts={conceptsData} />
 
       {themeConfigStatus === "success" && themeConfig.categories && (
         <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} startOpen>
@@ -189,16 +177,6 @@ const SearchFilters = ({
                 }}
               />
             </InputListContainer>
-            {showConceptClear && (
-              <div className="flex justify-end mt-2">
-                <button
-                  className="anchor underline text-sm"
-                  onClick={() => handleConceptRemove(query[QUERY_PARAMS["concept_filters.name"]] as string)}
-                >
-                  Clear
-                </button>
-              </div>
-            )}
           </Accordian>
         </>
       )}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -172,11 +172,6 @@ const SearchFilters = ({
             className="relative z-11"
             isBeta={!!conceptsData}
           >
-            {showClear && (
-              <button className="anchor underline text-sm" onClick={handleClearSearch}>
-                Clear
-              </button>
-            )}
             <InputListContainer>
               <TypeAhead
                 list={conceptsData}
@@ -189,6 +184,13 @@ const SearchFilters = ({
                 }}
               />
             </InputListContainer>
+            {showClear && (
+              <div className="flex justify-end mt-2">
+                <button className="anchor underline text-sm" onClick={handleClearSearch}>
+                  Clear
+                </button>
+              </div>
+            )}
           </Accordian>
         </>
       )}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -48,7 +48,6 @@ type TSearchFiltersProps = {
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
   handleYearChange(values: string[], reset?: boolean): void;
   handleRegionChange(region: string): void;
-  handleConceptRemove(concept: string): void;
   handleConceptChange(concept: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
@@ -65,7 +64,6 @@ const SearchFilters = ({
   handleYearChange,
   handleRegionChange,
   handleConceptChange,
-  handleConceptRemove,
   handleClearSearch,
   handleDocumentCategoryClick,
 }: TSearchFiltersProps) => {

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -101,7 +101,7 @@ export const ConceptsDocumentViewer = ({
     () => ({
       [QUERY_PARAMS.query_string]: state.queryTerm,
       [QUERY_PARAMS.exact_match]: state.isExactSearch ? "true" : undefined,
-      [QUERY_PARAMS["concept_filters.name"]]: initialConceptFilters
+      [QUERY_PARAMS.concept_name]: initialConceptFilters
         ? Array.isArray(initialConceptFilters)
           ? initialConceptFilters
           : [initialConceptFilters]
@@ -396,8 +396,8 @@ export const ConceptsDocumentViewer = ({
                   <EmptyPassages
                     hasQueryString={
                       !!searchQueryParams[QUERY_PARAMS.query_string] &&
-                      !!searchQueryParams[QUERY_PARAMS["concept_filters.id"]] &&
-                      !!searchQueryParams[QUERY_PARAMS["concept_filters.name"]]
+                      !!searchQueryParams[QUERY_PARAMS.concept_id] &&
+                      !!searchQueryParams[QUERY_PARAMS.concept_name]
                     }
                   />
                 )}

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -364,7 +364,7 @@ export const ConceptsDocumentViewer = ({
                     )}
                     {initialQueryTerm && (
                       <>
-                        <div className="my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
+                        <div className="border-gray-200 my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
                           <div className="mb-2">
                             Displaying {renderPassageCount(state.totalNoOfMatches)} for "
                             <span className="text-textDark font-medium">{`${initialQueryTerm}`}</span>"

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -65,7 +65,7 @@ const handleFilterDisplay = (
     case "region":
       filterLabel = handleCountryRegion(value, regions);
       break;
-    case "concept_filters.name":
+    case "concept_name":
       filterLabel = handleConceptName(value, concepts);
       break;
     case "exact_match":

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -27,6 +27,9 @@ const handleCountryRegion = (slug: string, dataSet: TGeography[]) => {
 };
 
 const handleConceptName = (label: string, concepts: TConcept[]) => {
+  if (!concepts) {
+    return label;
+  }
   return getConceptName(label, concepts);
 };
 

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -8,20 +8,26 @@ import useGetThemeConfig from "@hooks/useThemeConfig";
 import Pill from "@components/Pill";
 
 import { getCountryName } from "@helpers/getCountryFields";
+import { getConceptName } from "@helpers/getConceptFields";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { sortOptions } from "@constants/sortOptions";
 
-import { TGeography, TThemeConfig } from "@types";
+import { TConcept, TGeography, TThemeConfig } from "@types";
 
 type TFilterChange = (type: string, value: string) => void;
 
 type TProps = {
   filterChange: TFilterChange;
+  concepts?: TConcept[];
 };
 
 const handleCountryRegion = (slug: string, dataSet: TGeography[]) => {
   return getCountryName(slug, dataSet);
+};
+
+const handleConceptName = (label: string, concepts: TConcept[]) => {
+  return getConceptName(label, concepts);
 };
 
 type TFilterKeys = keyof typeof QUERY_PARAMS;
@@ -40,7 +46,8 @@ const handleFilterDisplay = (
   value: string,
   countries: TGeography[],
   regions: TGeography[],
-  themeConfig: TThemeConfig
+  themeConfig: TThemeConfig,
+  concepts?: TConcept[]
 ) => {
   let filterLabel: string | null | undefined = null;
   let filterValue = value;
@@ -54,6 +61,9 @@ const handleFilterDisplay = (
       break;
     case "region":
       filterLabel = handleCountryRegion(value, regions);
+      break;
+    case "concept_filters.name":
+      filterLabel = handleConceptName(value, concepts);
       break;
     case "exact_match":
       filterLabel = value === "true" ? "Exact phrases only" : "Related phrases";
@@ -74,7 +84,7 @@ const handleFilterDisplay = (
     case "query_string":
       filterLabel = `Search: ${value}`;
       break;
-    //TODO: write a case for any remainding key that loops through the filters array on the config and then searches within the options where the key === taxonomyKey
+    //TODO: write a case for any remaining key that loops through the filters array on the config and then searches within the options where the key === taxonomyKey
     case "status":
       filterLabel = decodeURI(value);
       break;
@@ -108,7 +118,8 @@ const generatePills = (
   filterChange: TFilterChange,
   countries: TGeography[],
   regions: TGeography[],
-  themeConfig: TThemeConfig
+  themeConfig: TThemeConfig,
+  concepts?: TConcept[]
 ) => {
   let pills: JSX.Element[] = [];
 
@@ -116,13 +127,13 @@ const generatePills = (
     const value = queryParams[QUERY_PARAMS[key]];
     if (value) {
       if (key === "year_range")
-        return pills.push(handleFilterDisplay(filterChange, queryParams, key, value.toString(), countries, regions, themeConfig));
+        return pills.push(handleFilterDisplay(filterChange, queryParams, key, value.toString(), countries, regions, themeConfig, concepts));
       if (Array.isArray(value)) {
         return value.map((v: string) => {
-          return pills.push(handleFilterDisplay(filterChange, queryParams, key, v, countries, regions, themeConfig));
+          return pills.push(handleFilterDisplay(filterChange, queryParams, key, v, countries, regions, themeConfig, concepts));
         });
       }
-      return pills.push(handleFilterDisplay(filterChange, queryParams, key, value, countries, regions, themeConfig));
+      return pills.push(handleFilterDisplay(filterChange, queryParams, key, value, countries, regions, themeConfig, concepts));
     } else {
       return;
     }
@@ -131,15 +142,15 @@ const generatePills = (
   return pills;
 };
 
-export const AppliedFilters = ({ filterChange }: TProps) => {
+export const AppliedFilters = ({ filterChange, concepts }: TProps) => {
   const router = useRouter();
   const configQuery = useConfig();
   const { themeConfig } = useGetThemeConfig();
   const { data: { countries = [], regions = [] } = {} } = configQuery;
 
   const appliedFilters = useMemo(
-    () => generatePills(router.query, filterChange, countries, regions, themeConfig).map((pill) => pill),
-    [router.query, filterChange, countries, regions, themeConfig]
+    () => generatePills(router.query, filterChange, countries, regions, themeConfig, concepts).map((pill) => pill),
+    [router.query, filterChange, countries, regions, themeConfig, concepts]
   );
 
   if (appliedFilters.length === 0) {

--- a/src/components/labels/Label.tsx
+++ b/src/components/labels/Label.tsx
@@ -1,0 +1,12 @@
+type TProps = {
+  children: React.ReactNode;
+  extraClasses?: string;
+};
+
+export const Label = ({ children, extraClasses = "" }: TProps) => {
+  return (
+    <>
+      <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">{children}</span>
+    </>
+  );
+};

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -23,6 +23,6 @@ export const QUERY_PARAMS = {
   // Reports
   author_type: "at",
   // Pass through
-  "concept_filters.id": "cfi",
-  "concept_filters.name": "cfn",
+  concept_id: "cfi",
+  concept_name: "cfn",
 };

--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -15,5 +15,5 @@ export const initialSearchCriteria: TSearchCriteria = {
   offset: 0,
   corpus_import_ids: [],
   metadata: [],
-  concept_filters: {},
+  concept_filters: [],
 };

--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -15,5 +15,5 @@ export const initialSearchCriteria: TSearchCriteria = {
   offset: 0,
   corpus_import_ids: [],
   metadata: [],
-  concept_filters: [],
+  concept_filters: {},
 };

--- a/src/helpers/getConceptFields.ts
+++ b/src/helpers/getConceptFields.ts
@@ -1,0 +1,16 @@
+import { TConcept } from "@types";
+
+const findConceptObject = (conceptSearch: string, dataSet: TConcept[]) => {
+  let concept = dataSet.find((c) => c.wikibase_id.toLowerCase() === conceptSearch.toLowerCase());
+  if (!concept) concept = dataSet.find((c) => c.preferred_label.toLowerCase() === conceptSearch.toLowerCase());
+  if (!concept) return null;
+  return concept;
+};
+
+export const getConceptName = (conceptSearch: string, dataSet: TConcept[]) => {
+  return findConceptObject(conceptSearch, dataSet)?.preferred_label;
+};
+
+export const getConceptId = (conceptSearch: string, dataSet: TConcept[]) => {
+  return findConceptObject(conceptSearch, dataSet)?.wikibase_id;
+};

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -66,6 +66,7 @@ const useSearch = (query: TRouterQuery, familyId = "", documentId = "", runFresh
       document_ids: searchQuery.document_ids,
       continuation_tokens: searchQuery.continuation_tokens,
       corpus_import_ids: searchQuery.corpus_import_ids,
+      concept_filters: searchQuery.concept_filters,
       metadata: searchQuery.metadata,
     };
 

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -228,7 +228,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
 
         const queryObj = { ...router.query };
 
-        // If no concept filters remain, remove the concept_filters.name query param entirely
+        // If no concept filters remain, remove the concept_name query param entirely
         if (updatedConceptFilters.length === 0) {
           delete queryObj[QUERY_PARAMS.concept_name];
         } else {

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -83,11 +83,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     router.query,
     null,
     document.import_id,
-    !!(
-      router.query[QUERY_PARAMS.query_string] ||
-      router.query[QUERY_PARAMS["concept_filters.id"]] ||
-      router.query[QUERY_PARAMS["concept_filters.name"]]
-    ),
+    !!(router.query[QUERY_PARAMS.query_string] || router.query[QUERY_PARAMS.concept_id] || router.query[QUERY_PARAMS.concept_name]),
     MAX_PASSAGES
   );
 
@@ -213,7 +209,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       .sort((a, b) => b.count - a.count);
   }, [vespaFamilyData]);
 
-  const conceptFiltersQuery = router.query[QUERY_PARAMS["concept_filters.name"]];
+  const conceptFiltersQuery = router.query[QUERY_PARAMS.concept_name];
   const conceptFilters = useMemo(
     () => (conceptFiltersQuery ? (Array.isArray(conceptFiltersQuery) ? conceptFiltersQuery : [conceptFiltersQuery]) : undefined),
     [conceptFiltersQuery]
@@ -234,10 +230,10 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
 
         // If no concept filters remain, remove the concept_filters.name query param entirely
         if (updatedConceptFilters.length === 0) {
-          delete queryObj[QUERY_PARAMS["concept_filters.name"]];
+          delete queryObj[QUERY_PARAMS.concept_name];
         } else {
           // Otherwise, update the concept filters
-          queryObj[QUERY_PARAMS["concept_filters.name"]] = updatedConceptFilters;
+          queryObj[QUERY_PARAMS.concept_name] = updatedConceptFilters;
         }
 
         router.push({
@@ -251,7 +247,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       const updatedConceptFilters = [...currentConceptFilters, conceptLabel];
 
       const queryObj = { ...router.query };
-      queryObj[QUERY_PARAMS["concept_filters.name"]] = updatedConceptFilters;
+      queryObj[QUERY_PARAMS.concept_name] = updatedConceptFilters;
       router.push({
         pathname: `/documents/${document.slug}`,
         query: queryObj,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -279,10 +279,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
 
   const handleConceptChange = (concept: string) => {
     router.query[QUERY_PARAMS["concept_filters.name"]] = concept;
-    // Default search is all categories, so we do not need to provide any concept if we want all
-    if (concept === "All") {
-      delete router.query[QUERY_PARAMS["concept_filters.name"]];
-    }
     router.push({ query: router.query });
     resetCSVStatus();
   };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -2,7 +2,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { ParsedUrlQueryInput } from "querystring";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MdOutlineTune } from "react-icons/md";
 
 import useConfig from "@hooks/useConfig";

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -2,7 +2,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { ParsedUrlQueryInput } from "querystring";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { MdOutlineTune } from "react-icons/md";
 
 import useConfig from "@hooks/useConfig";
@@ -287,6 +287,14 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     resetCSVStatus();
   };
 
+  const handleConceptRemove = (concept: string) => {
+    if (concept === "") return false;
+    const queryObj = { ...router.query };
+    delete queryObj[QUERY_PARAMS["concept_filters.name"]];
+    delete queryObj[QUERY_PARAMS["concept_filters.id"]];
+    router.push({ query: queryObj });
+  };
+
   const handleYearChange = (values: string[], reset = false) => {
     const newVals = values.map((value) => Number(value).toFixed(0));
     handleSearchChange(QUERY_PARAMS.year_range, newVals, reset);
@@ -421,6 +429,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   handleYearChange={handleYearChange}
                   handleRegionChange={handleRegionChange}
                   handleConceptChange={handleConceptChange}
+                  handleConceptRemove={handleConceptRemove}
                   handleClearSearch={handleClearSearch}
                   handleDocumentCategoryClick={handleDocumentCategoryClick}
                 />
@@ -445,6 +454,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 handleYearChange={handleYearChange}
                 handleRegionChange={handleRegionChange}
                 handleConceptChange={handleConceptChange}
+                handleConceptRemove={handleConceptRemove}
                 handleClearSearch={handleClearSearch}
                 handleDocumentCategoryClick={handleDocumentCategoryClick}
               />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -563,7 +563,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const client = new ApiClient(process.env.CONCEPTS_API_URL);
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
-      const { data: returnedData } = await client.get(`/concepts/search?limit=10000&q=`);
+      const { data: returnedData } = await client.get(`/search?limit=10000&q=`);
       conceptsData = returnedData;
     }
   } catch (error) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -278,7 +278,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
   };
 
   const handleConceptChange = (concept: string) => {
-    router.query[QUERY_PARAMS["concept_filters.name"]] = concept;
+    router.query[QUERY_PARAMS.concept_name] = concept;
     router.push({ query: router.query });
     resetCSVStatus();
   };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -421,7 +421,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   handleYearChange={handleYearChange}
                   handleRegionChange={handleRegionChange}
                   handleConceptChange={handleConceptChange}
-                  handleConceptRemove={handleConceptRemove}
                   handleClearSearch={handleClearSearch}
                   handleDocumentCategoryClick={handleDocumentCategoryClick}
                 />
@@ -446,7 +445,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 handleYearChange={handleYearChange}
                 handleRegionChange={handleRegionChange}
                 handleConceptChange={handleConceptChange}
-                handleConceptRemove={handleConceptRemove}
                 handleClearSearch={handleClearSearch}
                 handleDocumentCategoryClick={handleDocumentCategoryClick}
               />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -563,7 +563,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const client = new ApiClient(process.env.CONCEPTS_API_URL);
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
-      const { data: returnedData } = await client.get(`/search?limit=10000&q=`);
+      const { data: returnedData } = await client.get(`/concepts/search?limit=10000&q=`);
       conceptsData = returnedData;
     }
   } catch (error) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -36,11 +36,15 @@ import { readConfigFile } from "@utils/readConfigFile";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 
-import { TTheme, TThemeConfig } from "@types";
+import { TConcept, TFamilyPage, TTheme, TThemeConfig } from "@types";
+import { getFeatureFlags } from "@utils/featureFlags";
+import { ApiClient } from "@api/http-common";
 
 type TProps = {
   theme: TTheme;
   themeConfig: TThemeConfig;
+  featureFlags: Record<string, string | boolean>;
+  conceptsData?: TConcept[];
 };
 
 const SETTINGS_ANIMATION_VARIANTS = {
@@ -48,7 +52,7 @@ const SETTINGS_ANIMATION_VARIANTS = {
   visible: { opacity: 1, transition: { duration: 0 } },
 };
 
-const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme, themeConfig }: TProps) => {
+const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme, themeConfig, featureFlags, conceptsData }: TProps) => {
   const router = useRouter();
   const qQueryString = router.query[QUERY_PARAMS.query_string];
   const [showFilters, setShowFilters] = useState(false);
@@ -273,6 +277,16 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     resetCSVStatus();
   };
 
+  const handleConceptChange = (concept: string) => {
+    router.query[QUERY_PARAMS["concept_filters.name"]] = concept;
+    // Default search is all categories, so we do not need to provide any concept if we want all
+    if (concept === "All") {
+      delete router.query[QUERY_PARAMS["concept_filters.name"]];
+    }
+    router.push({ query: router.query });
+    resetCSVStatus();
+  };
+
   const handleYearChange = (values: string[], reset = false) => {
     const newVals = values.map((value) => Number(value).toFixed(0));
     handleSearchChange(QUERY_PARAMS.year_range, newVals, reset);
@@ -395,18 +409,22 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
             {configQuery.isFetching ? (
               <Loader size="20px" />
             ) : (
-              <SearchFilters
-                searchCriteria={searchQuery}
-                query={router.query}
-                regions={regions}
-                countries={countries}
-                corpus_types={corpus_types}
-                handleFilterChange={handleFilterChange}
-                handleYearChange={handleYearChange}
-                handleRegionChange={handleRegionChange}
-                handleClearSearch={handleClearSearch}
-                handleDocumentCategoryClick={handleDocumentCategoryClick}
-              />
+              <>
+                <SearchFilters
+                  searchCriteria={searchQuery}
+                  query={router.query}
+                  regions={regions}
+                  countries={countries}
+                  corpus_types={corpus_types}
+                  conceptsData={conceptsData}
+                  handleFilterChange={handleFilterChange}
+                  handleYearChange={handleYearChange}
+                  handleRegionChange={handleRegionChange}
+                  handleConceptChange={handleConceptChange}
+                  handleClearSearch={handleClearSearch}
+                  handleDocumentCategoryClick={handleDocumentCategoryClick}
+                />
+              </>
             )}
           </div>
         </SiteWidth>
@@ -422,9 +440,11 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 regions={regions}
                 countries={countries}
                 corpus_types={corpus_types}
+                conceptsData={conceptsData}
                 handleFilterChange={handleFilterChange}
                 handleYearChange={handleYearChange}
                 handleRegionChange={handleRegionChange}
+                handleConceptChange={handleConceptChange}
                 handleClearSearch={handleClearSearch}
                 handleDocumentCategoryClick={handleDocumentCategoryClick}
               />
@@ -524,6 +544,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
         onCancelClick={() => setShowCSVDownloadPopup(false)}
         onConfirmClick={() => handleDownloadCsvClick()}
       />
+      {/* This is here in the short term for us to test features flags with our cache settings */}
+      <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />
     </Layout>
   );
 };
@@ -532,6 +554,7 @@ export default Search;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
+  const featureFlags = await getFeatureFlags(context.req.cookies);
 
   const theme = process.env.THEME;
   let themeConfig = {};
@@ -539,7 +562,19 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     themeConfig = await readConfigFile(theme);
   } catch (error) {}
 
+  let conceptsData: TConcept[];
+  try {
+    const client = new ApiClient(process.env.CONCEPTS_API_URL);
+    const conceptsV1 = featureFlags["concepts-v1"];
+    if (conceptsV1) {
+      const { data: returnedData } = await client.get(`/concepts/search?q=`);
+      conceptsData = returnedData;
+    }
+  } catch (error) {
+    // TODO: handle error more elegantly
+  }
+
   return {
-    props: { theme, themeConfig },
+    props: { theme, themeConfig, featureFlags, conceptsData: conceptsData ?? null },
   };
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -567,7 +567,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const client = new ApiClient(process.env.CONCEPTS_API_URL);
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
-      const { data: returnedData } = await client.get(`/concepts/search?q=`);
+      const { data: returnedData } = await client.get(`/concepts/search?limit=10000&q=`);
       conceptsData = returnedData;
     }
   } catch (error) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -287,14 +287,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     resetCSVStatus();
   };
 
-  const handleConceptRemove = (concept: string) => {
-    if (concept === "") return false;
-    const queryObj = { ...router.query };
-    delete queryObj[QUERY_PARAMS["concept_filters.name"]];
-    delete queryObj[QUERY_PARAMS["concept_filters.id"]];
-    router.push({ query: queryObj });
-  };
-
   const handleYearChange = (values: string[], reset = false) => {
     const newVals = values.map((value) => Number(value).toFixed(0));
     handleSearchChange(QUERY_PARAMS.year_range, newVals, reset);

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -540,7 +540,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
         onCancelClick={() => setShowCSVDownloadPopup(false)}
         onConfirmClick={() => handleDownloadCsvClick()}
       />
-      {/* This is here in the short term for us to test features flags with our cache settings */}
       <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />
     </Layout>
   );

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -32,7 +32,7 @@ export type TSearchCriteria = {
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
   metadata: TSearchCriteriaMeta[];
-  concept_filters: { name: string }[];
+  concept_filters: { name: string; value: string }[];
   // for internal use
   runSearch?: boolean;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,6 +6,11 @@ export type TSearchKeywordFilters = {
   countries?: string[];
 };
 
+export type TSearchConceptFilters = {
+  names?: string[];
+  ids?: string[];
+};
+
 export type TSearchCriteriaMeta = {
   name: string;
   value: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -32,7 +32,7 @@ export type TSearchCriteria = {
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
   metadata: TSearchCriteriaMeta[];
-  concept_filters?: string[];
+  concept_filters?: TSearchConceptFilters;
   // for internal use
   runSearch?: boolean;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -32,7 +32,7 @@ export type TSearchCriteria = {
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
   metadata: TSearchCriteriaMeta[];
-  concept_filters?: TSearchConceptFilters;
+  concept_filters: { name: string }[];
   // for internal use
   runSearch?: boolean;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -27,7 +27,7 @@ export type TSearchCriteria = {
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
   metadata: TSearchCriteriaMeta[];
-  concept_filters: { name: string }[];
+  concept_filters?: string[];
   // for internal use
   runSearch?: boolean;
 };

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -3,7 +3,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 
 import { buildSearchQueryMetadata } from "./buildSearchQueryMetadata";
 
-import { TSearchCriteria, TSearchKeywordFilters, TThemeConfig } from "@types";
+import { TSearchConceptFilters, TSearchCriteria, TSearchKeywordFilters, TThemeConfig } from "@types";
 
 export type TRouterQuery = {
   [key: string]: string | string[];
@@ -20,6 +20,7 @@ export default function buildSearchQuery(
   noOfPassagesPerDoc: number = undefined
 ): TSearchCriteria {
   const keyword_filters: TSearchKeywordFilters = {};
+  const concept_filters: TSearchConceptFilters = {};
   let query = { ...initialSearchCriteria, runSearch: true };
 
   // don't build a query object if we are not provided with a config
@@ -52,23 +53,14 @@ export default function buildSearchQuery(
     }
   }
 
-  if (routerQuery[QUERY_PARAMS["concept_filters.id"]]) {
-    const conceptFilters = routerQuery[QUERY_PARAMS["concept_filters.id"]];
-    query.concept_filters = Array.isArray(conceptFilters)
-      ? conceptFilters.map((id) => ({
-          name: "id",
-          value: id,
-        }))
-      : [{ name: "id", value: conceptFilters }];
+  if (routerQuery[QUERY_PARAMS.concept_id]) {
+    const conceptIds = routerQuery[QUERY_PARAMS.concept_id];
+    concept_filters.ids = Array.isArray(conceptIds) ? conceptIds : [conceptIds];
   }
-  if (routerQuery[QUERY_PARAMS["concept_filters.name"]]) {
-    const conceptFilters = routerQuery[QUERY_PARAMS["concept_filters.name"]];
-    query.concept_filters = Array.isArray(conceptFilters)
-      ? conceptFilters.map((name) => ({
-          name: "name",
-          value: name,
-        }))
-      : [{ name: "name", value: conceptFilters }];
+
+  if (routerQuery[QUERY_PARAMS.concept_name]) {
+    const conceptNames = routerQuery[QUERY_PARAMS.concept_name];
+    concept_filters.names = Array.isArray(conceptNames) ? conceptNames : [conceptNames];
   }
 
   if (routerQuery[QUERY_PARAMS.category]) {

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -3,7 +3,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 
 import { buildSearchQueryMetadata } from "./buildSearchQueryMetadata";
 
-import { TSearchConceptFilters, TSearchCriteria, TSearchKeywordFilters, TThemeConfig } from "@types";
+import { TSearchCriteria, TSearchKeywordFilters, TThemeConfig } from "@types";
 
 export type TRouterQuery = {
   [key: string]: string | string[];
@@ -20,7 +20,6 @@ export default function buildSearchQuery(
   noOfPassagesPerDoc: number = undefined
 ): TSearchCriteria {
   const keyword_filters: TSearchKeywordFilters = {};
-  const concept_filters: TSearchConceptFilters = {};
   let query = { ...initialSearchCriteria, runSearch: true };
 
   // don't build a query object if we are not provided with a config
@@ -54,13 +53,22 @@ export default function buildSearchQuery(
   }
 
   if (routerQuery[QUERY_PARAMS.concept_id]) {
-    const conceptIds = routerQuery[QUERY_PARAMS.concept_id];
-    concept_filters.ids = Array.isArray(conceptIds) ? conceptIds : [conceptIds];
+    const conceptFilters = routerQuery[QUERY_PARAMS.concept_id];
+    query.concept_filters = Array.isArray(conceptFilters)
+      ? conceptFilters.map((id) => ({
+          name: "id",
+          value: id,
+        }))
+      : [{ name: "id", value: conceptFilters }];
   }
-
   if (routerQuery[QUERY_PARAMS.concept_name]) {
-    const conceptNames = routerQuery[QUERY_PARAMS.concept_name];
-    concept_filters.names = Array.isArray(conceptNames) ? conceptNames : [conceptNames];
+    const conceptFilters = routerQuery[QUERY_PARAMS.concept_name];
+    query.concept_filters = Array.isArray(conceptFilters)
+      ? conceptFilters.map((name) => ({
+          name: "name",
+          value: name,
+        }))
+      : [{ name: "name", value: conceptFilters }];
   }
 
   if (routerQuery[QUERY_PARAMS.category]) {


### PR DESCRIPTION
# What's changed

Add concept filtering under feature flag in global search.

- Concept filtering by name only enabled at the moment
- Concepts input is a type ahead
- Beta label where the concepts filter accordion appears

NOTE: We don't have all classfiers in yet. It is very likely that the user will select a concept we don't have data for or they will get 0 results based on other options selected. This is okay for now. Multiple concept search is not yet enabled in the API so if the user types more than one concept, the previous concept they had will be removed and the new one applied.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
