### PR TITLE
fix: add the type of buttons on CPR searchform

### DIFF
--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -11,6 +11,15 @@ test("search", async ({ page }) => {
   /** Homepage */
   await expect(page.getByLabel("Search").first()).toBeVisible();
   await page.getByLabel("Search").first().fill("Adaptation strategy");
+
+  /** Test keyboard submission */
+  await page.getByLabel("Search").first().press("Enter");
+  await page.waitForURL("/search*");
+
+  /** Test tap submission  */
+  await page.goBack();
+  await expect(page.getByLabel("Search").first()).toBeVisible();
+  await page.getByLabel("Search").first().fill("Adaptation strategy");
   await page.getByRole("button", { name: "Search" }).click();
 
   /** Search */

--- a/themes/cpr/components/LandingSearchForm.tsx
+++ b/themes/cpr/components/LandingSearchForm.tsx
@@ -51,7 +51,14 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
   const displayPlaceholder = placeholder ?? "Search the full text of 5000+ laws and policies";
 
   return (
-    <form data-cy="search-form" ref={formRef} onSubmit={(e) => e.preventDefault()}>
+    <form
+      data-cy="search-form"
+      ref={formRef}
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSearchInput(term);
+      }}
+    >
       <div className="max-w-screen-lg mx-auto flex items-stretch relative text-white">
         <input
           id="landingPage-searchInput"
@@ -77,12 +84,13 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
               variant="ghost"
               className="!text-text-light !outline-surface-light hover:!bg-transparent"
               onClick={clearSearch}
+              type="button"
             >
               <Icon name="close" />
             </Button>
           </div>
         )}
-        <button className="absolute top-0 right-0 h-full" onClick={() => handleSearchInput(term)} aria-label="Search">
+        <button type="submit" className="absolute top-0 right-0 h-full" onClick={() => handleSearchInput(term)} aria-label="Search">
           <span className="block">
             <Icon name="search" height="30" width="40" />
           </span>


### PR DESCRIPTION
# What's changed
As we don't specify the type of `button` on the search `form` - they are inferred as `type="submit"`.

This explicitly sets the `clear = button` and `search = submit`.

Fixes https://linear.app/climate-policy-radar/issue/APP-378/using-enter-to-search-in-the-homepage-is-not-working

## Proposed version

- [x] Patch
