### PR TITLE
feat: add smoke-tests workflow

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,0 +1,28 @@
+name: Smoke tests
+on: workflow_call
+# trunk-ignore(checkov/CKV2_GHA_1)
+permissions: write-all
+jobs:
+  test-e2e:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+      - run: npm ci
+      - run: cp .env.example .env
+      - run: npm run build
+        env:
+          NODE_ENV: production
+      - run: npx playwright install --with-deps
+      - run: npx playwright test
+        env:
+          PLAYWRIGHT_ENV: production
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30


### PR DESCRIPTION
# What's changed

- adds a smoke test that can be triggered from other events e.g. deploys, merges etc.

The first event I would like to spawn this from is `AppRunner: Update service: Succeeded`.
(@katybaulch hopefully allowing as to subscribe to `Rollback succeeded`)

**Why not make this a reusable job as we use it in a few places?**
It's such a small step that I think the flexibility out-weighs the reduction in code that this would present

## Why?

there are a few services that the frontend is dependant on and we would like to know if they've broken anything.

