### PR TITLE
fix: use prod env vars as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,22 +3,23 @@
 # API_URL=http://localhost:8888/api/v1
 
 # Production
-API_URL=https://app.dev.climatepolicyradar.org/api/v1
-TARGETS_URL=https://cpr-staging-targets-json-store.s3.eu-west-1.amazonaws.com
-CDN_URL=https://cdn.dev.climatepolicyradar.org
+API_URL=https://app.climatepolicyradar.org/api/v1
+TARGETS_URL=https://cpr-production-targets-json-store.s3.eu-west-1.amazonaws.com
+CDN_URL=https://cdn.climatepolicyradar.org
 CONCEPTS_API_URL=https://api.climatepolicyradar.org
+NEXT_PUBLIC_APP_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbGxvd2VkX2NvcnBvcmFfaWRzIjpbXSwic3ViIjoiY3ByIiwiYXVkIjoibG9jYWxob3N0IiwiaXNzIjoiQ2xpbWF0ZSBQb2xpY3kgUmFkYXIiLCJleHAiOjIwNTc4NDMxNTAuMCwiaWF0IjoxNzQyMzEwMzUwfQ.8e1XUvVmcDwXZH1ouEH635EDjSfjp2Qy0xq-Ez4-wp4
 
 # Staging
 # API_URL=https://app.dev.climatepolicyradar.org/api/v1
 # TARGETS_URL=https://cpr-staging-targets-json-store.s3.eu-west-1.amazonaws.com
 # CDN_URL=https://cdn.dev.climatepolicyradar.org
 # CONCEPTS_API_URL=https://api.climatepolicyradar.org
+# NEXT_PUBLIC_APP_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbGxvd2VkX2NvcnBvcmFfaWRzIjpbIkNDTFcuY29ycHVzLmkwMDAwMDAwMS5uMDAwMCIsIkNQUi5jb3JwdXMuaTAwMDAwMDAxLm4wMDAwIiwiVU5GQ0NDLmNvcnB1cy5pMDAwMDAwMDEubjAwMDAiXSwiZXhwIjoyMDQyMTEzMzY5LCJpYXQiOjE3MjY1NzY5NjksImlzcyI6IkNsaW1hdGUgUG9saWN5IFJhZGFyIiwic3ViIjoiQ1BSIiwiYXVkIjoiaHR0cHM6Ly9hcHAuZGV2LmNsaW1hdGVwb2xpY3lyYWRhci5vcmcvIn0.mJ2qLJmMyPLGt0rM_tTXhlVv1glxooxmQV0bWrvPwKU
 
 THEME=cpr
 ADOBE_API_KEY=dca9187b65294374a6367824df902fdf
 REDIRECT_FILE="test.json"
 HOSTNAME=http://localhost:3000
-NEXT_PUBLIC_APP_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbGxvd2VkX2NvcnBvcmFfaWRzIjpbIkNDTFcuY29ycHVzLmkwMDAwMDAwMS5uMDAwMCIsIkNQUi5jb3JwdXMuaTAwMDAwMDAxLm4wMDAwIiwiVU5GQ0NDLmNvcnB1cy5pMDAwMDAwMDEubjAwMDAiXSwiZXhwIjoyMDQyMTEzMzY5LCJpYXQiOjE3MjY1NzY5NjksImlzcyI6IkNsaW1hdGUgUG9saWN5IFJhZGFyIiwic3ViIjoiQ1BSIiwiYXVkIjoiaHR0cHM6Ly9hcHAuZGV2LmNsaW1hdGVwb2xpY3lyYWRhci5vcmcvIn0.mJ2qLJmMyPLGt0rM_tTXhlVv1glxooxmQV0bWrvPwKU
 
 # to run playwright tests in watch mode
 # PWTEST_WATCH=1


### PR DESCRIPTION
# What's changed
- uses production env variables as the default

I thought this had been done before, this makes for a more stable e2e testing environment and is low risk as the app is read only.

As per a discussion with @PatFawbertMills 

## Proposed version

- [x] Patch