### PR TITLE
fix: use `recursive_subconcept_of` for grouping concepts

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -202,10 +202,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   }, {});
 
   useEffectOnce(() => {
-    fetchAndProcessConcepts(conceptIds, (conceptId) => {
-      const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
-    }).then(({ rootConcepts, concepts }) => {
+    fetchAndProcessConcepts(conceptIds).then(({ rootConcepts, concepts }) => {
       setRootConcepts(rootConcepts);
       setConcepts(concepts);
     });

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -248,10 +248,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   useEffectOnce(() => {
     const conceptIds = conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]);
 
-    fetchAndProcessConcepts(conceptIds, (conceptId) => {
-      const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
-    }).then(({ rootConcepts, concepts }) => {
+    fetchAndProcessConcepts(conceptIds).then(({ rootConcepts, concepts }) => {
       setRootConcepts(rootConcepts);
       setConcepts(concepts);
     });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -325,6 +325,7 @@ export type TConcept = {
   negative_labels: string[];
   description: string;
   subconcept_of: string[];
+  recursive_subconcept_of: string[];
   has_subconcept: string[];
   related_concepts: string[];
   definition?: string;

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -38,11 +38,12 @@ export const fetchAndProcessConcepts = async (conceptIds: string[]) => {
   /** We currently fail silently for some concepts, but we will see errors in the network panel */
   const rootConceptsResults = filteredConcepts
     .slice(0, rootConceptsS3Promises.length)
-    .filter((promiseSettledResult) => promiseSettledResult.status === "fulfilled")
+    .filter((promiseSettledResult): promiseSettledResult is PromiseFulfilledResult<TConcept> => promiseSettledResult.status === "fulfilled")
     .map((promiseSettledResult) => promiseSettledResult.value);
+
   const conceptsResults = filteredConcepts
     .slice(rootConceptsS3Promises.length)
-    .filter((promiseSettledResult) => promiseSettledResult.status === "fulfilled")
+    .filter((promiseSettledResult): promiseSettledResult is PromiseFulfilledResult<TConcept> => promiseSettledResult.status === "fulfilled")
     .map((promiseSettledResult) => promiseSettledResult.value);
 
   return { rootConcepts: rootConceptsResults, concepts: conceptsResults };


### PR DESCRIPTION
# What's changed
- use `recursive_subconcept_of` for grouping concepts. This was introduced by @harrisonpim here https://github.com/climatepolicyradar/knowledge-graph/pull/281

### Drive-bys
- moves the whole abstraction of `fetchConcept` into `processConcepts`
- uses [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) in case any of the S3 calls fail

## screenshots

| before | after |
|---|---|
| ![Screenshot 2025-03-05 at 14 25 00](https://github.com/user-attachments/assets/06cb27c0-9096-4594-89f4-008000eb7b63) | ![Screenshot 2025-03-05 at 14 24 51](https://github.com/user-attachments/assets/5322f297-b8b6-4766-8d7d-f246bea077c0) |

## Proposed version

- [x] Patch
