### PR TITLE
Fix: Button component type and usage

### DIFF
--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -10,7 +10,7 @@ interface ButtonClassArgs {
   variant?: "solid" | "faded" | "outlined" | "ghost";
 }
 
-type ButtonProps = ButtonClassArgs & React.ButtonHTMLAttributes<HTMLButtonElement>;
+type ButtonProps = ButtonClassArgs & React.ComponentProps<"button">;
 
 export const getButtonClasses = ({
   className,

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -71,7 +71,7 @@ const Pagination = ({
               value={pageNumber}
               type="button"
               variant={isCurrentPage ? "solid" : "ghost"}
-              className={isCurrentPage && "pointer-events-none"}
+              className={isCurrentPage ? "pointer-events-none" : ""}
               onClick={() => onChange(token, offSet)}
               data-ct={token}
               data-offset={offSet}


### PR DESCRIPTION
# What's changed

Very minor PR to address a few runtime errors due to the `Button` component's type and how string props are computed.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
