### PR TITLE
Ensure conditional filters are case-insensitive

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import { ParsedUrlQuery } from "querystring";
+import dynamic from "next/dynamic";
 
 import useGetThemeConfig from "@hooks/useThemeConfig";
 import { Label } from "@components/labels/Label";
@@ -22,7 +23,6 @@ import { canDisplayFilter } from "@utils/canDisplayFilter";
 import { getFilterLabel } from "@utils/getFilterLabel";
 
 import { TConcept, TCorpusTypeDictionary, TGeography, TSearchCriteria, TThemeConfigOption } from "@types";
-import dynamic from "next/dynamic";
 
 const MethodologyLink = dynamic(() => import(`/themes/${process.env.THEME}/components/MethodologyLink`));
 

--- a/src/utils/canDisplayFilter.test.ts
+++ b/src/utils/canDisplayFilter.test.ts
@@ -108,4 +108,12 @@ describe("canDisplayFilter: ", () => {
 
     expect(canDisplay).toBe(true);
   });
+
+  it("should return true if the category is in a different case", () => {
+    const filter = { label: "TEST FILTER", category: ["test_category_3"], taxonomyKey: "test_filter", corporaKey: "TEST_CATEGORY_3", type: "radio" };
+
+    const canDisplay = canDisplayFilter(filter, { [QUERY_PARAMS.category]: "test_CATEGORY_3" }, testThemeConfig);
+
+    expect(canDisplay).toBe(true);
+  });
 });

--- a/src/utils/canDisplayFilter.ts
+++ b/src/utils/canDisplayFilter.ts
@@ -21,7 +21,7 @@ export const canDisplayFilter = (filter: TThemeConfigFilter, query: ParsedUrlQue
   const selectedCategory = query[QUERY_PARAMS.category] as string;
   if (!selectedCategory) return false;
   // Check whether the selected category is in theme's categories (someone might manipulate the query)
-  const selectedCategoryValue = themeConfig.categories.options.find((c) => c.slug === selectedCategory);
+  const selectedCategoryValue = themeConfig.categories.options.find((c) => c.slug.toLowerCase() === selectedCategory.toLowerCase());
   if (!selectedCategoryValue) return false;
   // Check whether the selected category is in the filter's category, and check the alias field too
   if (containsAny(filter.category, selectedCategoryValue.value) || containsAny(filter.category, [selectedCategoryValue.alias])) return true;

--- a/themes/cpr/components/oep/Hero.tsx
+++ b/themes/cpr/components/oep/Hero.tsx
@@ -25,7 +25,7 @@ export const Hero = () => {
   };
 
   const handleSubmit = (query?: string) => {
-    router.push({ pathname: "/search", query: { [QUERY_PARAMS.query_string]: query ?? term, [QUERY_PARAMS.category]: "reports" } });
+    router.push({ pathname: "/search", query: { [QUERY_PARAMS.query_string]: query ?? term, [QUERY_PARAMS.category]: "Reports" } });
   };
 
   return (


### PR DESCRIPTION
# What's changed
- Fix situation where category in URL was set as a different case and so filter was not being displayed
- By making the filter check insensitive
- Add test

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
