### PR TITLE
fix: rename release => deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ on:
         required: true
 permissions: read-all
 jobs:
-  deploy-on-merge:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -82,7 +82,7 @@ jobs:
           path: playwright-report/
           retention-days: 30
   # deploy
-  deploy:
+  release:
     runs-on: ubuntu-latest
     needs: [code-quality, test, test-e2e]
     environment: production


### PR DESCRIPTION
# What's changed
- ☝️ 

This is mainly because if you name an step "deploy" it gets registers [in the GitHub deploys](https://github.com/climatepolicyradar/navigator-frontend/deployments) - and fills @odrakes-cpr's inbox.

