### PR TITLE
fix: add pull-requests: write to pull_request action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,8 @@
 name: Pull request
 on: pull_request
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   size:


### PR DESCRIPTION
# What's changed
- adds `write` to `pull-requests` in `pull_request` action

I was interested in what affect @jesskelsall's PR #433 had on the size of the bundle but [noticed the size action could not post to a pull-request](https://github.com/climatepolicyradar/navigator-frontend/actions/runs/14059870909/job/39367761261?pr=433#step:3:183).

## Why?

To see what affect we're having on or bundle size.