### PR TITLE
Allow multiple concept filtering in global search

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -48,7 +48,6 @@ type TSearchFiltersProps = {
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
   handleYearChange(values: string[], reset?: boolean): void;
   handleRegionChange(region: string): void;
-  handleConceptChange(concept: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
 };
@@ -63,7 +62,6 @@ const SearchFilters = ({
   handleFilterChange,
   handleYearChange,
   handleRegionChange,
-  handleConceptChange,
   handleClearSearch,
   handleDocumentCategoryClick,
 }: TSearchFiltersProps) => {
@@ -170,9 +168,7 @@ const SearchFilters = ({
                 keyField="preferred_label"
                 keyFieldDisplay="preferred_label"
                 filterType={QUERY_PARAMS.concept_name}
-                handleFilterChange={(type, value) => {
-                  handleConceptChange(value);
-                }}
+                handleFilterChange={handleFilterChange}
               />
             </InputListContainer>
           </Accordian>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -63,7 +63,6 @@ export const ConceptsDocumentViewer = ({
   onClear,
 }: TProps) => {
   const [showSearchOptions, setShowSearchOptions] = useState(false);
-  const [showConceptFilter, setShowConceptFilter] = useState(false);
 
   const [state, setState] = useReducer((prev: any, next: Partial<any>) => ({ ...prev, ...next }), {
     passageIndex: initialPassage,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -170,6 +170,10 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
       delete router.query[QUERY_PARAMS.implementing_agency];
     }
 
+    if (type === QUERY_PARAMS.concept_name) {
+      queryCollection = Array.from(new Set(queryCollection)); // Remove duplicates
+    }
+
     router.query[type] = queryCollection;
     router.push({ query: router.query });
     resetCSVStatus();
@@ -230,7 +234,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
       delete router.query[QUERY_PARAMS.topic];
       delete router.query[QUERY_PARAMS.sector];
     }
-
+    delete router.query[QUERY_PARAMS.concept_id];
+    delete router.query[QUERY_PARAMS.concept_name];
     router.query[QUERY_PARAMS.category] = category;
     // Default search is all categories, so we do not need to provide any category if we want all
     if (category === "All") {
@@ -273,12 +278,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     if (!order) {
       delete router.query[QUERY_PARAMS.sort_order];
     }
-    router.push({ query: router.query });
-    resetCSVStatus();
-  };
-
-  const handleConceptChange = (concept: string) => {
-    router.query[QUERY_PARAMS.concept_name] = concept;
     router.push({ query: router.query });
     resetCSVStatus();
   };
@@ -416,7 +415,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                   handleFilterChange={handleFilterChange}
                   handleYearChange={handleYearChange}
                   handleRegionChange={handleRegionChange}
-                  handleConceptChange={handleConceptChange}
                   handleClearSearch={handleClearSearch}
                   handleDocumentCategoryClick={handleDocumentCategoryClick}
                 />
@@ -440,7 +438,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 handleFilterChange={handleFilterChange}
                 handleYearChange={handleYearChange}
                 handleRegionChange={handleRegionChange}
-                handleConceptChange={handleConceptChange}
                 handleClearSearch={handleClearSearch}
                 handleDocumentCategoryClick={handleDocumentCategoryClick}
               />


### PR DESCRIPTION
# What's changed

Allow multiple concept filtering in global search
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/c72030d4-b7e8-40a8-ad7d-c01fbb1be5ea" />


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
