### PR TITLE
Add root concept to self

### DIFF
--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -35,13 +35,13 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
     has_subconcept: [],
   };
 
-  const rootConceptIdToConceptsMap: { [rootConceptId: string]: TConcept[] } = Object.groupBy(concepts, (concept) => {
+  const conceptsGroupedByRootConcept: { [rootConceptId: string]: TConcept[] } = Object.groupBy(concepts, (concept) => {
     const rootConcept = rootConcepts.find((rootConcept) => concept.recursive_subconcept_of.includes(rootConcept.wikibase_id));
     const isRootConcept = rootConcepts.some((rootConcept) => rootConcept.wikibase_id === concept.wikibase_id);
 
     /**
      * 1. if it has a root concept, add to that list
-     * 2. if it is a root concept, add to is self
+     * 2. if it is a root concept, add to itself
      * 3. otherwise add to other
      */
     const rootConceptId = rootConcept?.wikibase_id ?? (isRootConcept ? concept.wikibase_id : otherRootConcept.wikibase_id);
@@ -55,7 +55,7 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
       </div>
 
       {rootConcepts.concat(otherRootConcept).map((rootConcept) => {
-        const hasConcepts = rootConceptIdToConceptsMap[rootConcept.wikibase_id]?.length > 0;
+        const hasConcepts = conceptsGroupedByRootConcept[rootConcept.wikibase_id]?.length > 0;
         if (!hasConcepts) return null;
 
         return (
@@ -88,7 +88,7 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
               </div>
             </div>
             <ul className="flex flex-wrap gap-2 mt-4">
-              {rootConceptIdToConceptsMap[rootConcept.wikibase_id].map((concept) => {
+              {conceptsGroupedByRootConcept[rootConcept.wikibase_id].map((concept) => {
                 return (
                   <li key={concept.wikibase_id}>
                     <Link

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -35,7 +35,7 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
     has_subconcept: [],
   };
 
-  const rootConceptIdToConceptsMap: { [rootConceptId: string]: TConcept[] } = concepts.reduce((parentKeyToConceptsMap, concept) => {
+  const rootConceptIdToConceptsMap: { [rootConceptId: string]: TConcept[] } = Object.groupBy(concepts, (concept) => {
     const rootConcept = rootConcepts.find((rootConcept) => concept.recursive_subconcept_of.includes(rootConcept.wikibase_id));
     const isRootConcept = rootConcepts.some((rootConcept) => rootConcept.wikibase_id === concept.wikibase_id);
 
@@ -45,12 +45,8 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
      * 3. otherwise add to other
      */
     const rootConceptId = rootConcept?.wikibase_id ?? (isRootConcept ? concept.wikibase_id : otherRootConcept.wikibase_id);
-
-    return {
-      ...parentKeyToConceptsMap,
-      [rootConceptId]: [...(parentKeyToConceptsMap[rootConceptId] || []), concept],
-    };
-  }, {});
+    return rootConceptId;
+  });
 
   return (
     <div className="pb-4">


### PR DESCRIPTION
# What's changed
- adds the root concept to the list of concepts if it is available
- refactored this out to create a `groupBy` as the code was getting a bit hard to read, and it felt more fit-for-purpose

Follow up from #401 

- **Note the greenhouse gas**
- **Target is known to be weird as it is a sub_concept of Policy instrument, and a root concept itself**. We have spoken with @AnneIsARealProgrammerNow about this

| before | after |
|---|---|
| ![Screenshot 2025-03-05 at 17 07 08](https://github.com/user-attachments/assets/2ac5655e-5e40-469a-9436-0710fb06dc95) | ![Screenshot 2025-03-05 at 17 06 53](https://github.com/user-attachments/assets/46922b5f-c5cf-4e95-a1eb-e1743b8336af) |

## Proposed version

- [x] Patch
