### PR TITLE
Feature/app 310 getting concepts work production ready paired programming (part 1)

### DIFF
--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -200,15 +200,14 @@ export const ConceptsDocumentViewer = ({
                 <div id="document-search" className="flex flex-col gap-2 md:pl-4">
                   {(selectedConcepts.length > 0 || initialQueryTerm) && (
                     <div className="flex gap-2">
-                      <Link className="capitalize hover:no-underline" href={`/documents/${document.slug}`} onClick={handleClearSearch}>
-                        <Button
-                          color="dark-dark"
-                          data-cy="view-document-viewer-concept"
-                          extraClasses="flex items-center text-[14px] font-normal pt-1 pb-1 bg-black text-white border-none"
-                        >
-                          ← Back
-                        </Button>
-                      </Link>
+                      <Button
+                        color="dark-dark"
+                        data-cy="view-document-viewer-concept"
+                        extraClasses="flex items-center text-[14px] font-normal pt-1 pb-1 bg-black text-white border-none"
+                        onClick={handleClearSearch}
+                      >
+                        ← Back
+                      </Button>
                     </div>
                   )}
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -2,7 +2,6 @@ import EmbeddedPDF from "@components/EmbeddedPDF";
 import { FullWidth } from "@components/panels/FullWidth";
 import { TConcept, TDocumentPage, TPassage, TSearchResponse } from "@types";
 import { EmptyDocument } from "./EmptyDocument";
-import Link from "next/link";
 import Button from "@components/buttons/Button";
 import SearchForm from "@components/forms/SearchForm";
 import { MdOutlineTune } from "react-icons/md";
@@ -16,9 +15,7 @@ import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
-import { HiOutlineFilter } from "react-icons/hi";
 import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
-import { Popover } from "@components/popover/Popover";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
 import { useEffectOnce } from "@hooks/useEffectOnce";
 import Loader from "@components/Loader";
@@ -110,10 +107,7 @@ export const ConceptsDocumentViewer = ({
   useEffectOnce(() => {
     const conceptIds = conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]);
 
-    fetchAndProcessConcepts(conceptIds, (conceptId) => {
-      const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
-    }).then(({ rootConcepts, concepts }) => {
+    fetchAndProcessConcepts(conceptIds).then(({ rootConcepts, concepts }) => {
       setRootConcepts(rootConcepts);
       setConcepts(concepts);
     });

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -21,6 +21,7 @@ import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
 import { Popover } from "@components/popover/Popover";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
 import { useEffectOnce } from "@hooks/useEffectOnce";
+import Loader from "@components/Loader";
 
 type TProps = {
   initialQueryTerm?: string | string[];
@@ -143,7 +144,7 @@ export const ConceptsDocumentViewer = ({
     [state.queryTerm, state.isExactSearch, initialConceptFilters]
   );
 
-  const { families, searchQuery } = useSearch(
+  const { status, families, searchQuery } = useSearch(
     searchQueryParams,
     null,
     document.import_id,
@@ -243,46 +244,44 @@ export const ConceptsDocumentViewer = ({
                     </div>
                   )}
 
-                  {
-                    <div className="flex gap-2">
-                      <div className="flex-1">
-                        <SearchForm
-                          placeholder="Search document text"
-                          handleSearchInput={handleSearchInput}
-                          input={state.queryTerm as string}
-                          size="default"
-                        />
-                      </div>
-                      <div className="relative z-10 flex justify-center">
-                        <button
-                          className="px-4 flex justify-center items-center text-textDark text-xl"
-                          onClick={() => setShowSearchOptions(!showSearchOptions)}
-                        >
-                          <MdOutlineTune />
-                        </button>
-                        <AnimatePresence initial={false}>
-                          {showSearchOptions && (
-                            <motion.div
-                              key="content"
-                              initial="collapsed"
-                              animate="open"
-                              exit="collapsed"
-                              variants={{
-                                collapsed: { opacity: 0, transition: { duration: 0.1 } },
-                                open: { opacity: 1, transition: { duration: 0.25 } },
-                              }}
-                            >
-                              <SearchSettings
-                                queryParams={searchQueryParams}
-                                handleSearchChange={handleSemanticSearchChange}
-                                setShowOptions={setShowSearchOptions}
-                              />
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-                      </div>
+                  <div className="flex gap-2">
+                    <div className="flex-1">
+                      <SearchForm
+                        placeholder="Search document text"
+                        handleSearchInput={handleSearchInput}
+                        input={state.queryTerm as string}
+                        size="default"
+                      />
                     </div>
-                  }
+                    <div className="relative z-10 flex justify-center">
+                      <button
+                        className="px-4 flex justify-center items-center text-textDark text-xl"
+                        onClick={() => setShowSearchOptions(!showSearchOptions)}
+                      >
+                        <MdOutlineTune />
+                      </button>
+                      <AnimatePresence initial={false}>
+                        {showSearchOptions && (
+                          <motion.div
+                            key="content"
+                            initial="collapsed"
+                            animate="open"
+                            exit="collapsed"
+                            variants={{
+                              collapsed: { opacity: 0, transition: { duration: 0.1 } },
+                              open: { opacity: 1, transition: { duration: 0.25 } },
+                            }}
+                          >
+                            <SearchSettings
+                              queryParams={searchQueryParams}
+                              handleSearchChange={handleSemanticSearchChange}
+                              setShowOptions={setShowSearchOptions}
+                            />
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
+                    </div>
+                  </div>
 
                   {selectedConcepts.length === 0 && !initialQueryTerm && (
                     <ConceptsPanel
@@ -307,51 +306,60 @@ export const ConceptsDocumentViewer = ({
                   )}
                 </div>
 
-                {state.totalNoOfMatches > 0 && (
+                {status !== "success" ? (
+                  <div className="w-full flex justify-center flex-1 bg-white">
+                    <Loader />
+                  </div>
+                ) : (
                   <>
-                    <div className="border-gray-200 my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
-                      <div className="mb-2">
-                        Displaying {renderPassageCount(state.totalNoOfMatches)}{" "}
-                        {initialQueryTerm && (
-                          <>
-                            for "<span className="text-textDark font-medium">{`${initialQueryTerm}`}</span>"
-                          </>
-                        )}
-                        {initialQueryTerm && !searchQuery.exact_match && ` and related phrases`}
-                        {selectedConcepts.length > 0 && (
-                          <>
-                            {" in "}
-                            <b>{selectedConcepts.map((concept) => concept.preferred_label).join(", ")}</b>
-                          </>
-                        )}
-                        {state.totalNoOfMatches >= MAX_RESULTS && (
-                          <span className="ml-1 inline-block">
-                            <SearchLimitTooltip colour="grey" />
-                          </span>
-                        )}
-                      </div>
-                      <p>Sorted by search relevance</p>
-                    </div>
-                    <div
-                      id="document-passage-matches"
-                      className="relative overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 md:pl-4"
-                    >
-                      <PassageMatches
-                        passages={state.passageMatches}
-                        onClick={handlePassageClick}
-                        activeIndex={state.passageIndex ?? initialPassage}
+                    {state.totalNoOfMatches > 0 && (
+                      <>
+                        <div className="border-gray-200 my-4 text-sm pb-4 border-b md:pl-4" data-cy="document-matches-description">
+                          <div className="mb-2">
+                            Displaying {renderPassageCount(state.totalNoOfMatches)}{" "}
+                            {initialQueryTerm && (
+                              <>
+                                for "<span className="text-textDark font-medium">{`${initialQueryTerm}`}</span>"
+                              </>
+                            )}
+                            {initialQueryTerm && !searchQuery.exact_match && ` and related phrases`}
+                            {selectedConcepts.length > 0 && (
+                              <>
+                                {" in "}
+                                <b>{selectedConcepts.map((concept) => concept.preferred_label).join(", ")}</b>
+                              </>
+                            )}
+                            {state.totalNoOfMatches >= MAX_RESULTS && (
+                              <span className="ml-1 inline-block">
+                                <SearchLimitTooltip colour="grey" />
+                              </span>
+                            )}
+                          </div>
+                          <p>Sorted by search relevance</p>
+                        </div>
+                        <div
+                          id="document-passage-matches"
+                          className="relative overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 md:pl-4"
+                        >
+                          <PassageMatches
+                            passages={state.passageMatches}
+                            onClick={handlePassageClick}
+                            activeIndex={state.passageIndex ?? initialPassage}
+                          />
+                        </div>
+                      </>
+                    )}
+
+                    {state.totalNoOfMatches === 0 && (
+                      <EmptyPassages
+                        hasQueryString={
+                          !!searchQueryParams[QUERY_PARAMS.query_string] &&
+                          !!searchQueryParams[QUERY_PARAMS.concept_id] &&
+                          !!searchQueryParams[QUERY_PARAMS.concept_name]
+                        }
                       />
-                    </div>
+                    )}
                   </>
-                )}
-                {state.totalNoOfMatches === 0 && (
-                  <EmptyPassages
-                    hasQueryString={
-                      !!searchQueryParams[QUERY_PARAMS.query_string] &&
-                      !!searchQueryParams[QUERY_PARAMS.concept_id] &&
-                      !!searchQueryParams[QUERY_PARAMS.concept_name]
-                    }
-                  />
                 )}
               </div>
             </div>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -68,7 +68,6 @@ export const ConceptsDocumentViewer = ({
     totalNoOfMatches: 0,
   });
 
-  /** Concepts: WIP */
   const [concepts, setConcepts] = useState<TConcept[]>([]);
   const [rootConcepts, setRootConcepts] = useState<TConcept[]>([]);
 

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -193,8 +193,6 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   }, [vespaFamilyData]);
 
   const conceptIds = conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]);
-  // const conceptIds = [...new Set(conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]))];
-
   const conceptCountsById = conceptCounts.reduce((acc, { conceptKey, count }) => {
     const conceptId = conceptKey.split(":")[0];
     acc[conceptId] = count;

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -142,10 +142,14 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     (queryTerm: string) => {
       const queryObj = { ...router.query };
       queryObj[QUERY_PARAMS.query_string] = queryTerm;
-      router.push({
-        pathname: `/documents/${document.slug}`,
-        query: queryObj,
-      });
+      router.push(
+        {
+          pathname: `/documents/${document.slug}`,
+          query: queryObj,
+        },
+        undefined,
+        { shallow: true }
+      );
     },
     [router, document.slug]
   );
@@ -158,10 +162,14 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
         queryObj[QUERY_PARAMS.exact_match] = "true";
       }
 
-      router.push({
-        pathname: `/documents/${document.slug}`,
-        query: queryObj,
-      });
+      router.push(
+        {
+          pathname: `/documents/${document.slug}`,
+          query: queryObj,
+        },
+        undefined,
+        { shallow: true }
+      );
     },
     [router, document.slug]
   );
@@ -210,37 +218,34 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       if (conceptLabel === "") return false;
 
       const currentConceptFilters = conceptFilters || [];
+      const queryObj = { ...router.query };
+
+      let updatedConceptFilters;
 
       // If the concept is already in filters, remove it
       if (currentConceptFilters.includes(conceptLabel)) {
-        const updatedConceptFilters = currentConceptFilters.filter((concept) => concept !== conceptLabel);
-
-        const queryObj = { ...router.query };
-
-        // If no concept filters remain, remove the concept_name query param entirely
-        if (updatedConceptFilters.length === 0) {
-          delete queryObj[QUERY_PARAMS.concept_name];
-        } else {
-          // Otherwise, update the concept filters
-          queryObj[QUERY_PARAMS.concept_name] = updatedConceptFilters;
-        }
-
-        router.push({
-          pathname: `/documents/${document.slug}`,
-          query: queryObj,
-        });
-        return;
+        updatedConceptFilters = currentConceptFilters.filter((concept) => concept !== conceptLabel);
+      } else {
+        // If the concept is not in filters, add it
+        updatedConceptFilters = [...currentConceptFilters, conceptLabel];
       }
 
-      // If the concept is not in filters, add it
-      const updatedConceptFilters = [...currentConceptFilters, conceptLabel];
+      // If no concept filters remain, remove the concept_name query param entirely
+      if (updatedConceptFilters.length === 0) {
+        delete queryObj[QUERY_PARAMS.concept_name];
+      } else {
+        // Otherwise, update the concept filters
+        queryObj[QUERY_PARAMS.concept_name] = updatedConceptFilters;
+      }
 
-      const queryObj = { ...router.query };
-      queryObj[QUERY_PARAMS.concept_name] = updatedConceptFilters;
-      router.push({
-        pathname: `/documents/${document.slug}`,
-        query: queryObj,
-      });
+      router.push(
+        {
+          pathname: `/documents/${document.slug}`,
+          query: queryObj,
+        },
+        undefined,
+        { shallow: true }
+      );
     },
     [router, document.slug, conceptFilters]
   );
@@ -258,10 +263,14 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   });
 
   const handleClearSearch = useCallback(() => {
-    router.push({
-      pathname: `/documents/${document.slug}`,
-      query: {},
-    });
+    router.push(
+      {
+        pathname: `/documents/${document.slug}`,
+        query: {},
+      },
+      undefined,
+      { shallow: true }
+    );
 
     setPassageMatches([]);
     setTotalNoOfMatches(0);

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -81,13 +81,13 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   const exactMatchQuery = !!router.query[QUERY_PARAMS.exact_match];
   const startingPassage = Number(router.query.passage) || 0;
 
-  const { status, families, searchQuery } = useSearch(
-    router.query,
-    null,
-    document.import_id,
-    !!(router.query[QUERY_PARAMS.query_string] || router.query[QUERY_PARAMS.concept_id] || router.query[QUERY_PARAMS.concept_name]),
-    MAX_PASSAGES
-  );
+  // const { status, families, searchQuery } = useSearch(
+  //   router.query,
+  //   null,
+  //   document.import_id,
+  //   !!(router.query[QUERY_PARAMS.query_string] || router.query[QUERY_PARAMS.concept_id] || router.query[QUERY_PARAMS.concept_name]),
+  //   MAX_PASSAGES
+  // );
 
   const handlePassageClick = (index: number) => {
     if (!canPreview) return;
@@ -174,37 +174,15 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     [router, document.slug]
   );
 
-  useEffect(() => {
-    const [passageMatches, totalNoOfMatches] = getMatchedPassagesFromSearch(families, document);
+  // useEffect(() => {
+  //   const [passageMatches, totalNoOfMatches] = getMatchedPassagesFromSearch(families, document);
 
-    setPassageMatches(passageMatches);
-    setTotalNoOfMatches(totalNoOfMatches);
-    setCanPreview(document.content_type === "application/pdf");
-    // comparing families as objects will cause an infinite loop as each collection is a new instance of an object
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(families), document.slug]);
-
-  /** Concepts: WIP */
-  const [concepts, setConcepts] = useState<TConcept[]>([]);
-  const [rootConcepts, setRootConcepts] = useState<TConcept[]>([]);
-
-  // Extract unique concept keys and their counts
-  const conceptCounts: { conceptKey: string; count: number }[] = useMemo(() => {
-    const uniqueConceptMap = new Map<string, number>();
-
-    (vespaFamilyData?.families ?? []).forEach((family) => {
-      family.hits.forEach((hit) => {
-        Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
-          const existingCount = uniqueConceptMap.get(conceptKey) || 0;
-          uniqueConceptMap.set(conceptKey, existingCount + count);
-        });
-      });
-    });
-
-    return Array.from(uniqueConceptMap.entries())
-      .map(([conceptKey, count]) => ({ conceptKey, count }))
-      .sort((a, b) => b.count - a.count);
-  }, [vespaFamilyData]);
+  //   setPassageMatches(passageMatches);
+  //   setTotalNoOfMatches(totalNoOfMatches);
+  //   setCanPreview(document.content_type === "application/pdf");
+  //   // comparing families as objects will cause an infinite loop as each collection is a new instance of an object
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [JSON.stringify(families), document.slug]);
 
   const conceptFiltersQuery = router.query[QUERY_PARAMS.concept_name];
   const conceptFilters = useMemo(
@@ -250,18 +228,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     [router, document.slug, conceptFilters]
   );
 
-  useEffectOnce(() => {
-    const conceptIds = conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]);
-
-    fetchAndProcessConcepts(conceptIds, (conceptId) => {
-      const url = `https://cdn.climatepolicyradar.org/concepts/${conceptId}.json`;
-      return fetch(url).then((response) => response.json());
-    }).then(({ rootConcepts, concepts }) => {
-      setRootConcepts(rootConcepts);
-      setConcepts(concepts);
-    });
-  });
-
   const handleClearSearch = useCallback(() => {
     router.push(
       {
@@ -293,7 +259,8 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
           handleViewSourceClick={handleViewSourceClick}
         />
 
-        <section className="flex-1 flex" id="document-viewer">
+        <>
+          {/* <section className="flex-1 flex" id="document-viewer">
           <FullWidth extraClasses="flex-1">
             {concepts.length === 0 && (
               <div id="document-container" className="flex flex-col md:flex-row md:h-[80vh]">
@@ -401,17 +368,16 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
               </div>
             )}
           </FullWidth>
-        </section>
+        </section> */}
+        </>
 
-        {concepts.length > 0 && (
+        {vespaFamilyData !== null && (
           <ConceptsDocumentViewer
             initialQueryTerm={qsSearchString}
             initialExactMatch={exactMatchQuery}
             initialPassage={startingPassage}
-            concepts={concepts}
+            vespaFamilyData={vespaFamilyData}
             initialConceptFilters={conceptFilters}
-            rootConcepts={rootConcepts}
-            conceptCounts={conceptCounts}
             document={document}
             onQueryTermChange={handleQueryTermChange}
             onExactMatchChange={handleExactMatchChange}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -81,13 +81,14 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   const exactMatchQuery = !!router.query[QUERY_PARAMS.exact_match];
   const startingPassage = Number(router.query.passage) || 0;
 
-  // const { status, families, searchQuery } = useSearch(
-  //   router.query,
-  //   null,
-  //   document.import_id,
-  //   !!(router.query[QUERY_PARAMS.query_string] || router.query[QUERY_PARAMS.concept_id] || router.query[QUERY_PARAMS.concept_name]),
-  //   MAX_PASSAGES
-  // );
+  // TODO: Remove this once we have hard launched concepts in product.
+  const { status, families, searchQuery } = useSearch(
+    router.query,
+    null,
+    document.import_id,
+    !!(router.query[QUERY_PARAMS.query_string] || router.query[QUERY_PARAMS.concept_id] || router.query[QUERY_PARAMS.concept_name]),
+    MAX_PASSAGES
+  );
 
   const handlePassageClick = (index: number) => {
     if (!canPreview) return;
@@ -174,15 +175,15 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     [router, document.slug]
   );
 
-  // useEffect(() => {
-  //   const [passageMatches, totalNoOfMatches] = getMatchedPassagesFromSearch(families, document);
+  useEffect(() => {
+    const [passageMatches, totalNoOfMatches] = getMatchedPassagesFromSearch(families, document);
 
-  //   setPassageMatches(passageMatches);
-  //   setTotalNoOfMatches(totalNoOfMatches);
-  //   setCanPreview(document.content_type === "application/pdf");
-  //   // comparing families as objects will cause an infinite loop as each collection is a new instance of an object
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [JSON.stringify(families), document.slug]);
+    setPassageMatches(passageMatches);
+    setTotalNoOfMatches(totalNoOfMatches);
+    setCanPreview(document.content_type === "application/pdf");
+    // comparing families as objects will cause an infinite loop as each collection is a new instance of an object
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(families), document.slug]);
 
   const conceptFiltersQuery = router.query[QUERY_PARAMS.concept_name];
   const conceptFilters = useMemo(
@@ -237,10 +238,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
       undefined,
       { shallow: true }
     );
-
-    setPassageMatches([]);
-    setTotalNoOfMatches(0);
-    setPassageIndex(0);
   }, [router, document.slug]);
 
   return (
@@ -259,10 +256,10 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
           handleViewSourceClick={handleViewSourceClick}
         />
 
-        <>
-          {/* <section className="flex-1 flex" id="document-viewer">
-          <FullWidth extraClasses="flex-1">
-            {concepts.length === 0 && (
+        {/* TODO: Remove this once we have hard launched concepts in product. */}
+        {vespaFamilyData === null && (
+          <section className="flex-1 flex" id="document-viewer">
+            <FullWidth extraClasses="flex-1">
               <div id="document-container" className="flex flex-col md:flex-row md:h-[80vh]">
                 <div
                   id="document-preview"
@@ -366,18 +363,17 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
                   )}
                 </div>
               </div>
-            )}
-          </FullWidth>
-        </section> */}
-        </>
+            </FullWidth>
+          </section>
+        )}
 
         {vespaFamilyData !== null && (
           <ConceptsDocumentViewer
             initialQueryTerm={qsSearchString}
             initialExactMatch={exactMatchQuery}
             initialPassage={startingPassage}
-            vespaFamilyData={vespaFamilyData}
             initialConceptFilters={conceptFilters}
+            vespaFamilyData={vespaFamilyData}
             document={document}
             onQueryTermChange={handleQueryTermChange}
             onExactMatchChange={handleExactMatchChange}


### PR DESCRIPTION
# What's changed

Part 1 of getting concepts document viewer production ready.

Includes:
- Fix document viewer page rerendering
- Move concepts logic into concepts doc viewer
- Show loader for concept search so we have user feedback for the lag

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
