### PR TITLE
fix: set posthog.person_profiles: 'always'

### DIFF
--- a/src/context/PostHogProvider.tsx
+++ b/src/context/PostHogProvider.tsx
@@ -63,6 +63,7 @@ export function PostHogProvider({ children, consent }: Props) {
       capture_pageview: false,
       capture_pageleave: true,
       persistence: "memory",
+      person_profiles: "always",
     });
     window.sessionStorage.setItem("posthogLoaded", "true");
   }, []);


### PR DESCRIPTION
# What's changed
- sets `person_profiles: always`

This allows to get some insight into retention i.e. when someone re-visits the site vs being a new user.

We are aware of
- the inference of what a "returning" user is given that it's cookie based thus inaccurate
- there might be a cost involved that means we need to look at our plan with Posthog

This is a test that will be running for the week - we will evaluate each day to assess if our usage is unsustainable.

[You can read the docs here](https://posthog.com/docs/data/anonymous-vs-identified-events).

## Proposed version

- [x] Patch