### PR TITLE
Fix icon not displaying properly on the OEP search page

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,8 @@ permissions: read-all
 
 jobs:
   check-auto-tagging-will-work:
+    if: |
+      (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))
     uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v17
 
   size:

--- a/themes/cpr/components/oep/Hero.tsx
+++ b/themes/cpr/components/oep/Hero.tsx
@@ -9,20 +9,6 @@ import { ExternalLink } from "@components/ExternalLink";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { Icon } from "@components/icon/Icon";
 
-const SearchIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-    <g opacity="0.6">
-      <path
-        d="M17.5 17.5L13.9167 13.9167M15.8333 9.16667C15.8333 12.8486 12.8486 15.8333 9.16667 15.8333C5.48477 15.8333 2.5 12.8486 2.5 9.16667C2.5 5.48477 5.48477 2.5 9.16667 2.5C12.8486 2.5 15.8333 5.48477 15.8333 9.16667Z"
-        stroke="#202020"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </g>
-  </svg>
-);
-
 export const Hero = () => {
   const router = useRouter();
   const [term, setTerm] = useState("");
@@ -61,9 +47,9 @@ export const Hero = () => {
               </h1>
               <p className="my-6 text-xl text-textDark md:text-2xl">Helping the offshore wind sector design effective strategies</p>
               <div className="relative z-1 mb-4">
-                <button className="h-full absolute left-0 px-4" onClick={() => handleSubmit()} aria-label="Search">
+                <button className="h-full absolute left-0 px-4 text-textNormal" onClick={() => handleSubmit()} aria-label="Search">
                   <span className="block">
-                    <Icon name="search" />
+                    <Icon name="search" height="20" width="20" />
                   </span>
                 </button>
                 <input


### PR DESCRIPTION
# What's changed
- Search magnifying glass icon was not displaying correctly on the OEP page

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
