### PR TITLE
fix: only autocomplete on concepts with `has_classifiers`

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -579,7 +579,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const client = new ApiClient(process.env.CONCEPTS_API_URL);
     const conceptsV1 = featureFlags["concepts-v1"];
     if (conceptsV1) {
-      const { data: returnedData } = await client.get(`/concepts/search?limit=10000&q=`);
+      const { data: returnedData } = await client.get(`/concepts/search?limit=10000&has_classifier=true&q=`);
       conceptsData = returnedData;
     }
   } catch (error) {


### PR DESCRIPTION
# What's changed
- adds `has_classifier` filter to search page

Here's an example of searching for `t` only returns 9 results:
https://api.climatepolicyradar.org/concepts/search?q=t&has_classifier=true&size=10000

I am not too sure how the lookahead logic works as it seems to return a whole bunch of stuff, but I don't really want to be changing that just as yet.

https://github.com/climatepolicyradar/navigator-frontend/blob/main/src/components/forms/TypeAhead.tsx#L31-L35

## Screenshots?

| before | after |
|---|---|
| ![Screenshot 2025-03-25 at 11 28 13](https://github.com/user-attachments/assets/a637f40b-803f-4e5f-9470-4cc77176c72a) | ![Screenshot 2025-03-25 at 11 29 00](https://github.com/user-attachments/assets/94934a16-0203-4d70-9dcc-28eebebb7068) |



