### PR TITLE
Update custom path to @/api

### DIFF
--- a/src/hooks/useMcfData.ts
+++ b/src/hooks/useMcfData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getEnvFromServer } from "@api/http-common";
+import { getEnvFromServer } from "@/api/http-common";
 import { hasMcfAccess } from "@utils/checkCorpusAccess";
 
 export const useMcfData = () => {

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -1,4 +1,4 @@
-import ViewSDKClient from "@api/pdf";
+import ViewSDKClient from "@/api/pdf";
 import { TPassage, TDocumentPage } from "@types";
 
 function generateHighlights(document: TDocumentPage, documentPassageMatches: TPassage[]) {

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { usePathname } from "next/navigation";
 import axios from "axios";
 
-import { ApiClient } from "@api/http-common";
+import { ApiClient } from "@/api/http-common";
 
 import useSearch from "@hooks/useSearch";
 

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { AnimatePresence, motion } from "framer-motion";
 import { MdOutlineTune } from "react-icons/md";
 
-import { ApiClient } from "@api/http-common";
+import { ApiClient } from "@/api/http-common";
 
 import useSearch from "@hooks/useSearch";
 

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 
-import { ApiClient } from "@api/http-common";
+import { ApiClient } from "@/api/http-common";
 
 import { SiteWidth } from "@components/panels/SiteWidth";
 import { SingleCol } from "@components/panels/SingleCol";

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -37,7 +37,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 
 import { TConcept, TFamilyPage, TTheme, TThemeConfig } from "@types";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { ApiClient } from "@api/http-common";
+import { ApiClient } from "@/api/http-common";
 import { Button } from "@components/atoms/button/Button";
 
 type TProps = {

--- a/src/pages/sitemap.txt.ts
+++ b/src/pages/sitemap.txt.ts
@@ -1,4 +1,4 @@
-import { ApiClient } from "@api/http-common";
+import { ApiClient } from "@/api/http-common";
 import { TDataNode, TGeography } from "@types";
 
 function Sitemap() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "baseUrl": "",
     "types": ["node", "vitest/globals"],
     "paths": {
-      "@api/*": ["src/api/*"],
+      "@/api/*": ["src/api/*"],
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
       "@context/*": ["src/context/*"],


### PR DESCRIPTION
# What's changed

As part of import sorting PR, we are going to update our custom path aliases so that they have a preceding / e.g., @api becomes @/api. This is so we can set an import rule later on in ESLint that groups our custom files separately from 3rd party libraries.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
