### PR TITLE
Update custom path to @/helpers

### DIFF
--- a/src/components/CountryLink.tsx
+++ b/src/components/CountryLink.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from "react";
 import useConfig from "@hooks/useConfig";
-import { getCountrySlug } from "@helpers/getCountryFields";
+import { getCountrySlug } from "@/helpers/getCountryFields";
 import { LinkWithQuery } from "./LinkWithQuery";
 import { systemGeoCodes } from "@constants/systemGeos";
 

--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 
 import { CountryLink } from "@components/CountryLink";
 
-import { getCountryName } from "@helpers/getCountryFields";
+import { getCountryName } from "@/helpers/getCountryFields";
 
 import { isSystemGeo, isSystemInternational } from "@utils/isSystemGeo";
 

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -17,7 +17,7 @@ import { FilterOptions } from "./FilterOptions";
 import { currentYear, minYear } from "@constants/timedate";
 import { QUERY_PARAMS } from "@constants/queryParams";
 
-import { getCountriesFromRegions } from "@helpers/getCountriesFromRegions";
+import { getCountriesFromRegions } from "@/helpers/getCountriesFromRegions";
 
 import { canDisplayFilter } from "@utils/canDisplayFilter";
 import { getFilterLabel } from "@utils/getFilterLabel";

--- a/src/components/document/FamilyDocument.tsx
+++ b/src/components/document/FamilyDocument.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from "next/router";
 import { Icon } from "@components/atoms/icon/Icon";
 import useConfig from "@hooks/useConfig";
-import { getLanguage } from "@helpers/getLanguage";
+import { getLanguage } from "@/helpers/getLanguage";
 import { TDocumentPage, TLoadingStatus } from "@types";
-import { getDocumentType } from "@helpers/getDocumentType";
+import { getDocumentType } from "@/helpers/getDocumentType";
 
 type TProps = {
   document: TDocumentPage;

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -1,5 +1,5 @@
 import useConfig from "@hooks/useConfig";
-import { getCategoryName } from "@helpers/getCategoryName";
+import { getCategoryName } from "@/helpers/getCategoryName";
 import { convertDate } from "@utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@types";
 import { CountryLinks } from "@components/CountryLinks";

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -3,7 +3,7 @@ import useConfig from "@hooks/useConfig";
 import { ExternalLink } from "@components/ExternalLink";
 import { CountryLinksAsList } from "@components/CountryLinks";
 
-import { mapFamilyMetadata } from "@helpers/mapFamilyMetadata";
+import { mapFamilyMetadata } from "@/helpers/mapFamilyMetadata";
 
 import { TConcept, TFamilyMetadata, TMCFFamilyMetadata } from "@types";
 import { LinkWithQuery } from "@components/LinkWithQuery";

--- a/src/components/document/renderers/MetadataRenderer.tsx
+++ b/src/components/document/renderers/MetadataRenderer.tsx
@@ -2,7 +2,7 @@ import { TFamilyMetadata, TMCFFamilyMetadata, TFamilyPage } from "@types";
 
 import { FamilyMeta } from "../FamilyMeta";
 import { McfFamilyMeta } from "../McfFamilyMeta";
-import { getApprovedYearFromEvents } from "@helpers/getApprovedYearFromEvents";
+import { getApprovedYearFromEvents } from "@/helpers/getApprovedYearFromEvents";
 
 const MultilateralClimateFunds = "MCF";
 

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -13,7 +13,7 @@ import { Alert } from "@components/Alert";
 import { ExternalLink } from "@components/ExternalLink";
 import { Heading } from "@components/typography/Heading";
 
-import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
+import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
 import { truncateString } from "@utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@constants/document";

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -1,6 +1,6 @@
 import useConfig from "@hooks/useConfig";
 
-import { getLanguage } from "@helpers/getLanguage";
+import { getLanguage } from "@/helpers/getLanguage";
 import { CountryLinks } from "@components/CountryLinks";
 import { convertDate } from "@utils/timedate";
 

--- a/src/components/documents/renderers/DocumentMetaRenderer.tsx
+++ b/src/components/documents/renderers/DocumentMetaRenderer.tsx
@@ -1,6 +1,6 @@
 import { McfFamilyMeta } from "@components/document/McfFamilyMeta";
 import { DocumentMeta } from "../DocumentMeta";
-import { getApprovedYearFromEvents } from "@helpers/getApprovedYearFromEvents";
+import { getApprovedYearFromEvents } from "@/helpers/getApprovedYearFromEvents";
 
 export const MULTILATERALCLIMATEFUNDSCATEGORY = "MCF";
 

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -7,8 +7,8 @@ import useGetThemeConfig from "@hooks/useThemeConfig";
 
 import Pill from "@components/Pill";
 
-import { getCountryName } from "@helpers/getCountryFields";
-import { getConceptName } from "@helpers/getConceptFields";
+import { getCountryName } from "@/helpers/getCountryFields";
+import { getConceptName } from "@/helpers/getConceptFields";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { sortOptions } from "@constants/sortOptions";

--- a/src/components/filters/MultiList.tsx
+++ b/src/components/filters/MultiList.tsx
@@ -1,6 +1,6 @@
 import useConfig from "@hooks/useConfig";
 import FilterTag from "../labels/FilterTag";
-import { getCountryName } from "@helpers/getCountryFields";
+import { getCountryName } from "@/helpers/getCountryFields";
 import { QUERY_PARAMS } from "@constants/queryParams";
 
 type TProps = {

--- a/src/components/nav/TabbedNav.tsx
+++ b/src/components/nav/TabbedNav.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 
 import TabbedNavItem from "./TabbedNavItem";
 
-import { getCategoryTooltip } from "@helpers/getCategoryTooltip";
+import { getCategoryTooltip } from "@/helpers/getCategoryTooltip";
 
 import { TDocumentCategory } from "@types";
 

--- a/src/components/nav/TabbedNavItem.tsx
+++ b/src/components/nav/TabbedNavItem.tsx
@@ -1,6 +1,6 @@
 import { ToolTipSSR } from "@components/tooltip/TooltipSSR";
 
-import { getCategoryTooltip } from "@helpers/getCategoryTooltip";
+import { getCategoryTooltip } from "@/helpers/getCategoryTooltip";
 
 import { TDocumentCategory } from "@types";
 

--- a/src/helpers/mapFamilyMetadata.ts
+++ b/src/helpers/mapFamilyMetadata.ts
@@ -1,7 +1,7 @@
 import { MULTILATERALCLIMATEFUNDSCATEGORY } from "@components/documents/renderers/DocumentMetaRenderer";
 import { metadataLabelMappings } from "@constants/familyMetadataMappings";
-import { getSubCategoryName } from "@helpers/getCategoryName";
-import { getSumUSD } from "@helpers/getSumUSD";
+import { getSubCategoryName } from "@/helpers/getCategoryName";
+import { getSumUSD } from "@/helpers/getSumUSD";
 import { TCorpusTypeSubCategory } from "@types";
 
 interface Metadata {

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -30,9 +30,9 @@ import { SubNav } from "@components/nav/SubNav";
 import { Heading } from "@components/typography/Heading";
 
 import { truncateString } from "@utils/truncateString";
-import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
-import { getCorpusInfo } from "@helpers/getCorpusInfo";
-import { getMainDocuments } from "@helpers/getMainDocuments";
+import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { getCorpusInfo } from "@/helpers/getCorpusInfo";
+import { getMainDocuments } from "@/helpers/getMainDocuments";
 
 import { sortFilterTargets } from "@utils/sortFilterTargets";
 import { pluralise } from "@utils/pluralise";

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -25,7 +25,7 @@ import { Alert } from "@components/Alert";
 import { SubNav } from "@components/nav/SubNav";
 import { Heading } from "@components/typography/Heading";
 
-import { getCountryCode } from "@helpers/getCountryFields";
+import { getCountryCode } from "@/helpers/getCountryFields";
 
 import { extractNestedData } from "@utils/extractNestedData";
 import { sortFilterTargets } from "@utils/sortFilterTargets";

--- a/src/utils/getFamilyMetaDescription.ts
+++ b/src/utils/getFamilyMetaDescription.ts
@@ -1,5 +1,5 @@
 import { TCategory } from "@types";
-import { getCategoryName } from "@helpers/getCategoryName";
+import { getCategoryName } from "@/helpers/getCategoryName";
 
 const stripHtml = (html: string) => {
   return html.replace(/<[^>]*>?/gm, "");

--- a/themes/cclw/components/Instructions.tsx
+++ b/themes/cclw/components/Instructions.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import useConfig from "@hooks/useConfig";
 
-import { calculateTotalFamilies } from "@helpers/getFamilyCounts";
+import { calculateTotalFamilies } from "@/helpers/getFamilyCounts";
 
 import { Button } from "@components/atoms/button/Button";
 import { Icon } from "@components/atoms/icon/Icon";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
       "@context/*": ["src/context/*"],
-      "@helpers/*": ["src/helpers/*"],
+      "@/helpers/*": ["src/helpers/*"],
       "@hooks/*": ["src/hooks/*"],
       "@interfaces/*": ["src/interfaces/*"],
       "@types": ["src/types/index"],


### PR DESCRIPTION
# What's changed

As part of import sorting PR, we are going to update our custom path aliases so that they have a preceding / e.g., @helpers becomes @/helpers. This is so we can set an import rule later on in ESLint that groups our custom files separately from 3rd party libraries.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
