### PR TITLE
Update custom path to @/hooks

### DIFF
--- a/src/components/CountryLink.tsx
+++ b/src/components/CountryLink.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 import { getCountrySlug } from "@helpers/getCountryFields";
 import { LinkWithQuery } from "./LinkWithQuery";
 import { systemGeoCodes } from "@constants/systemGeos";

--- a/src/components/EmbeddedPDF.tsx
+++ b/src/components/EmbeddedPDF.tsx
@@ -3,7 +3,7 @@ import Script from "next/script";
 
 import { AdobeContext } from "@context/AdobeContext";
 
-import usePDFPreview from "@hooks/usePDFPreview";
+import usePDFPreview from "@/hooks/usePDFPreview";
 
 import Loader from "./Loader";
 

--- a/src/components/blocks/CountryHeader.tsx
+++ b/src/components/blocks/CountryHeader.tsx
@@ -1,4 +1,4 @@
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 
 import Tooltip from "@components/tooltip";
 import { ExternalLink } from "@components/ExternalLink";

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { ParsedUrlQuery } from "querystring";
 import dynamic from "next/dynamic";
 
-import useGetThemeConfig from "@hooks/useThemeConfig";
+import useGetThemeConfig from "@/hooks/useThemeConfig";
 import { Label } from "@components/labels/Label";
 import { DateRange } from "../filters/DateRange";
 import { Accordian } from "@components/accordian/Accordian";

--- a/src/components/document/FamilyDocument.tsx
+++ b/src/components/document/FamilyDocument.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { Icon } from "@components/atoms/icon/Icon";
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 import { getLanguage } from "@helpers/getLanguage";
 import { TDocumentPage, TLoadingStatus } from "@types";
 import { getDocumentType } from "@helpers/getDocumentType";

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -1,4 +1,4 @@
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 import { getCategoryName } from "@helpers/getCategoryName";
 import { convertDate } from "@utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@types";

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -1,4 +1,4 @@
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 
 import { ExternalLink } from "@components/ExternalLink";
 import { CountryLinksAsList } from "@components/CountryLinks";

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -14,10 +14,10 @@ import { useEffect, useState, useCallback, useMemo, useReducer } from "react";
 import { SearchSettings } from "@components/filters/SearchSettings";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@constants/paging";
-import useSearch from "@hooks/useSearch";
+import useSearch from "@/hooks/useSearch";
 import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
-import { useEffectOnce } from "@hooks/useEffectOnce";
+import { useEffectOnce } from "@/hooks/useEffectOnce";
 import Loader from "@components/Loader";
 
 type TProps = {

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { LuMoveUpRight } from "react-icons/lu";
 
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 
 import { SiteWidth } from "@components/panels/SiteWidth";
 

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -1,4 +1,4 @@
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 
 import { getLanguage } from "@helpers/getLanguage";
 import { CountryLinks } from "@components/CountryLinks";

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -2,8 +2,8 @@ import { useMemo } from "react";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 
-import useConfig from "@hooks/useConfig";
-import useGetThemeConfig from "@hooks/useThemeConfig";
+import useConfig from "@/hooks/useConfig";
+import useGetThemeConfig from "@/hooks/useThemeConfig";
 
 import Pill from "@components/Pill";
 

--- a/src/components/filters/MultiList.tsx
+++ b/src/components/filters/MultiList.tsx
@@ -1,4 +1,4 @@
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 import FilterTag from "../labels/FilterTag";
 import { getCountryName } from "@helpers/getCountryFields";
 import { QUERY_PARAMS } from "@constants/queryParams";

--- a/src/components/forms/SearchDropdown.tsx
+++ b/src/components/forms/SearchDropdown.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 import { Icon } from "@components/atoms/icon/Icon";
 import { QUERY_PARAMS } from "@constants/queryParams";
 import { TGeography } from "@types";

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -1,4 +1,4 @@
-import { useMcfData } from "@hooks/useMcfData";
+import { useMcfData } from "@/hooks/useMcfData";
 
 export const Legend = ({ max }: { max: number }) => {
   const showMcf = useMcfData();

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -2,9 +2,9 @@ import React, { useRef, useState, useMemo, useEffect } from "react";
 import { ComposableMap, Geographies, Geography, Graticule, Marker, Sphere, ZoomableGroup, Point as TPoint } from "react-simple-maps";
 import { Tooltip, TooltipRefProps } from "react-tooltip";
 
-import useConfig from "@hooks/useConfig";
-import useGeographies from "@hooks/useGeographies";
-import { useMcfData } from "@hooks/useMcfData";
+import useConfig from "@/hooks/useConfig";
+import useGeographies from "@/hooks/useGeographies";
+import { useMcfData } from "@/hooks/useMcfData";
 
 import { LinkWithQuery } from "@components/LinkWithQuery";
 import GeographySelect from "./GeographySelect";

--- a/src/components/menus/MainMenu.tsx
+++ b/src/components/menus/MainMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import useOutsideAlerter from "@hooks/useOutsideAlerter";
+import useOutsideAlerter from "@/hooks/useOutsideAlerter";
 import { Icon } from "@components/atoms/icon/Icon";
 import DropdownMenuItem from "./DropdownMenuItem";
 import DropdownMenuWrapper from "./DropdownMenuWrapper";

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -7,7 +7,7 @@ import axios from "axios";
 
 import { ApiClient } from "@/api/http-common";
 
-import useSearch from "@hooks/useSearch";
+import useSearch from "@/hooks/useSearch";
 
 import { SingleCol } from "@components/panels/SingleCol";
 import Layout from "@components/layouts/Main";
@@ -48,7 +48,7 @@ import { MAX_PASSAGES } from "@constants/paging";
 import { getFeatureFlags } from "@utils/featureFlags";
 import { fetchAndProcessConcepts } from "@utils/processConcepts";
 import { MultiCol } from "@components/panels/MultiCol";
-import { useEffectOnce } from "@hooks/useEffectOnce";
+import { useEffectOnce } from "@/hooks/useEffectOnce";
 import { ConceptsPanel } from "@components/concepts/ConceptsPanel";
 
 type TProps = {

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -6,7 +6,7 @@ import { MdOutlineTune } from "react-icons/md";
 
 import { ApiClient } from "@/api/http-common";
 
-import useSearch from "@hooks/useSearch";
+import useSearch from "@/hooks/useSearch";
 
 import { FullWidth } from "@components/panels/FullWidth";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import useUpdateCountries from "@hooks/useUpdateCountries";
-import useConfig from "@hooks/useConfig";
+import useUpdateCountries from "@/hooks/useUpdateCountries";
+import useConfig from "@/hooks/useConfig";
 
 import { QUERY_PARAMS } from "@constants/queryParams";
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -5,9 +5,9 @@ import { ParsedUrlQueryInput } from "querystring";
 import { useEffect, useRef, useState } from "react";
 import { MdOutlineTune } from "react-icons/md";
 
-import useConfig from "@hooks/useConfig";
-import { useDownloadCsv } from "@hooks/useDownloadCsv";
-import useSearch from "@hooks/useSearch";
+import useConfig from "@/hooks/useConfig";
+import { useDownloadCsv } from "@/hooks/useDownloadCsv";
+import useSearch from "@/hooks/useSearch";
 
 import { MultiCol } from "@components/panels/MultiCol";
 import { SideCol } from "@components/panels/SideCol";

--- a/themes/cclw/components/Instructions.tsx
+++ b/themes/cclw/components/Instructions.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import useConfig from "@hooks/useConfig";
+import useConfig from "@/hooks/useConfig";
 
 import { calculateTotalFamilies } from "@helpers/getFamilyCounts";
 

--- a/themes/cclw/components/Menu.tsx
+++ b/themes/cclw/components/Menu.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import useOutsideAlerter from "@hooks/useOutsideAlerter";
+import useOutsideAlerter from "@/hooks/useOutsideAlerter";
 import { Icon } from "@components/atoms/icon/Icon";
 import DropdownMenuItem from "@components/menus/DropdownMenuItem";
 import DropdownMenuWrapper from "@components/menus/DropdownMenuWrapper";

--- a/themes/mcf/components/HeaderComponents/Menu.tsx
+++ b/themes/mcf/components/HeaderComponents/Menu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from "react";
 
-import useOutsideAlerter from "@hooks/useOutsideAlerter";
+import useOutsideAlerter from "@/hooks/useOutsideAlerter";
 import { Icon } from "@components/atoms/icon/Icon";
 import DropdownMenuItem from "@components/menus/DropdownMenuItem";
 import DropdownMenuWrapper from "@components/menus/DropdownMenuWrapper";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
       "@constants/*": ["src/constants/*"],
       "@context/*": ["src/context/*"],
       "@helpers/*": ["src/helpers/*"],
-      "@hooks/*": ["src/hooks/*"],
+      "@/hooks/*": ["src/hooks/*"],
       "@interfaces/*": ["src/interfaces/*"],
       "@types": ["src/types/index"],
       "@pages/*": ["src/pages/*"],


### PR DESCRIPTION
# What's changed

As part of import sorting PR, we are going to update our custom path aliases so that they have a preceding / e.g., `@hooks` becomes @/hooks. This is so we can set an import rule later on in ESLint that groups our custom files separately from 3rd party libraries.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
