### PR TITLE
Update custom path to @/utils

### DIFF
--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -4,7 +4,7 @@ import { CountryLink } from "@/components/CountryLink";
 
 import { getCountryName } from "@/helpers/getCountryFields";
 
-import { isSystemGeo, isSystemInternational } from "@utils/isSystemGeo";
+import { isSystemGeo, isSystemInternational } from "@/utils/isSystemGeo";
 
 import { TGeography } from "@/types";
 

--- a/src/components/FloatingSearch.tsx
+++ b/src/components/FloatingSearch.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { Icon } from "./atoms/icon/Icon";
 import { Divider } from "./dividers/Divider";
-import { CleanRouterQuery } from "@utils/cleanRouterQuery";
+import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { Button } from "./atoms/button/Button";
 

--- a/src/components/LinkWithQuery.tsx
+++ b/src/components/LinkWithQuery.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import { CleanRouterQuery } from "@utils/cleanRouterQuery";
+import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
 
 type TProps = {
   href: string;

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -19,8 +19,8 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 
 import { getCountriesFromRegions } from "@/helpers/getCountriesFromRegions";
 
-import { canDisplayFilter } from "@utils/canDisplayFilter";
-import { getFilterLabel } from "@utils/getFilterLabel";
+import { canDisplayFilter } from "@/utils/canDisplayFilter";
+import { getFilterLabel } from "@/utils/getFilterLabel";
 
 import { TConcept, TCorpusTypeDictionary, TGeography, TSearchCriteria, TThemeConfigOption } from "@/types";
 

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import { LinkWithQuery } from "@/components/LinkWithQuery";
-import { isSystemGeo } from "@utils/isSystemGeo";
+import { isSystemGeo } from "@/utils/isSystemGeo";
 
 const BREADCRUMB_MAXLENGTH = 50;
 

--- a/src/components/cookies/CookieConsent.tsx
+++ b/src/components/cookies/CookieConsent.tsx
@@ -4,8 +4,8 @@ import Script from "next/script";
 import { Button } from "@/components/atoms/button/Button";
 import { ExternalLink } from "@/components/ExternalLink";
 
-import { getCookie, setCookie } from "@utils/cookies";
-import getDomain from "@utils/getDomain";
+import { getCookie, setCookie } from "@/utils/cookies";
+import getDomain from "@/utils/getDomain";
 
 import { COOKIE_CONSENT_NAME } from "@/constants/cookies";
 import dynamic from "next/dynamic";

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -4,7 +4,7 @@ import { TFamily } from "@/types";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { FamilyMeta } from "./FamilyMeta";
 
-import { truncateString } from "@utils/truncateString";
+import { truncateString } from "@/utils/truncateString";
 
 type TProps = {
   family: TFamily;

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -1,6 +1,6 @@
 import useConfig from "@/hooks/useConfig";
 import { getCategoryName } from "@/helpers/getCategoryName";
-import { convertDate } from "@utils/timedate";
+import { convertDate } from "@/utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@/types";
 import { CountryLinks } from "@/components/CountryLinks";
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -12,7 +12,7 @@ import { EmptyPassages } from "./EmptyPassages";
 import { motion } from "framer-motion";
 import { useEffect, useState, useCallback, useMemo, useReducer } from "react";
 import useSearch from "@/hooks/useSearch";
-import { fetchAndProcessConcepts } from "@utils/processConcepts";
+import { fetchAndProcessConcepts } from "@/utils/processConcepts";
 import { useEffectOnce } from "@/hooks/useEffectOnce";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { MAX_PASSAGES, MAX_RESULTS } from "@/constants/paging";

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -14,7 +14,7 @@ import { ExternalLink } from "@/components/ExternalLink";
 import { Heading } from "@/components/typography/Heading";
 
 import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
-import { truncateString } from "@utils/truncateString";
+import { truncateString } from "@/utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
 

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -2,7 +2,7 @@ import useConfig from "@/hooks/useConfig";
 
 import { CountryLinks } from "@/components/CountryLinks";
 import { getLanguage } from "@/helpers/getLanguage";
-import { convertDate } from "@utils/timedate";
+import { convertDate } from "@/utils/timedate";
 
 export const DocumentMeta = ({ family, isMain, document, document_type }: { family: any; isMain: boolean; document: any; document_type: any }) => {
   const configQuery = useConfig();

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -8,8 +8,8 @@ import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Button } from "@/components/atoms/button/Button";
 import { Heading } from "@/components/typography/Heading";
 
-import { CleanRouterQuery } from "@utils/cleanRouterQuery";
-import { truncateString } from "@utils/truncateString";
+import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
+import { truncateString } from "@/utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
 

--- a/src/components/filters/SuggestList.tsx
+++ b/src/components/filters/SuggestList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import { addClass, removeClass } from "@utils/cssClass";
+import { addClass, removeClass } from "@/utils/cssClass";
 
 const SuggestList = ({ list, setList, keyField, keyFieldDisplay, type, setInput, handleFilterChange }) => {
   const ulRef = useRef(null);

--- a/src/components/forms/TypeAhead.tsx
+++ b/src/components/forms/TypeAhead.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import SuggestList from "../filters/SuggestList";
 import { TextInput } from "./TextInput";
 
-import { sortData } from "@utils/sorting";
+import { sortData } from "@/utils/sorting";
 import { Icon } from "@/components/atoms/icon/Icon";
 
 type TProps = {

--- a/src/components/layouts/LandingPage.tsx
+++ b/src/components/layouts/LandingPage.tsx
@@ -2,10 +2,10 @@ import React, { ReactNode } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
 
-import { getAppTitle } from "@utils/getAppTitle";
-import { getPageDescription } from "@utils/getPageDescription";
-import { getPageTitle } from "@utils/getPageTitle";
-import { getCanonicalUrl } from "@utils/getCanonicalUrl";
+import { getAppTitle } from "@/utils/getAppTitle";
+import { getPageDescription } from "@/utils/getPageDescription";
+import { getPageTitle } from "@/utils/getPageTitle";
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl";
 
 import { TTheme, TThemeConfig } from "@/types";
 

--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -4,10 +4,10 @@ import Head from "next/head";
 
 import { ThemeContext } from "@context/ThemeContext";
 
-import { getAppTitle } from "@utils/getAppTitle";
-import { getPageDescription } from "@utils/getPageDescription";
-import { getPageTitle } from "@utils/getPageTitle";
-import { getCanonicalUrl } from "@utils/getCanonicalUrl";
+import { getAppTitle } from "@/utils/getAppTitle";
+import { getPageDescription } from "@/utils/getPageDescription";
+import { getPageTitle } from "@/utils/getPageTitle";
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl";
 
 import { TTheme, TThemeConfig } from "@/types";
 import dynamic from "next/dynamic";

--- a/src/components/map/GeographySelect.tsx
+++ b/src/components/map/GeographySelect.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import SuggestList from "@/components/filters/SuggestList";
-import { sortData } from "@utils/sorting";
+import { sortData } from "@/utils/sorting";
 import { Icon } from "@/components/atoms/icon/Icon";
 
 interface ByTextInputProps {

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -3,7 +3,7 @@ import { Fragment } from "react";
 import { MAX_PAGES, RESULTS_PER_PAGE, PAGES_PER_CONTINUATION_TOKEN } from "@/constants/paging";
 import { Button } from "@/components/atoms/button/Button";
 
-import { getCurrentPage } from "@utils/getCurrentPage";
+import { getCurrentPage } from "@/utils/getCurrentPage";
 
 interface PaginationProps {
   onChange(ct: string, offSet: number): void;

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -1,7 +1,7 @@
 import { TConcept } from "@/types";
 import { ExternalLink } from "@/components/ExternalLink";
 import { Heading } from "@/components/typography/Heading";
-import { getConceptStoreLink } from "@utils/getConceptStoreLink";
+import { getConceptStoreLink } from "@/utils/getConceptStoreLink";
 import { Popover } from "./Popover";
 
 type TProps = {

--- a/src/components/timeline/Event.tsx
+++ b/src/components/timeline/Event.tsx
@@ -1,5 +1,5 @@
 import { TEvent } from "@/types";
-import { convertDate } from "@utils/timedate";
+import { convertDate } from "@/utils/timedate";
 
 interface EventProps {
   event: TEvent;

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "react-query";
 import { ApiClient, getEnvFromServer } from "../api/http-common";
-import { extractNestedData } from "@utils/extractNestedData";
+import { extractNestedData } from "@/utils/extractNestedData";
 import { TGeography, TLanguages, TCorpusTypeDictionary, TDataNode } from "@/types";
 
 type TQueryResponse = {

--- a/src/hooks/useDownloadCsv.ts
+++ b/src/hooks/useDownloadCsv.ts
@@ -1,5 +1,5 @@
 import { ApiClient, getEnvFromServer, getFilters } from "../api/http-common";
-import buildSearchQuery, { TRouterQuery } from "@utils/buildSearchQuery";
+import buildSearchQuery, { TRouterQuery } from "@/utils/buildSearchQuery";
 import { TLoadingStatus, TSearch } from "@/types";
 import { useState } from "react";
 

--- a/src/hooks/useGetTheme.ts
+++ b/src/hooks/useGetTheme.ts
@@ -1,4 +1,4 @@
-import { getSiteAsync } from "@utils/getSite";
+import { getSiteAsync } from "@/utils/getSite";
 import { useEffect, useState } from "react";
 
 export default function useGetTheme() {

--- a/src/hooks/useMcfData.ts
+++ b/src/hooks/useMcfData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { getEnvFromServer } from "@/api/http-common";
-import { hasMcfAccess } from "@utils/checkCorpusAccess";
+import { hasMcfAccess } from "@/utils/checkCorpusAccess";
 
 export const useMcfData = () => {
   const [showMcf, setShowMcf] = useState(true);

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,8 +3,8 @@ import { ApiClient, getEnvFromServer } from "../api/http-common";
 
 import useGetThemeConfig from "./useThemeConfig";
 
-import buildSearchQuery, { TRouterQuery } from "@utils/buildSearchQuery";
-import { getCachedSearch, updateCacheSearch, TCacheResult } from "@utils/searchCache";
+import buildSearchQuery, { TRouterQuery } from "@/utils/buildSearchQuery";
+import { getCachedSearch, updateCacheSearch, TCacheResult } from "@/utils/searchCache";
 
 import { initialSearchCriteria } from "../constants/searchCriteria";
 

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/atoms/button/Button";
-import { setFeatureFlags } from "@utils/featureFlags";
+import { setFeatureFlags } from "@/utils/featureFlags";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
 

--- a/src/pages/api/theme-config.ts
+++ b/src/pages/api/theme-config.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { readConfigFile } from "@utils/readConfigFile";
+import { readConfigFile } from "@/utils/readConfigFile";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -29,15 +29,15 @@ import { Alert } from "@/components/Alert";
 import { SubNav } from "@/components/nav/SubNav";
 import { Heading } from "@/components/typography/Heading";
 
-import { truncateString } from "@utils/truncateString";
+import { truncateString } from "@/utils/truncateString";
 import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
 import { getCorpusInfo } from "@/helpers/getCorpusInfo";
 import { getMainDocuments } from "@/helpers/getMainDocuments";
 
-import { sortFilterTargets } from "@utils/sortFilterTargets";
-import { pluralise } from "@utils/pluralise";
-import { getFamilyMetaDescription } from "@utils/getFamilyMetaDescription";
-import { extractNestedData } from "@utils/extractNestedData";
+import { sortFilterTargets } from "@/utils/sortFilterTargets";
+import { pluralise } from "@/utils/pluralise";
+import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
+import { extractNestedData } from "@/utils/extractNestedData";
 
 import { TFamilyPage, TMatchedFamily, TTarget, TGeography, TTheme, TCorpusTypeDictionary, TSearchResponse, TConcept } from "@/types";
 
@@ -45,8 +45,8 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { EXAMPLE_SEARCHES } from "@/constants/exampleSearches";
 import { MAX_FAMILY_SUMMARY_LENGTH } from "@/constants/document";
 import { MAX_PASSAGES } from "@/constants/paging";
-import { getFeatureFlags } from "@utils/featureFlags";
-import { fetchAndProcessConcepts } from "@utils/processConcepts";
+import { getFeatureFlags } from "@/utils/featureFlags";
+import { fetchAndProcessConcepts } from "@/utils/processConcepts";
 import { useEffectOnce } from "@/hooks/useEffectOnce";
 import { MultiCol } from "@/components/panels/MultiCol";
 import { ConceptsPanel } from "@/components/concepts/ConceptsPanel";

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -27,9 +27,9 @@ import { EXAMPLE_SEARCHES } from "@/constants/exampleSearches";
 import { MAX_PASSAGES, MAX_RESULTS } from "@/constants/paging";
 
 import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TConcept } from "@/types";
-import { getFeatureFlags } from "@utils/featureFlags";
+import { getFeatureFlags } from "@/utils/featureFlags";
 import { ConceptsDocumentViewer } from "@/components/documents/ConceptsDocumentViewer";
-import { getMatchedPassagesFromSearch } from "@utils/getMatchedPassagesFromFamiy";
+import { getMatchedPassagesFromSearch } from "@/utils/getMatchedPassagesFromFamiy";
 
 type TProps = {
   document: TDocumentPage;

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -27,9 +27,9 @@ import { Heading } from "@/components/typography/Heading";
 
 import { getCountryCode } from "@/helpers/getCountryFields";
 
-import { extractNestedData } from "@utils/extractNestedData";
-import { sortFilterTargets } from "@utils/sortFilterTargets";
-import { readConfigFile } from "@utils/readConfigFile";
+import { extractNestedData } from "@/utils/extractNestedData";
+import { sortFilterTargets } from "@/utils/sortFilterTargets";
+import { readConfigFile } from "@/utils/readConfigFile";
 
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { systemGeoNames } from "@/constants/systemGeos";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import useConfig from "@/hooks/useConfig";
 
 import { QUERY_PARAMS } from "@/constants/queryParams";
 
-import { triggerNewSearch } from "@utils/triggerNewSearch";
+import { triggerNewSearch } from "@/utils/triggerNewSearch";
 import dynamic from "next/dynamic";
 import { TProps as HomepageProps } from "@cpr/pages/homepage";
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -30,13 +30,13 @@ import Pagination from "@/components/pagination";
 import SearchResultList from "@/components/search/SearchResultList";
 import { Icon } from "@/components/atoms/icon/Icon";
 
-import { getThemeConfigLink } from "@utils/getThemeConfigLink";
-import { readConfigFile } from "@utils/readConfigFile";
+import { getThemeConfigLink } from "@/utils/getThemeConfigLink";
+import { readConfigFile } from "@/utils/readConfigFile";
 
 import { QUERY_PARAMS } from "@/constants/queryParams";
 
 import { TConcept, TFamilyPage, TTheme, TThemeConfig } from "@/types";
-import { getFeatureFlags } from "@utils/featureFlags";
+import { getFeatureFlags } from "@/utils/featureFlags";
 import { ApiClient } from "@/api/http-common";
 import { Button } from "@/components/atoms/button/Button";
 

--- a/src/utils/extractNestedData.ts
+++ b/src/utils/extractNestedData.ts
@@ -1,5 +1,5 @@
 import { TDataNode } from "@/types";
-import { removeDuplicates } from "@utils/removeDuplicates";
+import { removeDuplicates } from "@/utils/removeDuplicates";
 
 export function extractNestedData<T>(response: TDataNode<T>[], levels: number, filterProp: string): { level1: T[]; level2: T[] } {
   let level1 = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
       "@/hooks/*": ["src/hooks/*"],
       "@/interfaces/*": ["src/interfaces/*"],
       "@/types": ["src/types/index"],
-      "@pages/*": ["src/pages/*"],
-      "@utils/*": ["src/utils/*"],
+      "@/pages/*": ["src/pages/*"],
+      "@/utils/*": ["src/utils/*"],
       "@cclw/*": ["themes/cclw/*"],
       "@cpr/*": ["themes/cpr/*"],
       "@mcf/*": ["themes/mcf/*"]


### PR DESCRIPTION
# What's changed

As part of import sorting PR, we are going to update our custom path aliases so that they have a preceding / e.g., @utils becomes @/utils. This is so we can set an import rule later on in ESLint that groups our custom files separately from 3rd party libraries.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
