### PR TITLE
APP-277: Add Input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@base-ui-components/react": "^1.0.0-alpha.6",
         "@hookform/resolvers": "^2.8.8",
         "axios": "^0.24.0",
         "babel-loader": "^9.1.0",
@@ -1874,6 +1875,37 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui-components/react": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-0Jkp8twk3z3TJNOTUyzrK1dPOF7w1/LH+TYksuZc8TyJzuJx8V2O15BgpMJczvFdSR2ncdN1WQxsTe2ayYJ6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "@floating-ui/react": "^0.27.3",
+        "@floating-ui/utils": "^0.2.9",
+        "@react-aria/overlays": "^3.25.0",
+        "prop-types": "^15.8.1",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2914,11 +2946,90 @@
         "@floating-ui/utils": "^0.2.9"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.5.tgz",
+      "integrity": "sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.3.tgz",
+      "integrity": "sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.6",
+        "@formatjs/intl-localematcher": "0.6.0",
+        "decimal.js": "10",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.6.tgz",
+      "integrity": "sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.1.tgz",
+      "integrity": "sha512-o0AhSNaOfKoic0Sn1GkFCK4MxdRsw7mPJ5/rBpIqdvcC7MIuyUSW8WChUEvrK78HhNpYOgqCQbINxCTumJLzZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "@formatjs/icu-skeleton-parser": "1.8.13",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.13.tgz",
+      "integrity": "sha512-N/LIdTvVc1TpJmMt2jVg0Fr1F7Q1qJPdZSCs19unMskCmVQ/sa0H9L8PWt13vq+gLdLg1+pPsvBLydL1Apahjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.0.tgz",
+      "integrity": "sha512-4rB4g+3hESy1bHSBG3tDFaMY2CH67iT7yne1e+0CLTsGLDcmoEWWpJjjpWVaYgYfYuohIRuo0E+N536gd2ZHZA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "2.9.11",
@@ -3312,6 +3423,43 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.7.0.tgz",
+      "integrity": "sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.6.tgz",
+      "integrity": "sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.0.tgz",
+      "integrity": "sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.5.tgz",
+      "integrity": "sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jest/types": {
@@ -4231,6 +4379,200 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.0.tgz",
+      "integrity": "sha512-KXZCwWzwnmtUo6xhnyV26ptxlxmqd0Reez7axduqqqeDDgDZOVscoo/5gFg71fdPZmnDC8MyUK1vxSbMhOTrGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.24.0",
+        "@react-aria/utils": "^3.28.0",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.6.tgz",
+      "integrity": "sha512-I2Qz1vAlgdeW2GUMLhHucYhk514/BRuEzvH1iih8qeqvv0gEbKdSIjPJUomW+WzYVmJ2/bwKQAr7otr2fNcbrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.7.0",
+        "@internationalized/message": "^3.1.6",
+        "@internationalized/number": "^3.6.0",
+        "@internationalized/string": "^3.2.5",
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.28.0",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.24.0.tgz",
+      "integrity": "sha512-6Zdhp1pswyPgbwEWzvXARdKAWPjP7mACczoIUvlEQiMsX04fuizBiBLAA+W/5mPe17pbJYHA/rxZF5Y5m+M0Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.28.0",
+        "@react-stately/flags": "^3.1.0",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.26.0.tgz",
+      "integrity": "sha512-Rr3yoyGwXzp446QK6CwnjJl9ZfH/Cq2o01XQmMjya2gmk5N4aefRORg7eRoVy5EVfecIH/HJVg0BKEjXQOp4nA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.0",
+        "@react-aria/i18n": "^3.12.6",
+        "@react-aria/interactions": "^3.24.0",
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.28.0",
+        "@react-aria/visually-hidden": "^3.8.20",
+        "@react-stately/overlays": "^3.6.14",
+        "@react-types/button": "^3.11.0",
+        "@react-types/overlays": "^3.8.13",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
+      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.0.tgz",
+      "integrity": "sha512-FfpvpADk61OvEnFe37k6jF1zr5gtafIPN9ccJRnPCTqrzuExag01mGi+wX/hWyFK0zAe1OjWf1zFOX3FsFvikg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.7",
+        "@react-stately/flags": "^3.1.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.20",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.20.tgz",
+      "integrity": "sha512-Y7JbrpheUhNgnJWogDWxuxxiWAnuaW9MKOUY5vD3KOa+vEWuc2IBOGSzOOUkAGnVP4L2rvaHeZIuR5flqyeskA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.24.0",
+        "@react-aria/utils": "^3.28.0",
+        "@react-types/shared": "^3.28.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.0.tgz",
+      "integrity": "sha512-KSHOCxTFpBtxhIRcKwsD1YDTaNxFtCYuAUb0KEihc16QwqZViq4hasgPBs2gYm7fHRbw7WYzWKf6ZSo/+YsFlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.14.tgz",
+      "integrity": "sha512-RRalTuHdwrKO1BmXKaqBtE1GGUXU4VUAWwgh4lsP2EFSixDHmOVLxHFDWYvOPChBhpi8KXfLEgm6DEgPBvLBZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/overlays": "^3.8.13",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.5.tgz",
+      "integrity": "sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.11.0.tgz",
+      "integrity": "sha512-gJh5i0JiBiZGZGDo+tXMp6xbixPM7IKZ0sDuxTYBG49qNzzWJq0uNYltO3emwSVXFSsBgRV/Wu8kQGhfuN7wIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.28.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.8.13",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.13.tgz",
+      "integrity": "sha512-xgT843KIh1otvYPQ6kCGTVUICiMF5UQ7SZUQZd4Zk3VtiFIunFVUvTvL03cpt0026UmY7tbv7vFrPKcT6xjsjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.28.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.28.0.tgz",
+      "integrity": "sha512-9oMEYIDc3sk0G5rysnYvdNrkSg7B04yTKl50HHSZVbokeHpnU0yRmsDaWb9B/5RprcKj8XszEk5guBO8Sa/Q+Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6344,14 +6686,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
       "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6393,7 +6735,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -8465,7 +8807,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8985,7 +9326,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cypress-pseudo-localization": {
@@ -9196,7 +9537,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -11899,6 +12239,18 @@
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "license": "ISC"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.15",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.15.tgz",
+      "integrity": "sha512-LRyExsEsefQSBjU2p47oAheoKz+EOJxSLDdjOaEjdriajfHsMXOmV/EhMvYSg9bAgCUHasuAC+mcUBe/95PfIg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "@formatjs/fast-memoize": "2.2.6",
+        "@formatjs/icu-messageformat-parser": "2.11.1",
+        "tslib": "2"
+      }
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -17178,6 +17530,12 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-scrollbar": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.1.tgz",
@@ -17887,6 +18245,15 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@base-ui-components/react": "^1.0.0-alpha.6",
     "@hookform/resolvers": "^2.8.8",
     "axios": "^0.24.0",
     "babel-loader": "^9.1.0",

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -1,3 +1,4 @@
+import { joinTailwindClasses } from "@utils/tailwind";
 import { useMemo } from "react";
 
 interface ButtonClassArgs {
@@ -49,7 +50,7 @@ export const getButtonClasses = ({
 
   /* Shape */
 
-  const border = variant === "outlined" ? "border border-border-grey" : "";
+  const border = variant === "outlined" ? "border border-border-light" : "";
   const outlineColor = color === "brand" ? "outline-surface-brand-dark" : "outline-surface-mono-dark";
   const roundness = rounded ? "rounded-full" : "rounded-md";
 
@@ -75,7 +76,7 @@ export const getButtonClasses = ({
 
   const cursor = disabled ? "pointer-events-none" : "";
 
-  return [baseClasses, layout, sizing, bgColor, border, outlineColor, roundness, textColor, cursor, className].filter((classes) => classes).join(" ");
+  return joinTailwindClasses([baseClasses, layout, sizing, bgColor, border, outlineColor, roundness, textColor, cursor, className]);
 };
 
 export const Button = ({

--- a/src/components/atoms/icon/Icon.stories.tsx
+++ b/src/components/atoms/icon/Icon.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { Icon, iconNames } from "./Icon";
 
 const meta = {
-  title: "New/Icon",
+  title: "Atoms/Icon",
   component: Icon,
   parameters: {
     layout: "centered",

--- a/src/components/molecules/input/Input.stories.tsx
+++ b/src/components/molecules/input/Input.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react/*";
+import { Input } from "./Input";
+import { iconNames } from "@components/atoms/icon/Icon";
+import { useState } from "react";
+
+const meta = {
+  title: "Molecules/Input",
+  component: Input,
+  argTypes: {
+    icon: {
+      control: "select",
+      options: iconNames,
+    },
+    placeholder: { control: "text" },
+    valueSetter: { control: false },
+  },
+} satisfies Meta<typeof Input>;
+type Story = StoryObj<typeof Input>;
+
+export default meta;
+
+const useInputContext = ({ ...props }) => {
+  const [value, setValue] = useState("");
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => setValue(event.currentTarget.value);
+
+  return <Input value={value} onChange={handleChange} valueSetter={setValue} {...props} />;
+};
+
+export const Default: Story = {
+  args: {},
+  render: useInputContext,
+};
+
+export const Clearable: Story = {
+  args: {
+    clearable: true,
+    icon: undefined,
+    iconOnLeft: false,
+    placeholder: "Type something",
+    size: "medium",
+  },
+  render: useInputContext,
+};
+
+export const IconRight: Story = {
+  args: {
+    clearable: false,
+    icon: "search",
+    iconOnLeft: false,
+    placeholder: "Search",
+    size: "medium",
+  },
+  render: useInputContext,
+};
+
+export const IconLeft: Story = {
+  args: {
+    clearable: false,
+    icon: "add",
+    iconOnLeft: true,
+    placeholder: "Add...",
+    size: "medium",
+  },
+  render: useInputContext,
+};

--- a/src/components/molecules/input/Input.tsx
+++ b/src/components/molecules/input/Input.tsx
@@ -31,8 +31,6 @@ export const Input = ({
   const classes = useMemo(() => {
     /* Colour */
 
-    // TODO may want to only support one colour
-
     const outlineColor = color === "brand" ? "focus-within:outline-border-brand" : "focus-within:outline-border-mono";
 
     /* Size */

--- a/src/components/molecules/input/Input.tsx
+++ b/src/components/molecules/input/Input.tsx
@@ -1,0 +1,99 @@
+import { Input as BaseInput } from "@base-ui-components/react";
+import { Icon, IconName, iconNames } from "@components/atoms/icon/Icon";
+import { joinTailwindClasses } from "@utils/tailwind";
+import { Dispatch, SetStateAction, useMemo } from "react";
+
+interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
+  clearable?: boolean;
+  containerClasses?: string;
+  color?: "brand" | "mono";
+  icon?: IconName | React.ReactNode;
+  iconOnLeft?: boolean;
+  inputClasses?: string;
+  size?: "small" | "medium" | "large";
+  valueSetter?: Dispatch<SetStateAction<string>>;
+}
+
+const isIconName = (icon: unknown): icon is IconName => iconNames.includes(icon as IconName);
+
+export const Input = ({
+  className: _className,
+  clearable = false,
+  color = "brand",
+  containerClasses = "",
+  icon,
+  iconOnLeft = false,
+  inputClasses = "",
+  size = "medium",
+  valueSetter,
+  ...props
+}: InputProps) => {
+  const classes = useMemo(() => {
+    /* Colour */
+
+    // TODO may want to only support one colour
+
+    const outlineColor = color === "brand" ? "focus-within:outline-border-brand" : "focus-within:outline-border-mono";
+
+    /* Size */
+
+    let textSize = "text-sm";
+    let inputPadding = "px-1.5 py-2.5";
+    let iconPadding = "p-1.5";
+
+    switch (size) {
+      case "small":
+        textSize = "text-xs";
+        break;
+      case "large":
+        textSize = "text-base";
+        inputPadding = "px-2 py-3.5";
+        iconPadding = "p-2";
+        break;
+    }
+
+    return {
+      button: joinTailwindClasses([iconPadding]),
+      container: joinTailwindClasses([
+        "w-full px-2 flex flex-row justify-around items-center bg-surface-ui rounded-md focus-within:outline",
+        outlineColor,
+        containerClasses,
+      ]),
+      icon: joinTailwindClasses([iconPadding]),
+      input: joinTailwindClasses([
+        "w-full block bg-transparent border-none focus:shadow-[none] leading-none font-medium text-text-primary placeholder:text-text-tertiary caret-text-brand",
+        inputPadding,
+        textSize,
+        inputClasses,
+      ]),
+    };
+  }, [color, containerClasses, inputClasses, size]);
+
+  let iconNode: React.ReactNode = null;
+  if (icon) {
+    iconNode = isIconName(icon) ? (
+      <div className={classes.icon}>
+        <Icon name={icon} height="16" width="16" />
+      </div>
+    ) : (
+      icon
+    );
+  }
+
+  const handleClear = () => {
+    if (valueSetter) valueSetter("");
+  };
+
+  return (
+    <div className={classes.container}>
+      {iconOnLeft && iconNode}
+      <BaseInput className={classes.input} {...props} />
+      {!iconOnLeft && iconNode}
+      {clearable && (
+        <button type="button" className={classes.button} onClick={handleClear}>
+          <Icon name="close" height="12" width="12" />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -56,8 +56,10 @@ function MyApp({ Component, pageProps, theme, adobeApiKey }: TProps) {
             <Head>
               <link rel="icon" href={favicon} />
             </Head>
-            <div id={dynamicTheme} className="h-full">
-              <Component {...pageProps} />
+            <div id="Root">
+              <div id={dynamicTheme} className="h-full">
+                <Component {...pageProps} />
+              </div>
             </div>
             <CookieConsent />
           </ErrorBoundary>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -88,6 +88,11 @@
   }
 }
 
+/* Necessary for Base UI overlays (tooltip, popover etc.) */
+.root {
+  isolation: isolate;
+}
+
 body,
 html,
 #__next {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -78,7 +78,9 @@
   --color-text-light: #ffffff;
   --color-text-brand: #005eeb;
 
-  --color-border-grey: #e5e5e5;
+  --color-border-light: #e5e5e5;
+  --color-border-brand: #005eeb;
+  --color-border-mono: #202020;
 
   --color-surface-light: #ffffff;
   --color-surface-bg: #fafafa;

--- a/src/utils/tailwind.test.ts
+++ b/src/utils/tailwind.test.ts
@@ -1,0 +1,17 @@
+import { joinTailwindClasses } from "./tailwind";
+
+describe("joinTailwindClasses", () => {
+  it("joins multiple class strings", () => {
+    expect(joinTailwindClasses(["md-5"])).toBe("md-5");
+    expect(joinTailwindClasses(["md-5", "bg-text-primary"])).toBe("md-5 bg-text-primary");
+  });
+
+  it("handles empty strings", () => {
+    expect(joinTailwindClasses([undefined])).toBe("");
+    expect(joinTailwindClasses(["", "text-md"])).toBe("text-md");
+  });
+
+  it("handles whitespace trimming", () => {
+    expect(joinTailwindClasses([" underline  "])).toBe("underline");
+  });
+});

--- a/src/utils/tailwind.ts
+++ b/src/utils/tailwind.ts
@@ -1,0 +1,5 @@
+export const joinTailwindClasses = (parts: (string | undefined)[]) =>
+  parts
+    .map((part) => (part || "").trim())
+    .filter((part) => part)
+    .join(" ");


### PR DESCRIPTION
# What's changed

Adds a new `Input` component to Storybook, which will replace most `<input />` uses in my next PR.

- Add Base UI as a dependency.
- Add `components/molecules/input`
  - This is a molecule because it relies on `Icon` and eventually `Tooltip` (Base UI).
  - Built upon Base UI Input.
  - Effectively a div that wraps an input plus potentially an icon and/or clear button.
  - Some styling flexibility in terms of sizes and colours.
  - Props for overriding container and input styles.
- Add `Input` stories.
- Add `joinTailwindClasses` util function.
  - Handles repetitive string joins which are then used in `className` prop.
  - Tests.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
