### PR TITLE
chore(deps): bump typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "tailwind-scrollbar": "^4.0.0",
         "tailwindcss": "^4.0.0",
         "ts-node": "^10.9.2",
-        "typescript": "^4.5.4",
+        "typescript": "5.8.2",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^2.1.8"
       }
@@ -17711,9 +17711,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17721,7 +17721,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -18066,22 +18066,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tailwind-scrollbar": "^4.0.0",
     "tailwindcss": "^4.0.0",
     "ts-node": "^10.9.2",
-    "typescript": "^4.5.4",
+    "typescript": "5.8.2",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.8"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "esnext",
     "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
# What's changed
- bumps typescript => v5
- uses esnext as the compiler target

Super fun, no updates needed!

## Proposed version

- [x] Patch
