### PR TITLE
fix: remove main prefix on docker-tag and make playwright environment aware

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
                 workflow_id: "deploy.yml",
                 ref: "main",
                 inputs: {
-                    "docker-tag": `main-${{ inputs.docker-tag }}`,
+                    "docker-tag": `${{ inputs.docker-tag }}`,
                     stack: stack
                 }
             })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "test": "vitest",
     "test-e2e": "npx playwright test",
     "test-e2e-ui": "npx playwright test --ui",
+    "test-e2e-staging": "PLAYWRIGHT_ENV=staging npx playwright test",
+    "test-e2e-staging-ui": "PLAYWRIGHT_ENV=staging npx playwright test --ui",
+    "test-e2e-prod": "PLAYWRIGHT_ENV=production npx playwright test",
+    "test-e2e-prod-ui": "PLAYWRIGHT_ENV=production npx playwright test --ui",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,21 @@
 import { defineConfig, devices } from "@playwright/test";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+const config = {
+  development: {
+    baseURL: "http://localhost:3000",
+    useWebserver: true,
+  },
+  staging: {
+    baseURL: "https://app.dev.climatepolicyradar.org",
+    useWebserver: false,
+  },
+  production: {
+    baseURL: "https://app.climatepolicyradar.org",
+    useWebserver: false,
+  },
+};
+const env = process.env.PLAYWRIGHT_ENV ?? "development";
+const envConfig = config[env];
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -25,7 +34,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: envConfig.baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -70,9 +79,11 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "npm run start",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: envConfig.useWebserver
+    ? {
+        command: "npm run start",
+        url: envConfig.baseURL,
+        reuseExistingServer: !process.env.CI,
+      }
+    : undefined,
 });


### PR DESCRIPTION
# What's changed
- removes the `main` prefix on the `docker-tag`
- make playwright environment aware

[This is generated in the `merge_to_main` action as just the `github.sha`](https://github.com/climatepolicyradar/navigator-frontend/blob/main/.github/workflows/merge_to_main.yml#L118).

Making playwright environment aware will allow us to run smoke tests on the different environments.

## Proposed version

- [x] Patch
