### PR TITLE
Feature/app 339 Only show concepts in document in document viewer

### DIFF
--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -10,7 +10,7 @@ type TProps = {
   concepts: TConcept[];
   rootConcepts: TConcept[];
   conceptCountsById: Record<string, number>;
-  showCounts: boolean;
+  showCounts?: boolean;
   onConceptClick?: (conceptLabel: string) => void;
 };
 

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -10,10 +10,11 @@ type TProps = {
   concepts: TConcept[];
   rootConcepts: TConcept[];
   conceptCountsById: Record<string, number>;
+  showCounts: boolean;
   onConceptClick?: (conceptLabel: string) => void;
 };
 
-export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onConceptClick }: TProps) => {
+export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showCounts = true, onConceptClick }: TProps) => {
   const [openPopoverIds, setOpenPopoverIds] = useState<string[]>([]);
 
   const handleConceptClick = useCallback(
@@ -100,7 +101,8 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, onCon
                       }}
                     >
                       <Button color="mono" rounded variant="outlined" className="capitalize" data-cy="view-document-viewer-concept">
-                        {concept.preferred_label} {conceptCountsById[concept.wikibase_id]}
+                        {concept.preferred_label}
+                        {showCounts && ` (${conceptCountsById[concept.wikibase_id]})`}
                       </Button>
                     </Link>
                   </li>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -277,6 +277,7 @@ export const ConceptsDocumentViewer = ({
                       concepts={concepts}
                       conceptCountsById={conceptCountsById}
                       onConceptClick={onConceptClick}
+                      showCounts={true}
                     ></ConceptsPanel>
                   )}
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -277,7 +277,7 @@ export const ConceptsDocumentViewer = ({
                       concepts={concepts}
                       conceptCountsById={conceptCountsById}
                       onConceptClick={onConceptClick}
-                      showCounts={true}
+                      showCounts={false}
                     ></ConceptsPanel>
                   )}
 

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -408,7 +408,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     // Fetch Vespa family data for concepts (similar to document/[id].tsx)
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
-      const { data: vespaFamilyDataResponse } = await client.get(`/families/${familyData.import_id}`);
+      const { data: vespaFamilyDataResponse } = await client.get(`/document/${documentData.import_id}`);
       vespaFamilyData = vespaFamilyDataResponse;
     }
   } catch {


### PR DESCRIPTION
# What's changed

Previously we were showing all of the concepts associated with the family rather than the specific document. This will fix this. However, I've also removed the concept counts on the document viewer as I've discovered a bug in the way the concept counts are generated in the SDK. I've made this a boolean for whether to display or not - so we can always toggle it back, but whilst we're investigating the issue with the counts I thought we'd be better off removing them from here!

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
