### PR TITLE
Update custom path to @/components

### DIFF
--- a/scripts/build-custom-app.sh
+++ b/scripts/build-custom-app.sh
@@ -61,8 +61,8 @@ printf " -> Created custom app directory for %s: %s\n\n" "${theme}" "${new_dir}"
 read -r -d '' MAIN_CONTENT <<EOM
 
 import React, { FC, ReactNode } from "react";
-import Header from "@components/headers/Main";
-import Footer from "@components/footer/Footer";
+import Header from "@/components/headers/Main";
+import Footer from "@/components/footer/Footer";
 
 type TProps = {
   children?: ReactNode;
@@ -97,7 +97,7 @@ read -r -d '' HOMEPAGE_CONTENT <<EOM
 
 import React from "react";
 // generic layer component
-import Layout from "@components/layouts/LandingPage";
+import Layout from "@/components/layouts/LandingPage";
 
 import Hero from "@${theme}/components/Hero";
 

--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 
-import { CountryLink } from "@components/CountryLink";
+import { CountryLink } from "@/components/CountryLink";
 
 import { getCountryName } from "@helpers/getCountryFields";
 

--- a/src/components/NoOfResults.tsx
+++ b/src/components/NoOfResults.tsx
@@ -1,4 +1,4 @@
-import { SearchLimitTooltip } from "@components/tooltip/SearchLimitTooltip";
+import { SearchLimitTooltip } from "@/components/tooltip/SearchLimitTooltip";
 
 import { MAX_RESULTS } from "@constants/paging";
 

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "./atoms/icon/Icon";
-import { ToolTipSSR } from "@components/tooltip/TooltipSSR";
+import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
 
 type TProps = {
   onClick?: () => void;

--- a/src/components/atoms/button/Button.stories.tsx
+++ b/src/components/atoms/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 import { Meta, StoryObj } from "@storybook/react/*";
 import { LuMoveUpRight } from "react-icons/lu";
 import { Button } from "./Button";

--- a/src/components/blocks/CountryHeader.tsx
+++ b/src/components/blocks/CountryHeader.tsx
@@ -1,8 +1,8 @@
 import useConfig from "@hooks/useConfig";
 
-import Tooltip from "@components/tooltip";
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import Tooltip from "@/components/tooltip";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 import { TGeographyStats, TGeography, TTheme } from "@types";
 

--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { ParsedUrlQuery } from "querystring";
 
-import { InputCheck } from "@components/forms/Checkbox";
-import { InputRadio } from "@components/forms/Radio";
+import { InputCheck } from "@/components/forms/Checkbox";
+import { InputRadio } from "@/components/forms/Radio";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 
 import { TCorpusTypeDictionary, TThemeConfig, TThemeConfigFilter } from "@types";
-import { TextInput } from "@components/forms/TextInput";
+import { TextInput } from "@/components/forms/TextInput";
 
 const getTaxonomyAllowedValues = (corporaKey: string, taxonomyKey: string, corpus_types: TCorpusTypeDictionary) => {
   const allowedValues = corpus_types[corporaKey].taxonomy[taxonomyKey]?.allowed_values;

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -3,15 +3,15 @@ import { ParsedUrlQuery } from "querystring";
 import dynamic from "next/dynamic";
 
 import useGetThemeConfig from "@hooks/useThemeConfig";
-import { Label } from "@components/labels/Label";
+import { Label } from "@/components/labels/Label";
 import { DateRange } from "../filters/DateRange";
-import { Accordian } from "@components/accordian/Accordian";
-import { InputListContainer } from "@components/filters/InputListContainer";
+import { Accordian } from "@/components/accordian/Accordian";
+import { InputListContainer } from "@/components/filters/InputListContainer";
 import { TypeAhead } from "../forms/TypeAhead";
-import { InputCheck } from "@components/forms/Checkbox";
-import { InputRadio } from "@components/forms/Radio";
-import { AppliedFilters } from "@components/filters/AppliedFilters";
-import Loader from "@components/Loader";
+import { InputCheck } from "@/components/forms/Checkbox";
+import { InputRadio } from "@/components/forms/Radio";
+import { AppliedFilters } from "@/components/filters/AppliedFilters";
+import Loader from "@/components/Loader";
 import { FilterOptions } from "./FilterOptions";
 
 import { currentYear, minYear } from "@constants/timedate";

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { isSystemGeo } from "@utils/isSystemGeo";
 
 const BREADCRUMB_MAXLENGTH = 50;

--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
-import { Label } from "@components/labels/Label";
-import { Quote } from "@components/typography/Quote";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
+import { Label } from "@/components/labels/Label";
+import { Quote } from "@/components/typography/Quote";
 
 export const ConceptsHead = () => {
   return (

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -1,7 +1,7 @@
 import { ConceptsHead } from "./ConceptsHead";
 import { HiOutlineDotsHorizontal } from "react-icons/hi";
-import { ConceptsPopover } from "@components/popover/ConceptsPopover";
-import { Button } from "@components/atoms/button/Button";
+import { ConceptsPopover } from "@/components/popover/ConceptsPopover";
+import { Button } from "@/components/atoms/button/Button";
 import Link from "next/link";
 import { TConcept } from "@types";
 import { useCallback, useState } from "react";

--- a/src/components/cookies/CookieConsent.tsx
+++ b/src/components/cookies/CookieConsent.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import Script from "next/script";
 
-import { Button } from "@components/atoms/button/Button";
-import { ExternalLink } from "@components/ExternalLink";
+import { Button } from "@/components/atoms/button/Button";
+import { ExternalLink } from "@/components/ExternalLink";
 
 import { getCookie, setCookie } from "@utils/cookies";
 import getDomain from "@utils/getDomain";

--- a/src/components/document/FamilyDocument.tsx
+++ b/src/components/document/FamilyDocument.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 import useConfig from "@hooks/useConfig";
 import { getLanguage } from "@helpers/getLanguage";
 import { TDocumentPage, TLoadingStatus } from "@types";

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 import { TFamilyPage } from "@types";
 
 import { MetadataRenderer } from "./renderers/MetadataRenderer";

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 import { TFamily } from "@types";
 
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { FamilyMeta } from "./FamilyMeta";
 
 import { truncateString } from "@utils/truncateString";

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -2,7 +2,7 @@ import useConfig from "@hooks/useConfig";
 import { getCategoryName } from "@helpers/getCategoryName";
 import { convertDate } from "@utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@types";
-import { CountryLinks } from "@components/CountryLinks";
+import { CountryLinks } from "@/components/CountryLinks";
 
 type TProps = {
   category: TCategory;

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -1,12 +1,12 @@
 import useConfig from "@hooks/useConfig";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { CountryLinksAsList } from "@components/CountryLinks";
+import { ExternalLink } from "@/components/ExternalLink";
+import { CountryLinksAsList } from "@/components/CountryLinks";
 
 import { mapFamilyMetadata } from "@helpers/mapFamilyMetadata";
 
 import { TConcept, TFamilyMetadata, TMCFFamilyMetadata } from "@types";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 interface MetadataItemProps {
   label: string;

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -1,24 +1,24 @@
-import EmbeddedPDF from "@components/EmbeddedPDF";
-import { FullWidth } from "@components/panels/FullWidth";
+import EmbeddedPDF from "@/components/EmbeddedPDF";
+import { FullWidth } from "@/components/panels/FullWidth";
 import { TConcept, TDocumentPage, TSearchResponse } from "@types";
 import { EmptyDocument } from "./EmptyDocument";
-import { Button } from "@components/atoms/button/Button";
-import SearchForm from "@components/forms/SearchForm";
+import { Button } from "@/components/atoms/button/Button";
+import SearchForm from "@/components/forms/SearchForm";
 import { MdOutlineTune } from "react-icons/md";
 import { AnimatePresence } from "framer-motion";
-import PassageMatches from "@components/PassageMatches";
-import { SearchLimitTooltip } from "@components/tooltip/SearchLimitTooltip";
+import PassageMatches from "@/components/PassageMatches";
+import { SearchLimitTooltip } from "@/components/tooltip/SearchLimitTooltip";
 import { EmptyPassages } from "./EmptyPassages";
 import { motion } from "framer-motion";
 import { useEffect, useState, useCallback, useMemo, useReducer } from "react";
-import { SearchSettings } from "@components/filters/SearchSettings";
+import { SearchSettings } from "@/components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 import useSearch from "@hooks/useSearch";
-import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
+import { ConceptsPanel } from "@/components/concepts/ConceptsPanel";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
 import { useEffectOnce } from "@hooks/useEffectOnce";
-import Loader from "@components/Loader";
+import Loader from "@/components/Loader";
 
 type TProps = {
   initialQueryTerm?: string | string[];

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -3,15 +3,15 @@ import { LuMoveUpRight } from "react-icons/lu";
 
 import useConfig from "@hooks/useConfig";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { SubNav } from "@components/nav/SubNav";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Button } from "@components/atoms/button/Button";
-import { Icon } from "@components/atoms/icon/Icon";
-import { Alert } from "@components/Alert";
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { SubNav } from "@/components/nav/SubNav";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Button } from "@/components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { Alert } from "@/components/Alert";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
 import { truncateString } from "@utils/truncateString";

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -1,7 +1,7 @@
 import useConfig from "@hooks/useConfig";
 
 import { getLanguage } from "@helpers/getLanguage";
-import { CountryLinks } from "@components/CountryLinks";
+import { CountryLinks } from "@/components/CountryLinks";
 import { convertDate } from "@utils/timedate";
 
 export const DocumentMeta = ({ family, isMain, document, document_type }: { family: any; isMain: boolean; document: any; document_type: any }) => {

--- a/src/components/documents/EmptyDocument.tsx
+++ b/src/components/documents/EmptyDocument.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Icon } from "@components/atoms/icon/Icon";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 export const EmptyDocument = () => (
   <div className="ml-4 text-center text-gray-600">

--- a/src/components/documents/EmptyPassages.tsx
+++ b/src/components/documents/EmptyPassages.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 type TProps = {
   hasQueryString: boolean;

--- a/src/components/documents/renderers/DocumentMetaRenderer.tsx
+++ b/src/components/documents/renderers/DocumentMetaRenderer.tsx
@@ -1,4 +1,4 @@
-import { McfFamilyMeta } from "@components/document/McfFamilyMeta";
+import { McfFamilyMeta } from "@/components/document/McfFamilyMeta";
 import { DocumentMeta } from "../DocumentMeta";
 import { getApprovedYearFromEvents } from "@helpers/getApprovedYearFromEvents";
 

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from "react";
-import { Icon } from "@components/atoms/icon/Icon";
-import { Button } from "@components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { Button } from "@/components/atoms/button/Button";
 
 interface SlideoutProps {
   children: JSX.Element | string;

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -2,11 +2,11 @@ import { useRouter } from "next/router";
 
 import { TMatchedFamily } from "@types";
 
-import { FamilyMeta } from "@components/document/FamilyMeta";
-import PassageMatches from "@components/PassageMatches";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { Button } from "@components/atoms/button/Button";
-import { Heading } from "@components/typography/Heading";
+import { FamilyMeta } from "@/components/document/FamilyMeta";
+import PassageMatches from "@/components/PassageMatches";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { Button } from "@/components/atoms/button/Button";
+import { Heading } from "@/components/typography/Heading";
 
 import { CleanRouterQuery } from "@utils/cleanRouterQuery";
 import { truncateString } from "@utils/truncateString";

--- a/src/components/error/PageLevel.tsx
+++ b/src/components/error/PageLevel.tsx
@@ -1,8 +1,8 @@
-import Layout from "@components/layouts/Main";
+import Layout from "@/components/layouts/Main";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Button } from "@components/atoms/button/Button";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Button } from "@/components/atoms/button/Button";
+import { Heading } from "@/components/typography/Heading";
 
 type TProps = {
   resetError: () => void;

--- a/src/components/error/TopLevel.tsx
+++ b/src/components/error/TopLevel.tsx
@@ -1,6 +1,6 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Button } from "@components/atoms/button/Button";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Button } from "@/components/atoms/button/Button";
+import { Heading } from "@/components/typography/Heading";
 
 type TProps = {
   resetError: () => void;

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -5,7 +5,7 @@ import { ParsedUrlQuery } from "querystring";
 import useConfig from "@hooks/useConfig";
 import useGetThemeConfig from "@hooks/useThemeConfig";
 
-import Pill from "@components/Pill";
+import Pill from "@/components/Pill";
 
 import { getCountryName } from "@helpers/getCountryFields";
 import { getConceptName } from "@helpers/getConceptFields";

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -3,9 +3,9 @@ import { useRouter } from "next/router";
 
 import { DateRangeInput } from "./DateRangeInput";
 import { FormError } from "../forms/FormError";
-import { InputListContainer } from "@components/filters/InputListContainer";
-import { InputRadio } from "@components/forms/Radio";
-import { Button } from "@components/atoms/button/Button";
+import { InputListContainer } from "@/components/filters/InputListContainer";
+import { InputRadio } from "@/components/forms/Radio";
+import { Button } from "@/components/atoms/button/Button";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { currentYear } from "@constants/timedate";

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,6 +1,6 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 import FooterLinks from "./FooterLinks";
 
 const Footer = () => {

--- a/src/components/footer/FooterLinks.tsx
+++ b/src/components/footer/FooterLinks.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 const FooterLinks = () => {
   return (

--- a/src/components/forms/DocumentSearchForm.tsx
+++ b/src/components/forms/DocumentSearchForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import SearchForm from "./SearchForm";
-import { Button } from "@components/atoms/button/Button";
+import { Button } from "@/components/atoms/button/Button";
 
 interface DocumentSearchFormProps {
   input?: string;

--- a/src/components/forms/SearchDropdown.tsx
+++ b/src/components/forms/SearchDropdown.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import useConfig from "@hooks/useConfig";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { TGeography } from "@types";
 import { systemGeoCodes } from "@constants/systemGeos";

--- a/src/components/forms/SearchForm.tsx
+++ b/src/components/forms/SearchForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 
 import { SearchDropdown } from "./SearchDropdown";
 import { TextInput } from "./TextInput";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 type TProps = {
   input?: string;

--- a/src/components/forms/TypeAhead.tsx
+++ b/src/components/forms/TypeAhead.tsx
@@ -4,7 +4,7 @@ import SuggestList from "../filters/SuggestList";
 import { TextInput } from "./TextInput";
 
 import { sortData } from "@utils/sorting";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 type TProps = {
   list: Object[];

--- a/src/components/headers/LandingPage.tsx
+++ b/src/components/headers/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
 import MainMenu from "../menus/MainMenu";
 

--- a/src/components/headers/PageHeader.tsx
+++ b/src/components/headers/PageHeader.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 import { useRouter } from "next/router";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 import MainMenu from "../menus/MainMenu";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { FloatingSearch } from "@components/FloatingSearch";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { FloatingSearch } from "@/components/FloatingSearch";
 
 const NON_SEARCH_PAGES = ["/", "/search"];
 

--- a/src/components/map/GeographySelect.tsx
+++ b/src/components/map/GeographySelect.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import SuggestList from "@components/filters/SuggestList";
+import SuggestList from "@/components/filters/SuggestList";
 import { sortData } from "@utils/sorting";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 interface ByTextInputProps {
   title: string;

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -6,7 +6,7 @@ import useConfig from "@hooks/useConfig";
 import useGeographies from "@hooks/useGeographies";
 import { useMcfData } from "@hooks/useMcfData";
 
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import GeographySelect from "./GeographySelect";
 import { ZoomControls } from "./ZoomControls";
 import { Legend } from "./Legend";

--- a/src/components/menus/DropdownMenuItem.tsx
+++ b/src/components/menus/DropdownMenuItem.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { useRouter } from "next/router";
 
 interface DropdownMenuItemProps {

--- a/src/components/menus/MainMenu.tsx
+++ b/src/components/menus/MainMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react";
 import useOutsideAlerter from "@hooks/useOutsideAlerter";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 import DropdownMenuItem from "./DropdownMenuItem";
 import DropdownMenuWrapper from "./DropdownMenuWrapper";
 

--- a/src/components/modals/DownloadCsv.tsx
+++ b/src/components/modals/DownloadCsv.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Button } from "@components/atoms/button/Button";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Button } from "@/components/atoms/button/Button";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { Heading } from "@/components/typography/Heading";
 import Popup from "./Popup";
 
 type TProps = {

--- a/src/components/modals/Popup.tsx
+++ b/src/components/modals/Popup.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@components/atoms/button/Button";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Button } from "@/components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 const Popup = ({ active, onCloseClick, children }) => {
   return (

--- a/src/components/nav/SubNav.tsx
+++ b/src/components/nav/SubNav.tsx
@@ -1,4 +1,4 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
 type TProps = {
   extraClasses?: string;

--- a/src/components/nav/TabbedNavItem.tsx
+++ b/src/components/nav/TabbedNavItem.tsx
@@ -1,4 +1,4 @@
-import { ToolTipSSR } from "@components/tooltip/TooltipSSR";
+import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
 
 import { getCategoryTooltip } from "@helpers/getCategoryTooltip";
 

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 
-import { Button } from "@components/atoms/button/Button";
+import { Button } from "@/components/atoms/button/Button";
 import { MAX_PAGES, RESULTS_PER_PAGE, PAGES_PER_CONTINUATION_TOKEN } from "@constants/paging";
 
 import { getCurrentPage } from "@utils/getCurrentPage";

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 import { TConcept } from "@types";
 import { getConceptStoreLink } from "@utils/getConceptStoreLink";
 import { Popover } from "./Popover";

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -1,7 +1,7 @@
-import { Button } from "@components/atoms/button/Button";
-import { FamilyListItem } from "@components/document/FamilyListItem";
-import { Icon } from "@components/atoms/icon/Icon";
-import { ToolTipSSR } from "@components/tooltip/TooltipSSR";
+import { Button } from "@/components/atoms/button/Button";
+import { FamilyListItem } from "@/components/document/FamilyListItem";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
 import { MAX_RESULTS } from "@constants/paging";
 import { TMatchedFamily } from "@types";
 interface ISearchResultProps {

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 import SearchResult from "./SearchResult";
 
 import { TMatchedFamily } from "@types";

--- a/src/helpers/mapFamilyMetadata.ts
+++ b/src/helpers/mapFamilyMetadata.ts
@@ -1,4 +1,4 @@
-import { MULTILATERALCLIMATEFUNDSCATEGORY } from "@components/documents/renderers/DocumentMetaRenderer";
+import { MULTILATERALCLIMATEFUNDSCATEGORY } from "@/components/documents/renderers/DocumentMetaRenderer";
 import { metadataLabelMappings } from "@constants/familyMetadataMappings";
 import { getSubCategoryName } from "@helpers/getCategoryName";
 import { getSumUSD } from "@helpers/getSumUSD";

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,8 @@
 import Layout from "../components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 export default function NotFound() {
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,8 +10,8 @@ import "../styles/main.css";
 import { ThemeContext } from "@context/ThemeContext";
 import { AdobeContext } from "@context/AdobeContext";
 
-import { CookieConsent } from "@components/cookies/CookieConsent";
-import ErrorBoundary from "@components/error/ErrorBoundary";
+import { CookieConsent } from "@/components/cookies/CookieConsent";
+import ErrorBoundary from "@/components/error/ErrorBoundary";
 import { PostHogProvider } from "@context/PostHogProvider";
 
 const favicon = `/images/favicon/${process.env.THEME}.png`;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,8 +1,8 @@
 import Layout from "../components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 function Error({ statusCode }) {
   return (

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@components/atoms/button/Button";
+import { Button } from "@/components/atoms/button/Button";
 import { setFeatureFlags } from "@utils/featureFlags";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -9,25 +9,25 @@ import { ApiClient } from "@api/http-common";
 
 import useSearch from "@hooks/useSearch";
 
-import { SingleCol } from "@components/panels/SingleCol";
-import Layout from "@components/layouts/Main";
-import { Timeline } from "@components/timeline/Timeline";
-import { Event } from "@components/timeline/Event";
-import { FamilyHead } from "@components/document/FamilyHead";
-import { FamilyDocument } from "@components/document/FamilyDocument";
-import { ExternalLink } from "@components/ExternalLink";
-import { Targets } from "@components/Targets";
-import { ShowHide } from "@components/controls/ShowHide";
-import { Divider } from "@components/dividers/Divider";
-import { Icon } from "@components/atoms/icon/Icon";
-import { Button } from "@components/atoms/button/Button";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Tooltip from "@components/tooltip";
-import DocumentSearchForm from "@components/forms/DocumentSearchForm";
-import { Alert } from "@components/Alert";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
+import { SingleCol } from "@/components/panels/SingleCol";
+import Layout from "@/components/layouts/Main";
+import { Timeline } from "@/components/timeline/Timeline";
+import { Event } from "@/components/timeline/Event";
+import { FamilyHead } from "@/components/document/FamilyHead";
+import { FamilyDocument } from "@/components/document/FamilyDocument";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Targets } from "@/components/Targets";
+import { ShowHide } from "@/components/controls/ShowHide";
+import { Divider } from "@/components/dividers/Divider";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { Button } from "@/components/atoms/button/Button";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Tooltip from "@/components/tooltip";
+import DocumentSearchForm from "@/components/forms/DocumentSearchForm";
+import { Alert } from "@/components/Alert";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
 
 import { truncateString } from "@utils/truncateString";
 import { getCountryName, getCountrySlug } from "@helpers/getCountryFields";
@@ -47,9 +47,9 @@ import { MAX_FAMILY_SUMMARY_LENGTH } from "@constants/document";
 import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
-import { MultiCol } from "@components/panels/MultiCol";
+import { MultiCol } from "@/components/panels/MultiCol";
 import { useEffectOnce } from "@hooks/useEffectOnce";
-import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
+import { ConceptsPanel } from "@/components/concepts/ConceptsPanel";
 
 type TProps = {
   page: TFamilyPage;

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -8,18 +8,18 @@ import { ApiClient } from "@api/http-common";
 
 import useSearch from "@hooks/useSearch";
 
-import { FullWidth } from "@components/panels/FullWidth";
+import { FullWidth } from "@/components/panels/FullWidth";
 
-import Layout from "@components/layouts/Main";
-import EmbeddedPDF from "@components/EmbeddedPDF";
-import PassageMatches from "@components/PassageMatches";
-import Loader from "@components/Loader";
-import SearchForm from "@components/forms/SearchForm";
-import { SearchLimitTooltip } from "@components/tooltip/SearchLimitTooltip";
-import { DocumentHead } from "@components/documents/DocumentHead";
-import { EmptyPassages } from "@components/documents/EmptyPassages";
-import { EmptyDocument } from "@components/documents/EmptyDocument";
-import { SearchSettings } from "@components/filters/SearchSettings";
+import Layout from "@/components/layouts/Main";
+import EmbeddedPDF from "@/components/EmbeddedPDF";
+import PassageMatches from "@/components/PassageMatches";
+import Loader from "@/components/Loader";
+import SearchForm from "@/components/forms/SearchForm";
+import { SearchLimitTooltip } from "@/components/tooltip/SearchLimitTooltip";
+import { DocumentHead } from "@/components/documents/DocumentHead";
+import { EmptyPassages } from "@/components/documents/EmptyPassages";
+import { EmptyDocument } from "@/components/documents/EmptyDocument";
+import { SearchSettings } from "@/components/filters/SearchSettings";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { getDocumentDescription } from "@constants/metaDescriptions";
@@ -28,7 +28,7 @@ import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
 
 import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TConcept } from "@types";
 import { getFeatureFlags } from "@utils/featureFlags";
-import { ConceptsDocumentViewer } from "@components/documents/ConceptsDocumentViewer";
+import { ConceptsDocumentViewer } from "@/components/documents/ConceptsDocumentViewer";
 import { getMatchedPassagesFromSearch } from "@utils/getMatchedPassagesFromFamiy";
 
 type TProps = {

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -5,25 +5,25 @@ import { useRouter } from "next/router";
 
 import { ApiClient } from "@api/http-common";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
 
-import Layout from "@components/layouts/Main";
-import { Timeline } from "@components/timeline/Timeline";
-import { Event } from "@components/timeline/Event";
-import { CountryHeader } from "@components/blocks/CountryHeader";
-import { Divider } from "@components/dividers/Divider";
-import { Icon } from "@components/atoms/icon/Icon";
-import { FamilyListItem } from "@components/document/FamilyListItem";
-import { Targets } from "@components/Targets";
-import { Button } from "@components/atoms/button/Button";
-import TabbedNav from "@components/nav/TabbedNav";
-import { ExternalLink } from "@components/ExternalLink";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import DocumentSearchForm from "@components/forms/DocumentSearchForm";
-import { Alert } from "@components/Alert";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
+import Layout from "@/components/layouts/Main";
+import { Timeline } from "@/components/timeline/Timeline";
+import { Event } from "@/components/timeline/Event";
+import { CountryHeader } from "@/components/blocks/CountryHeader";
+import { Divider } from "@/components/dividers/Divider";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { FamilyListItem } from "@/components/document/FamilyListItem";
+import { Targets } from "@/components/Targets";
+import { Button } from "@/components/atoms/button/Button";
+import TabbedNav from "@/components/nav/TabbedNav";
+import { ExternalLink } from "@/components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import DocumentSearchForm from "@/components/forms/DocumentSearchForm";
+import { Alert } from "@/components/Alert";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
 
 import { getCountryCode } from "@helpers/getCountryFields";
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -9,26 +9,26 @@ import useConfig from "@hooks/useConfig";
 import { useDownloadCsv } from "@hooks/useDownloadCsv";
 import useSearch from "@hooks/useSearch";
 
-import { MultiCol } from "@components/panels/MultiCol";
-import { SideCol } from "@components/panels/SideCol";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { MultiCol } from "@/components/panels/MultiCol";
+import { SideCol } from "@/components/panels/SideCol";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import Loader from "@components/Loader";
-import { NoOfResults } from "@components/NoOfResults";
-import SearchFilters from "@components/blocks/SearchFilters";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Drawer from "@components/drawer/Drawer";
-import { FamilyMatchesDrawer } from "@components/drawer/FamilyMatchesDrawer";
-import { SearchSettings } from "@components/filters/SearchSettings";
-import SearchForm from "@components/forms/SearchForm";
-import Layout from "@components/layouts/Main";
-import { DownloadCsvPopup } from "@components/modals/DownloadCsv";
-import { SubNav } from "@components/nav/SubNav";
-import Pagination from "@components/pagination";
-import SearchResultList from "@components/search/SearchResultList";
-import { Icon } from "@components/atoms/icon/Icon";
+import { ExternalLink } from "@/components/ExternalLink";
+import Loader from "@/components/Loader";
+import { NoOfResults } from "@/components/NoOfResults";
+import SearchFilters from "@/components/blocks/SearchFilters";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Drawer from "@/components/drawer/Drawer";
+import { FamilyMatchesDrawer } from "@/components/drawer/FamilyMatchesDrawer";
+import { SearchSettings } from "@/components/filters/SearchSettings";
+import SearchForm from "@/components/forms/SearchForm";
+import Layout from "@/components/layouts/Main";
+import { DownloadCsvPopup } from "@/components/modals/DownloadCsv";
+import { SubNav } from "@/components/nav/SubNav";
+import Pagination from "@/components/pagination";
+import SearchResultList from "@/components/search/SearchResultList";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 import { getThemeConfigLink } from "@utils/getThemeConfigLink";
 import { readConfigFile } from "@utils/readConfigFile";
@@ -38,7 +38,7 @@ import { QUERY_PARAMS } from "@constants/queryParams";
 import { TConcept, TFamilyPage, TTheme, TThemeConfig } from "@types";
 import { getFeatureFlags } from "@utils/featureFlags";
 import { ApiClient } from "@api/http-common";
-import { Button } from "@components/atoms/button/Button";
+import { Button } from "@/components/atoms/button/Button";
 
 type TProps = {
   theme: TTheme;

--- a/themes/cclw/components/Acknowledgements.tsx
+++ b/themes/cclw/components/Acknowledgements.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @next/next/no-img-element */
 import { ReactNode } from "react";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 type TAcknowledgement = {
   partnerImage?: {

--- a/themes/cclw/components/Articles.tsx
+++ b/themes/cclw/components/Articles.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Card } from "@cclw/components/Card";
 
 type TArticle = {

--- a/themes/cclw/components/Banner.tsx
+++ b/themes/cclw/components/Banner.tsx
@@ -1,4 +1,4 @@
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 export const Banner = () => {
   return (

--- a/themes/cclw/components/Feature.tsx
+++ b/themes/cclw/components/Feature.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
 import Image from "next/image";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 
 type TProps = {
   heading?: string;

--- a/themes/cclw/components/FeatureDiscover.tsx
+++ b/themes/cclw/components/FeatureDiscover.tsx
@@ -1,8 +1,8 @@
 import { Feature } from "./Feature";
 
-import { getButtonClasses } from "@components/atoms/button/Button";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { ExternalLink } from "@components/ExternalLink";
+import { getButtonClasses } from "@/components/atoms/button/Button";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
 
 export const FeatureDiscover = () => (
   <Feature heading="Central knowledge-base for climate policy data" image="app_search_results.jpg" imageAlt="Screenshot of the search results">

--- a/themes/cclw/components/FeatureSearch.tsx
+++ b/themes/cclw/components/FeatureSearch.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { Feature } from "./Feature";
 
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 export const FeatureSearch = () => (
   <Feature

--- a/themes/cclw/components/Feedback.tsx
+++ b/themes/cclw/components/Feedback.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 export const Feedback = () => {
   return (

--- a/themes/cclw/components/Footer.tsx
+++ b/themes/cclw/components/Footer.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import Image from "next/image";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Feedback } from "./Feedback";
 import MENU_LINKS from "../constants/menuLinks";
 

--- a/themes/cclw/components/Header.tsx
+++ b/themes/cclw/components/Header.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from "next/router";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { FloatingSearch } from "@components/FloatingSearch";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { FloatingSearch } from "@/components/FloatingSearch";
 
 import { Menu } from "@cclw/components/Menu";
 import { Logo } from "@cclw/components/Logo";

--- a/themes/cclw/components/HelpUs.tsx
+++ b/themes/cclw/components/HelpUs.tsx
@@ -1,9 +1,9 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { Heading } from "@components/typography/Heading";
-import { getButtonClasses } from "@components/atoms/button/Button";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { Heading } from "@/components/typography/Heading";
+import { getButtonClasses } from "@/components/atoms/button/Button";
 
 const EMAIL_SUBJECT = "Joining the NLP community";
 const EMAIL_BODY = "Hi, I am interested in joining the climate NLP community. It is relevant to me because...";

--- a/themes/cclw/components/Hero.tsx
+++ b/themes/cclw/components/Hero.tsx
@@ -1,10 +1,10 @@
 import dynamic from "next/dynamic";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
 import LandingSearchForm from "./LandingSearchForm";
 import { LogoLarge } from "./LogoLarge";
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 
 const Instructions = dynamic(() => import("./Instructions"), {
   loading: () => <p>Loading document stats...</p>,

--- a/themes/cclw/components/Instructions.tsx
+++ b/themes/cclw/components/Instructions.tsx
@@ -4,8 +4,8 @@ import useConfig from "@hooks/useConfig";
 
 import { calculateTotalFamilies } from "@helpers/getFamilyCounts";
 
-import { Button } from "@components/atoms/button/Button";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Button } from "@/components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 import { INSTRUCTIONS } from "@cclw/constants/instructions";
 

--- a/themes/cclw/components/LandingSearchForm.tsx
+++ b/themes/cclw/components/LandingSearchForm.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, ChangeEvent } from "react";
 
-import { Icon } from "@components/atoms/icon/Icon";
-import { SearchDropdown } from "@components/forms/SearchDropdown";
-import { Button } from "@components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { SearchDropdown } from "@/components/forms/SearchDropdown";
+import { Button } from "@/components/atoms/button/Button";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 

--- a/themes/cclw/components/Menu.tsx
+++ b/themes/cclw/components/Menu.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef } from "react";
 import useOutsideAlerter from "@hooks/useOutsideAlerter";
-import { Icon } from "@components/atoms/icon/Icon";
-import DropdownMenuItem from "@components/menus/DropdownMenuItem";
-import DropdownMenuWrapper from "@components/menus/DropdownMenuWrapper";
+import { Icon } from "@/components/atoms/icon/Icon";
+import DropdownMenuItem from "@/components/menus/DropdownMenuItem";
+import DropdownMenuWrapper from "@/components/menus/DropdownMenuWrapper";
 import MENU_LINKS from "@cclw/constants/menuLinks";
 
 export const Menu = () => {

--- a/themes/cclw/components/MethodologyLink.tsx
+++ b/themes/cclw/components/MethodologyLink.tsx
@@ -1,4 +1,4 @@
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 const MethodologyLink = () => <LinkWithQuery href="/methodology">our methodology page</LinkWithQuery>;
 

--- a/themes/cclw/components/Partners.tsx
+++ b/themes/cclw/components/Partners.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 const partners = [
   {

--- a/themes/cclw/components/PoweredBy.tsx
+++ b/themes/cclw/components/PoweredBy.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 export const PoweredBy = () => (
   <div className="md:flex justify-center gap-12 text-center">

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 type TFAQ = {
   id?: string;

--- a/themes/cclw/constants/instructions.tsx
+++ b/themes/cclw/constants/instructions.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 type TFamilyTotals = {
   laws: number;

--- a/themes/cclw/constants/methodologyItems.tsx
+++ b/themes/cclw/constants/methodologyItems.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 type TDataListItem = {
   title: string;

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -1,14 +1,14 @@
 import Image from "next/image";
 
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 
 import { Acknowledgements } from "@cclw/components/Acknowledgements";
 

--- a/themes/cclw/pages/contact.tsx
+++ b/themes/cclw/pages/contact.tsx
@@ -1,11 +1,11 @@
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 
 const Contact = () => {
   return (

--- a/themes/cclw/pages/faq.tsx
+++ b/themes/cclw/pages/faq.tsx
@@ -1,14 +1,14 @@
 import { Fragment } from "react";
 
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import { AccordianItem } from "@cclw/components/AccordianItem";
 
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 
 import { FAQS } from "@cclw/constants/faqs";
 

--- a/themes/cclw/pages/framework-laws.tsx
+++ b/themes/cclw/pages/framework-laws.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 import { QUERY_PARAMS } from "@constants/queryParams";
 
 const FrameworkLaws = () => {

--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import dynamic from "next/dynamic";
 
-import Layout from "@components/layouts/LandingPage";
-import { FullWidth } from "@components/panels/FullWidth";
-import { SiteWidth } from "@components/panels/SiteWidth";
+import Layout from "@/components/layouts/LandingPage";
+import { FullWidth } from "@/components/panels/FullWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
 import Header from "@cclw/components/Header";
 import Footer from "@cclw/components/Footer";
@@ -15,9 +15,9 @@ import { FeatureDiscover } from "@cclw/components/FeatureDiscover";
 import { HelpUs } from "@cclw/components/HelpUs";
 import { FeatureSearch } from "@cclw/components/FeatureSearch";
 import { PAGE_DESCRIPTION, APP_NAME } from "@cclw/constants/pageMetadata";
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 
-const WorldMap = dynamic(() => import("@components/map/WorldMap"), {
+const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
   loading: () => <p>Loading world map...</p>,
   ssr: false,
 });

--- a/themes/cclw/pages/methodology.tsx
+++ b/themes/cclw/pages/methodology.tsx
@@ -1,14 +1,14 @@
 import { Fragment } from "react";
 
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 import { AccordianItem } from "@cclw/components/AccordianItem";
 
 import { METHODOLOGY } from "@cclw/constants/methodologyItems";

--- a/themes/cclw/pages/terms-of-use.tsx
+++ b/themes/cclw/pages/terms-of-use.tsx
@@ -1,11 +1,11 @@
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (

--- a/themes/cpr/components/GSTBanner.tsx
+++ b/themes/cpr/components/GSTBanner.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "@components/ExternalLink";
-import { Icon } from "@components/atoms/icon/Icon";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 export const GSTBanner = () => {
   return (

--- a/themes/cpr/components/LandingPageLinks.tsx
+++ b/themes/cpr/components/LandingPageLinks.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 const LandingPageLinks = ({ handleLinkClick }) => {
   const terms = ["Adaptation strategy", "Energy prices", "Flood defence", "Just transition"];

--- a/themes/cpr/components/LandingSearchForm.tsx
+++ b/themes/cpr/components/LandingSearchForm.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, ChangeEvent } from "react";
-import { Icon } from "@components/atoms/icon/Icon";
-import { SearchDropdown } from "@components/forms/SearchDropdown";
-import { Button } from "@components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { SearchDropdown } from "@/components/forms/SearchDropdown";
+import { Button } from "@/components/atoms/button/Button";
 
 interface SearchFormProps {
   placeholder?: string;

--- a/themes/cpr/components/MethodologyLink.tsx
+++ b/themes/cpr/components/MethodologyLink.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 const MethodologyLink = () => <ExternalLink url="https://github.com/climatepolicyradar/methodology">our methodology page</ExternalLink>;
 

--- a/themes/cpr/components/Partners.tsx
+++ b/themes/cpr/components/Partners.tsx
@@ -1,10 +1,10 @@
 import Image from "next/legacy/image";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
 
 import { partners } from "@constants/partners";
 

--- a/themes/cpr/components/Summary.tsx
+++ b/themes/cpr/components/Summary.tsx
@@ -1,8 +1,8 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { Icon } from "@components/atoms/icon/Icon";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { Heading } from "@/components/typography/Heading";
 
 const Summary = () => {
   return (

--- a/themes/cpr/components/oep/Footer.tsx
+++ b/themes/cpr/components/oep/Footer.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 export const Footer = () => {
   return (

--- a/themes/cpr/components/oep/Header.tsx
+++ b/themes/cpr/components/oep/Header.tsx
@@ -1,9 +1,9 @@
 import Image from "next/image";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import MainMenu from "@components/menus/MainMenu";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import MainMenu from "@/components/menus/MainMenu";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 export function Header() {
   return (

--- a/themes/cpr/components/oep/Hero.tsx
+++ b/themes/cpr/components/oep/Hero.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 
-import { SingleCol } from "@components/panels/SingleCol";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { ExternalLink } from "@components/ExternalLink";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { ExternalLink } from "@/components/ExternalLink";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 export const Hero = () => {
   const router = useRouter();

--- a/themes/cpr/layouts/main.tsx
+++ b/themes/cpr/layouts/main.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from "react";
-import { PageHeader } from "@components/headers/PageHeader";
-import Footer from "@components/footer/Footer";
+import { PageHeader } from "@/components/headers/PageHeader";
+import Footer from "@/components/footer/Footer";
 
 type TProps = {
   children?: ReactNode;

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -1,22 +1,22 @@
 import { MouseEvent } from "react";
 import dynamic from "next/dynamic";
 
-import Layout from "@components/layouts/LandingPage";
-import { FullWidth } from "@components/panels/FullWidth";
-import { SiteWidth } from "@components/panels/SiteWidth";
+import Layout from "@/components/layouts/LandingPage";
+import { FullWidth } from "@/components/panels/FullWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import AlphaLogo from "@components/logo/AlphaLogo";
-import ExactMatch from "@components/filters/ExactMatch";
-import Header from "@components/headers/LandingPage";
-import Banner from "@components/banner/FullHeight";
-import Footer from "@components/footer/Footer";
+import AlphaLogo from "@/components/logo/AlphaLogo";
+import ExactMatch from "@/components/filters/ExactMatch";
+import Header from "@/components/headers/LandingPage";
+import Banner from "@/components/banner/FullHeight";
+import Footer from "@/components/footer/Footer";
 import { PAGE_DESCRIPTION, APP_NAME } from "@cpr/constants/pageMetadata";
 import LandingPageLinks from "@cpr/components/LandingPageLinks";
 import Partners from "@cpr/components/Partners";
 import Summary from "@cpr/components/Summary";
 import LandingSearchForm from "@cpr/components/LandingSearchForm";
 
-const WorldMap = dynamic(() => import("@components/map/WorldMap"), {
+const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
   loading: () => <p>Loading world map...</p>,
   ssr: false,
 });

--- a/themes/cpr/pages/oep.tsx
+++ b/themes/cpr/pages/oep.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
 import Image from "next/image";
 
-import Layout from "@components/layouts/LandingPage";
-import { ExternalLink } from "@components/ExternalLink";
+import Layout from "@/components/layouts/LandingPage";
+import { ExternalLink } from "@/components/ExternalLink";
 import { ColumnAndImage } from "@cpr/components/oep/ColumnAndImage";
 import { EqualColumn, EqualColumns } from "@cpr/components/oep/EqualColumns";
 import { Footer } from "@cpr/components/oep/Footer";

--- a/themes/cpr/pages/terms-of-use.tsx
+++ b/themes/cpr/pages/terms-of-use.tsx
@@ -1,11 +1,11 @@
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (

--- a/themes/mcf/components/AboutClimateProjectExplorer.tsx
+++ b/themes/mcf/components/AboutClimateProjectExplorer.tsx
@@ -1,6 +1,6 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { Heading } from "@components/typography/Heading";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { Heading } from "@/components/typography/Heading";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 const AboutClimateProjectExplorer = () => {
   return (

--- a/themes/mcf/components/AboutTheFunds.tsx
+++ b/themes/mcf/components/AboutTheFunds.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { Heading } from "@components/typography/Heading";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { Heading } from "@/components/typography/Heading";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 type FundDescription = {
   name: string;

--- a/themes/mcf/components/ClimatePolicyRadarBanner.tsx
+++ b/themes/mcf/components/ClimatePolicyRadarBanner.tsx
@@ -1,7 +1,7 @@
-import { Heading } from "@components/typography/Heading";
-import { ExternalLink } from "@components/ExternalLink";
+import { Heading } from "@/components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
 const ClimatePolicyRadarBannerHolder = () => {
   return (

--- a/themes/mcf/components/ContextualSearchContent.tsx
+++ b/themes/mcf/components/ContextualSearchContent.tsx
@@ -1,5 +1,5 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { Heading } from "@components/typography/Heading";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { Heading } from "@/components/typography/Heading";
 
 const ContextualSearchContent = () => {
   return (

--- a/themes/mcf/components/Footer.tsx
+++ b/themes/mcf/components/Footer.tsx
@@ -1,9 +1,9 @@
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { ExternalLink } from "@/components/ExternalLink";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import SocialMediaContent from "./FooterComponents/SocialMediaContent";
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 
 const Footer = () => {
   return (

--- a/themes/mcf/components/FooterComponents/SocialMediaContent.tsx
+++ b/themes/mcf/components/FooterComponents/SocialMediaContent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 import { multilateralClimateFundSocialMedia } from "./socialMediaData";
 
 const SocialMediaContent = () => {

--- a/themes/mcf/components/FooterComponents/socialMediaData.tsx
+++ b/themes/mcf/components/FooterComponents/socialMediaData.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@components/atoms/icon/Icon";
+import { Icon } from "@/components/atoms/icon/Icon";
 
 import { colors } from "@mcf/constants/colors";
 

--- a/themes/mcf/components/Header.tsx
+++ b/themes/mcf/components/Header.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from "next/router";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
+import { SiteWidth } from "@/components/panels/SiteWidth";
 
-import { LinkWithQuery } from "@components/LinkWithQuery";
-import { FloatingSearch } from "@components/FloatingSearch";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { FloatingSearch } from "@/components/FloatingSearch";
 
 import { Menu } from "./HeaderComponents/Menu";
 import { Logo } from "./HeaderComponents/Logo";

--- a/themes/mcf/components/HeaderComponents/Menu.tsx
+++ b/themes/mcf/components/HeaderComponents/Menu.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useCallback } from "react";
 
 import useOutsideAlerter from "@hooks/useOutsideAlerter";
-import { Icon } from "@components/atoms/icon/Icon";
-import DropdownMenuItem from "@components/menus/DropdownMenuItem";
-import DropdownMenuWrapper from "@components/menus/DropdownMenuWrapper";
+import { Icon } from "@/components/atoms/icon/Icon";
+import DropdownMenuItem from "@/components/menus/DropdownMenuItem";
+import DropdownMenuWrapper from "@/components/menus/DropdownMenuWrapper";
 
 import menuLinks from "../../constants/menuLinks";
 import { colors } from "@mcf/constants/colors";

--- a/themes/mcf/components/Hero.tsx
+++ b/themes/mcf/components/Hero.tsx
@@ -1,8 +1,8 @@
-import { Heading } from "@components/typography/Heading";
+import { Heading } from "@/components/typography/Heading";
 import LandingSearchForm from "./LandingSearchForm";
 
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { VerticalSpacing } from "@components/utility/VerticalSpacing";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
 import { MultilateralClimateFundLogos } from "./HeroComponents/MultilateralClimateFundsLogos";
 
 const Instructions = () => <p>Loading document stats...</p>;

--- a/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
+++ b/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 interface FundData {
   imgSrc: string;

--- a/themes/mcf/components/LandingSearchForm.tsx
+++ b/themes/mcf/components/LandingSearchForm.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, ChangeEvent } from "react";
 
-import { Icon } from "@components/atoms/icon/Icon";
-import { SearchDropdown } from "@components/forms/SearchDropdown";
-import { Button } from "@components/atoms/button/Button";
+import { Icon } from "@/components/atoms/icon/Icon";
+import { SearchDropdown } from "@/components/forms/SearchDropdown";
+import { Button } from "@/components/atoms/button/Button";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 

--- a/themes/mcf/components/MethodologyLink.tsx
+++ b/themes/mcf/components/MethodologyLink.tsx
@@ -1,4 +1,4 @@
-import { LinkWithQuery } from "@components/LinkWithQuery";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 const MethodologyLink = () => <LinkWithQuery href="/methodology">our methodology page</LinkWithQuery>;
 

--- a/themes/mcf/constants/faqs.tsx
+++ b/themes/mcf/constants/faqs.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "@components/ExternalLink";
+import { ExternalLink } from "@/components/ExternalLink";
 
 type TFAQ = {
   id?: string;

--- a/themes/mcf/pages/about.tsx
+++ b/themes/mcf/pages/about.tsx
@@ -1,10 +1,10 @@
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
-import { ExternalLink } from "@components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
 
 const About = () => {
   return (

--- a/themes/mcf/pages/contact.tsx
+++ b/themes/mcf/pages/contact.tsx
@@ -1,10 +1,10 @@
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
-import { ExternalLink } from "@components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
 
 const Contact = () => {
   return (

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -1,15 +1,15 @@
 import { Fragment } from "react";
 
-import { Accordian } from "@components/accordian/Accordian";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
+import { Accordian } from "@/components/accordian/Accordian";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
 
 import { FAQS, PLATFORMFAQS } from "@mcf/constants/faqs";
-import { VerticalSpacing } from "@components/utility/VerticalSpacing";
+import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
 
 const ACCORDIANMAXHEIGHT = "464px";
 

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import Layout from "@components/layouts/LandingPage";
+import Layout from "@/components/layouts/LandingPage";
 
 import { Header, Footer, Hero, ClimatePolicyRadarBanner, AboutTheFunds, ContextualSearchContent, AboutClimateProjectExplorer } from "@mcf/components";
 import { PAGE_DESCRIPTION, APP_NAME } from "@mcf/constants/pageMetadata";

--- a/themes/mcf/pages/methodology.tsx
+++ b/themes/mcf/pages/methodology.tsx
@@ -1,9 +1,9 @@
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
-import { Heading } from "@components/typography/Heading";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
+import { Heading } from "@/components/typography/Heading";
 
 const Methodology = () => {
   return (

--- a/themes/mcf/pages/terms-of-use.tsx
+++ b/themes/mcf/pages/terms-of-use.tsx
@@ -1,11 +1,11 @@
-import Layout from "@components/layouts/Main";
-import { SiteWidth } from "@components/panels/SiteWidth";
-import { SingleCol } from "@components/panels/SingleCol";
-import { SubNav } from "@components/nav/SubNav";
+import Layout from "@/components/layouts/Main";
+import { SiteWidth } from "@/components/panels/SiteWidth";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { SubNav } from "@/components/nav/SubNav";
 
-import { ExternalLink } from "@components/ExternalLink";
-import { BreadCrumbs } from "@components/breadcrumbs/Breadcrumbs";
-import { Heading } from "@components/typography/Heading";
+import { ExternalLink } from "@/components/ExternalLink";
+import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
+import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "types": ["node", "vitest/globals"],
     "paths": {
       "@api/*": ["src/api/*"],
-      "@components/*": ["src/components/*"],
+      "@/components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
       "@context/*": ["src/context/*"],
       "@helpers/*": ["src/helpers/*"],


### PR DESCRIPTION
# What's changed

As part of import sorting PR, we are going to update our custom path aliases so that they have a preceding / e.g., @components becomes @/components. This is so we can set an import rule later on in ESLint that groups our custom files separately from 3rd party libraries.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
