### PR TITLE
APP-420: Search bar iteration

### DIFF
--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -88,7 +88,7 @@ export const Input = ({
       {iconOnLeft && iconNode}
       <BaseInput className={classes.input} value={value} {...props} />
       {clearable && (
-        <button type="button" className={`${classes.button} ${value ? "in-focus-within:hidden" : "hidden"}`} onClick={handleClear}>
+        <button type="button" className={`${classes.button} ${value ? "" : "hidden"}`} onClick={handleClear}>
           <Icon name="close" height="12" width="12" />
         </button>
       )}

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -52,7 +52,7 @@ export const Input = ({
     }
 
     return {
-      button: joinTailwindClasses([iconPadding]),
+      button: joinTailwindClasses(["text-icon-standard", iconPadding]),
       container: joinTailwindClasses([
         "w-full px-2 flex flex-row justify-around items-center bg-surface-ui rounded-md focus-within:outline",
         outlineColor,

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -52,13 +52,13 @@ export const Input = ({
     }
 
     return {
-      button: joinTailwindClasses(["text-icon-standard", iconPadding]),
+      button: joinTailwindClasses(["shrink-0 text-icon-standard", iconPadding]),
       container: joinTailwindClasses([
         "w-full px-2 flex flex-row justify-around items-center bg-surface-ui rounded-md focus-within:outline",
         outlineColor,
         containerClasses,
       ]),
-      icon: joinTailwindClasses([iconPadding]),
+      icon: joinTailwindClasses(["shrink-0", iconPadding]),
       input: joinTailwindClasses([
         "w-full block bg-transparent border-none focus:shadow-[none] leading-none font-medium text-text-primary placeholder:text-text-tertiary caret-text-brand",
         inputPadding,
@@ -88,7 +88,7 @@ export const Input = ({
       {iconOnLeft && iconNode}
       <BaseInput className={classes.input} value={value} {...props} />
       {clearable && (
-        <button type="button" className={`${classes.button} ${value ? "" : "invisible"}`} onClick={handleClear}>
+        <button type="button" className={`${classes.button} ${value ? "in-focus-within:hidden" : "hidden"}`} onClick={handleClear}>
           <Icon name="close" height="12" width="12" />
         </button>
       )}

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -51,7 +51,7 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showC
 
   return (
     <div className="pb-4">
-      <div className="mt-4 grow-0 shrink-0">
+      <div className="grow-0 shrink-0">
         <ConceptsHead></ConceptsHead>
       </div>
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -28,7 +28,6 @@ type TProps = {
   vespaDocumentData: TSearchResponse;
   document: TDocumentPage;
   familySlug: string;
-
   // Callback props for state changes
   onExactMatchChange?: (isExact: boolean) => void;
   onConceptClick?: (conceptLabel: string) => void;
@@ -130,10 +129,13 @@ export const ConceptsDocumentViewer = ({
 
   const documentConceptCountsById = useMemo(
     () =>
-      documentConcepts.reduce((acc, concept) => {
-        acc[concept.wikibase_id] = concept.count || 0;
-        return acc;
-      }, {} as Record<string, number>),
+      documentConcepts.reduce(
+        (acc, concept) => {
+          acc[concept.wikibase_id] = concept.count || 0;
+          return acc;
+        },
+        {} as Record<string, number>
+      ),
     [documentConcepts]
   );
 

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -27,7 +27,7 @@ const Slideout = ({ children, show, setShow }: SlideoutProps) => {
   return (
     <div
       ref={ref}
-      className={`fixed top-0 bottom-0 right-0 w-11/12 bg-white z-50 transition duration-300 origin-left transform shadow-2xl shadow-black/40 md:w-2/3 xl:w-5/12 overflow-y-scroll scrollbar-narrow ${
+      className={`fixed top-0 bottom-0 right-0 w-11/12 bg-white z-70 transition duration-300 origin-left transform shadow-2xl shadow-black/40 md:w-2/3 xl:w-5/12 overflow-y-scroll scrollbar-narrow ${
         show ? "translate-x-0" : "translate-x-[110%]"
       }`}
     >

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@/components/atoms/icon/Icon";
 import { Input } from "@/components/atoms/input/Input";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { systemGeoCodes } from "@/constants/systemGeos";
 import useConfig from "@/hooks/useConfig";
@@ -8,7 +9,6 @@ import { sortBy } from "lodash";
 import { useRouter } from "next/router";
 import { FormEventHandler, MouseEventHandler, useEffect, useMemo, useRef, useState } from "react";
 import { NavSearchDropdown } from "./NavSearchDropdown";
-import { LinkWithQuery } from "@/components/LinkWithQuery";
 
 const pagesWithContextualSearch: string[] = ["/document/[id]", "/documents/[id]", "/geographies/[id]"];
 
@@ -138,9 +138,9 @@ export const NavSearch = () => {
           <Input
             autoComplete="off"
             clearable
-            containerClasses="focus-within:!outline-0"
+            containerClasses={`h-[45px] focus-within:!outline-0`}
             icon={
-              <button type="submit" className="w-4 h-4 ml-2">
+              <button type="submit" className="w-4 h-4 ml-2 shrink-0">
                 <Icon name="search" />
               </button>
             }

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -1,18 +1,15 @@
-import { Icon } from "@/components/atoms/icon/Icon";
 import { Input } from "@/components/atoms/input/Input";
-import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { systemGeoCodes } from "@/constants/systemGeos";
 import useConfig from "@/hooks/useConfig";
 import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
 import { sortBy } from "lodash";
-import { useRouter } from "next/router";
-import { FormEventHandler, MouseEventHandler, useEffect, useMemo, useRef, useState } from "react";
-import { NavSearchDropdown } from "./NavSearchDropdown";
-import { LuArrowRight, LuCornerDownLeft, LuSearch } from "react-icons/lu";
-import { NavSearchSuggestion } from "./NavSearchSuggestion";
-import Link from "next/link";
 import { Url } from "next/dist/shared/lib/router/router";
+import { useRouter } from "next/router";
+import { FormEventHandler, useEffect, useMemo, useRef, useState } from "react";
+import { LuArrowRight, LuCornerDownLeft, LuSearch } from "react-icons/lu";
+import { NavSearchDropdown } from "./NavSearchDropdown";
+import { NavSearchSuggestion } from "./NavSearchSuggestion";
 
 const pagesWithContextualSearch: string[] = ["/document/[id]", "/documents/[id]", "/geographies/[id]"];
 

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -133,18 +133,19 @@ export const NavSearch = () => {
   return (
     <div className="relative" ref={ref}>
       <div className="p-4 relative z-20">
-        <form onSubmit={handleSubmit} className="flex flex-row">
+        <form onSubmit={handleSubmit} className="flex flex-row gap-2">
           {/* Search field */}
           <Input
             autoComplete="off"
             clearable
-            containerClasses={`focus-within:!outline-0 ${showDropdown ? "rounded-r-none" : ""}`}
+            containerClasses="focus-within:!outline-0"
             icon={
               <button type="submit" className="w-4 h-4 ml-2">
                 <Icon name="search" />
               </button>
             }
             iconOnLeft
+            inputClasses="text-sm"
             onChange={(event) => setSearchText(event.target.value)}
             onClear={handleClear}
             onFocus={() => setIsFocused(true)}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -162,7 +162,7 @@ export const NavSearch = () => {
 
       {/* Results */}
       {isFocused && (
-        <div className="absolute top-0 left-0 right-0 outline -outline-offset-1 outline-border-lighter rounded-xl bg-surface-light shadow-[0px_4px_48px_0px_rgba(0,0,0,0.08)]">
+        <div className="absolute top-0 left-0 right-0 min-h-[56px] outline -outline-offset-1 outline-border-lighter rounded-xl bg-surface-light shadow-[0px_4px_48px_0px_rgba(0,0,0,0.08)]">
           {showResults && (
             <div className="flex flex-col gap-3 p-2 pt-[56px]">
               {/* Geographies */}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -132,13 +132,13 @@ export const NavSearch = () => {
 
   return (
     <div className="relative" ref={ref}>
-      <div className="p-4 relative z-20">
+      <div className="p-2 relative z-20">
         <form onSubmit={handleSubmit} className="flex flex-row gap-2">
           {/* Search field */}
           <Input
             autoComplete="off"
             clearable
-            containerClasses={`h-[45px] focus-within:!outline-0`}
+            containerClasses={`h-[40px] focus-within:!outline-0`}
             icon={
               <button type="submit" className="w-4 h-4 ml-2 shrink-0">
                 <Icon name="search" />
@@ -150,7 +150,6 @@ export const NavSearch = () => {
             onClear={handleClear}
             onFocus={() => setIsFocused(true)}
             placeholder="Search"
-            size="large"
             value={searchText}
           />
 
@@ -162,25 +161,29 @@ export const NavSearch = () => {
       </div>
 
       {/* Results */}
-      {showResults && (
-        <div className="absolute top-0 left-0 right-0 border border-border-lighter rounded-xl bg-surface-light shadow-[0px_4px_48px_0px_rgba(0,0,0,0.08)] p-4 pt-16">
-          {/* Geographies */}
-          {geographyResults.length > 0 && (
-            <div className="my-6 flex flex-col gap-4">
-              <h3 className="text-text-brand text-sm font-medium select-none">Geographies</h3>
-              {geographyResults.map((geography) => (
-                <LinkWithQuery href={`/geographies/${geography.slug}`} key={geography.id} className="text-sm hover:underline">
-                  {withBoldMatch(geography.display_value, searchText)}
-                </LinkWithQuery>
-              ))}
+      {isFocused && (
+        <div className="absolute top-0 left-0 right-0 border border-border-lighter rounded-xl bg-surface-light shadow-[0px_4px_48px_0px_rgba(0,0,0,0.08)] min-h-full">
+          {showResults && (
+            <div className="p-2 pt-[56px]">
+              {/* Geographies */}
+              {geographyResults.length > 0 && (
+                <div className="my-6 flex flex-col gap-4">
+                  <h3 className="text-text-brand text-sm font-medium select-none">Geographies</h3>
+                  {geographyResults.map((geography) => (
+                    <LinkWithQuery href={`/geographies/${geography.slug}`} key={geography.id} className="text-sm hover:underline">
+                      {withBoldMatch(geography.display_value, searchText)}
+                    </LinkWithQuery>
+                  ))}
+                </div>
+              )}
+              {/* Search */}
+              <div className="pt-4 pb-2 not-first:border-t border-border-lighter">
+                <button type="button" onClick={handleSearchButton} className="w-full text-sm text-left hover:underline">
+                  Search for <span className="font-bold">{searchText}</span>
+                </button>
+              </div>
             </div>
           )}
-          {/* Search */}
-          <div className="pt-4 pb-2 not-first:border-t border-border-lighter">
-            <button type="button" onClick={handleSearchButton} className="w-full text-sm text-left hover:underline">
-              Search for <span className="font-bold">{searchText}</span>
-            </button>
-          </div>
         </div>
       )}
     </div>

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -64,7 +64,7 @@ export const NavSearch = () => {
   }, [ref]);
 
   const geographyResults = useMemo(() => {
-    if (searchText.length < 2) return [];
+    if (!searchEverything || searchText.length < 2) return [];
 
     const geographies = configQuery.data?.countries || [];
 
@@ -82,7 +82,7 @@ export const NavSearch = () => {
         "display_value",
       ]
     );
-  }, [searchText, configQuery]);
+  }, [searchEverything, searchText, configQuery]);
 
   let contextualSearchName = "This document";
   if (router.pathname === "/geographies/[id]") contextualSearchName = "This geography";
@@ -117,7 +117,12 @@ export const NavSearch = () => {
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
+    setIsFocused(false);
     router.push(searchHref);
+  };
+
+  const handleSuggestionClick = () => {
+    setIsFocused(false);
   };
 
   const handleClear = () => {
@@ -174,6 +179,7 @@ export const NavSearch = () => {
                       Icon={
                         <LuArrowRight height="16" width="16" className="opacity-0 group-hover:opacity-100 text-text-brand transition duration-200" />
                       }
+                      onClick={handleSuggestionClick}
                     >
                       {withBoldMatch(geography.display_value, searchText)}
                     </NavSearchSuggestion>
@@ -189,6 +195,7 @@ export const NavSearch = () => {
                     Press <LuCornerDownLeft height="12" width="12" className="inline group-hover:text-text-brand transition duration-200" /> ENTER
                   </div>
                 }
+                onClick={handleSuggestionClick}
               >
                 All results for <span className="font-bold">&#8216;{searchText}&#8217;</span>
               </NavSearchSuggestion>

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -56,29 +56,31 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
   };
 
   return (
-    <div
-      ref={ref}
-      className={`flex flex-col bg-surface-light -outline-offset-1 outline-border-lighter rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
-    >
-      {dropdownOptions.map((option, optionIndex) => (
-        <button
-          key={option.name}
-          type="button"
-          onClick={() => handleClick(option.newIsEverythingValue)}
-          className={`w-full flex items-center justify-between gap-2 text-sm leading-4 font-medium text-nowrap cursor-pointer
+    <div className="h-[40px] overflow-visible">
+      <div
+        ref={ref}
+        className={`flex flex-col bg-surface-light -outline-offset-1 outline-border-lighter rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
+      >
+        {dropdownOptions.map((option, optionIndex) => (
+          <button
+            key={option.name}
+            type="button"
+            onClick={() => handleClick(option.newIsEverythingValue)}
+            className={`w-full flex items-center justify-between gap-2 text-sm leading-4 font-medium text-nowrap cursor-pointer
           ${
             isOpen
               ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
               : "h-[40px] px-3 bg-surface-ui rounded-md hover:text-text-primary"
           }
           ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}
-        >
-          {option.name}
-          <div className={isOpen ? "invisible" : ""}>
-            <LuChevronsUpDown height="12" width="12" />
-          </div>
-        </button>
-      ))}
+          >
+            {option.name}
+            <div className={isOpen ? "invisible" : ""}>
+              <LuChevronsUpDown height="12" width="12" />
+            </div>
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -50,13 +50,10 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
   ];
   if (!isEverything) dropdownOptions.reverse();
 
-  const handleClick =
-    (newValue: boolean): React.MouseEventHandler<HTMLButtonElement> =>
-    (event) => {
-      event.preventDefault();
-      setIsOpen((current) => !current);
-      if (isOpen) setIsEverything(newValue);
-    };
+  const handleClick = (newValue: boolean) => {
+    setIsOpen((current) => !current);
+    if (isOpen) setIsEverything(newValue);
+  };
 
   return (
     <div
@@ -67,12 +64,12 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
         <button
           key={option.name}
           type="button"
-          onClick={handleClick(option.newIsEverythingValue)}
-          className={`w-full flex items-center justify-between gap-2 text-sm leading-4 text-nowrap cursor-pointer
+          onClick={() => handleClick(option.newIsEverythingValue)}
+          className={`w-full flex items-center justify-between gap-2 text-sm leading-4 font-medium text-nowrap cursor-pointer
           ${
             isOpen
-              ? "h-[37px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
-              : "h-[45px] px-3 bg-surface-ui rounded-md hover:text-text-primary"
+              ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
+              : "h-[40px] px-3 bg-surface-ui rounded-md hover:text-text-primary"
           }
           ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}
         >

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -49,34 +49,39 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
     },
   ];
   if (!isEverything) dropdownOptions.reverse();
-  const [firstOption, secondOption] = dropdownOptions;
 
-  const handleClick = (newValue: boolean) => {
-    setIsOpen((current) => !current);
-    if (isOpen) setIsEverything(newValue);
-  };
-
-  const optionClasses = "h-full w-full flex items-center justify-between gap-2 pl-3 pr-3 bg-surface-ui text-sm leading-4 text-nowrap cursor-pointer";
+  const handleClick =
+    (newValue: boolean): React.MouseEventHandler<HTMLButtonElement> =>
+    (event) => {
+      event.preventDefault();
+      setIsOpen((current) => !current);
+      if (isOpen) setIsEverything(newValue);
+    };
 
   return (
-    <div ref={ref} className="text-text-secondary">
-      <button
-        type="button"
-        onClick={() => handleClick(firstOption.newIsEverythingValue)}
-        className={`${optionClasses} ${isOpen ? "rounded-t-md" : "rounded-md"}`}
-      >
-        {firstOption.name}
-        <div className={`text-icon-standard ${isOpen ? "invisible" : ""}`}>
-          <LuChevronsUpDown height="12" width="12" />
-        </div>
-      </button>
-      <button
-        type="button"
-        onClick={() => handleClick(secondOption.newIsEverythingValue)}
-        className={`${optionClasses} ${isOpen ? "" : "invisible"} rounded-b-md`}
-      >
-        {secondOption.name}
-      </button>
+    <div
+      ref={ref}
+      className={`flex flex-col bg-surface-light -outline-offset-1 outline-border-lighter rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
+    >
+      {dropdownOptions.map((option, optionIndex) => (
+        <button
+          key={option.name}
+          type="button"
+          onClick={handleClick(option.newIsEverythingValue)}
+          className={`w-full flex items-center justify-between gap-2 text-sm leading-4 text-nowrap cursor-pointer
+          ${
+            isOpen
+              ? "h-[37px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
+              : "h-[45px] px-3 bg-surface-ui rounded-md hover:text-text-primary"
+          }
+          ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}
+        >
+          {option.name}
+          <div className={isOpen ? "invisible" : ""}>
+            <LuChevronsUpDown height="12" width="12" />
+          </div>
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -59,14 +59,14 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
   const optionClasses = "h-full w-full flex items-center justify-between gap-2 pl-3 pr-3 bg-surface-ui text-sm leading-4 text-nowrap cursor-pointer";
 
   return (
-    <div ref={ref} className="border-l border-l-border-light">
+    <div ref={ref} className="text-text-secondary">
       <button
         type="button"
         onClick={() => handleClick(firstOption.newIsEverythingValue)}
-        className={`${optionClasses} ${isOpen ? "rounded-tr-md" : "rounded-r-md"}`}
+        className={`${optionClasses} ${isOpen ? "rounded-t-md" : "rounded-md"}`}
       >
         {firstOption.name}
-        <div className={isOpen ? "invisible" : ""}>
+        <div className={`text-icon-standard ${isOpen ? "invisible" : ""}`}>
           <LuChevronsUpDown height="12" width="12" />
         </div>
       </button>

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -1,0 +1,18 @@
+import { Url } from "next/dist/shared/lib/router/router";
+import Link from "next/link";
+import { IconType } from "react-icons";
+
+interface NavSearchSuggestionProps {
+  children: React.ReactNode;
+  hint?: React.ReactNode;
+  href: Url;
+  Icon?: React.ReactNode;
+}
+
+export const NavSearchSuggestion = ({ children, hint, href, Icon }: NavSearchSuggestionProps) => (
+  <Link href={href} className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-surface-ui transition duration-200 group">
+    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-brand transition duration-200" : ""}`}>{Icon}</div>
+    <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>
+    {hint}
+  </Link>
+);

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -1,16 +1,17 @@
 import { Url } from "next/dist/shared/lib/router/router";
 import Link from "next/link";
-import { IconType } from "react-icons";
+import { MouseEventHandler } from "react";
 
 interface NavSearchSuggestionProps {
   children: React.ReactNode;
   hint?: React.ReactNode;
   href: Url;
   Icon?: React.ReactNode;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
 }
 
-export const NavSearchSuggestion = ({ children, hint, href, Icon }: NavSearchSuggestionProps) => (
-  <Link href={href} className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-surface-ui transition duration-200 group">
+export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick }: NavSearchSuggestionProps) => (
+  <Link href={href} className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-surface-ui transition duration-200 group" onClick={onClick}>
     <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-brand transition duration-200" : ""}`}>{Icon}</div>
     <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>
     {hint}

--- a/src/components/organisms/navBar/NavBar.tsx
+++ b/src/components/organisms/navBar/NavBar.tsx
@@ -12,7 +12,7 @@ export const NavBar = ({ headerClasses = "", logo, menu, showLogo = true, showSe
   return (
     <header
       data-cy="header"
-      className={`w-full sm:px-4 flex justify-between items-center flex-wrap sm:flex-nowrap gap-y-1 sm:gap-y-0 sticky top-0 z-100 ${headerClasses}`}
+      className={`w-full sm:px-4 flex justify-between items-center flex-wrap sm:flex-nowrap gap-y-1 sm:gap-y-0 sticky top-0 z-60 ${headerClasses}`}
     >
       {showLogo && <div className="lg:flex-1 pl-4 pt-4 sm:pl-0 sm:pt-0">{logo}</div>}
       {showSearch && (

--- a/src/components/organisms/navBar/NavBar.tsx
+++ b/src/components/organisms/navBar/NavBar.tsx
@@ -12,9 +12,9 @@ export const NavBar = ({ headerClasses = "", logo, menu, showLogo = true, showSe
   return (
     <header
       data-cy="header"
-      className={`w-full sm:px-4 flex justify-between items-center flex-wrap sm:flex-nowrap gap-y-1 sm:gap-y-0 sticky top-0 z-60 ${headerClasses}`}
+      className={`w-full sm:px-4 pt-2 sm:pb-2 flex justify-between items-center flex-wrap sm:flex-nowrap gap-y-1 sm:gap-y-0 sticky top-0 z-60 ${headerClasses}`}
     >
-      {showLogo && <div className="lg:flex-1 pl-4 pt-4 sm:pl-0 sm:pt-0">{logo}</div>}
+      {showLogo && <div className="lg:flex-1 shrink-4 md:max-w-[30%] px-4 sm:pl-0 sm:pt-0">{logo}</div>}
       {showSearch && (
         <div className="flex-[1_1_100%] sm:flex-initial order-1 sm:order-0 lg:min-w-[550px]">
           <NavSearch />

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -125,21 +125,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
   };
 
   // Handlers to update router
-  const handleQueryTermChange = useCallback(
-    (queryTerm: string) => {
-      const queryObj = { ...router.query };
-      queryObj[QUERY_PARAMS.query_string] = queryTerm;
-      router.push(
-        {
-          pathname: `/documents/${document.slug}`,
-          query: queryObj,
-        },
-        undefined,
-        { shallow: true }
-      );
-    },
-    [router, document.slug]
-  );
 
   const handleExactMatchChange = useCallback(
     (isExact: boolean) => {
@@ -214,17 +199,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
     },
     [router, document.slug, conceptFilters]
   );
-
-  const handleClearSearch = useCallback(() => {
-    router.push(
-      {
-        pathname: `/documents/${document.slug}`,
-        query: {},
-      },
-      undefined,
-      { shallow: true }
-    );
-  }, [router, document.slug]);
 
   return (
     <Layout title={`${document.title}`} description={getDocumentDescription(document.title)} theme={theme}>
@@ -342,10 +316,8 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ 
             initialConceptFilters={conceptFilters}
             vespaFamilyData={vespaFamilyData}
             document={document}
-            onQueryTermChange={handleQueryTermChange}
             onExactMatchChange={handleExactMatchChange}
             onConceptClick={handleConceptClick}
-            onClear={handleClearSearch}
           />
         )}
       </section>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10,7 +10,7 @@
   nocompatible: true;
 }
 
-@custom-variant hocus (&:hover, &:focus);
+@custom-variant hocus (&:hover, &:focus-visible);
 
 :root {
   --MAX_SITE_WIDTH: 1440px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -78,6 +78,8 @@
   --color-text-light: #ffffff;
   --color-text-brand: #005eeb;
 
+  --color-icon-standard: #707070;
+
   --color-border-lighter: #ececec;
   --color-border-light: #e5e5e5;
   --color-border-brand: #005eeb;

--- a/themes/cclw/components/Header.tsx
+++ b/themes/cclw/components/Header.tsx
@@ -16,7 +16,7 @@ export const CCLWLogo = (
 const Header = () => {
   const router = useRouter();
 
-  const showBackground = router.pathname === "/";
+  const showBackground = router.pathname !== "/";
   const showLogo = router.pathname !== "/";
   const showSearch = router.pathname !== "/";
 


### PR DESCRIPTION
# What's changed

- `NavSearchDropdown`:
  - Separated from `NavSearch` input.
  - New visual style, particularly when the dropdown is open.
- `NavSearch`:
  - Redesign of search results UI including each suggestion.
  - Search results pop-around displays when the search input is empty.
  - All suggestions are now Next.js `Link`s with accurate URLs for better accessibility.
  - Tweaked when the clear (cross) button shows (when input is not empty).
- Functionality fixes:
  - Document page: submitting a "this document" search now correctly updates the passage results.
  - Document page: removed old passage search input.
  - Geography suggestions now only show when the search context is "everything".
  - Search results: "X matches in this document" button slide-out panel now correctly overlaps the sticky navbar (z-index).

Note: the changes I've made to the document page results area might not work 100% as intended but will be fixed as part of the next ticket. Everything appears to work well enough for the time being.

## Why?

Solid design crit feedback from @conordelahunty encapsulated in APP-420.

## Screenshots?

Family page showing context dropdown:
<img width="1331" alt="Screenshot 2025-04-01 at 11 53 24" src="https://github.com/user-attachments/assets/b7e66e21-fe7d-4045-9ed8-315ffbfe5eeb" />

Search results:
<img width="561" alt="Screenshot 2025-04-01 at 11 53 36" src="https://github.com/user-attachments/assets/a09b40f8-a39b-43c8-9313-b6c133df2406" />

Context dropdown open:
<img width="559" alt="Screenshot 2025-04-01 at 11 53 50" src="https://github.com/user-attachments/assets/423de280-7b62-4101-8c91-ce52110fc197" />

Geography suggestions with hover state:
<img width="565" alt="Screenshot 2025-04-01 at 11 54 02" src="https://github.com/user-attachments/assets/b1018826-5954-449a-b361-03048d52dda3" />

Generic search hover state:
<img width="563" alt="Screenshot 2025-04-01 at 11 54 10" src="https://github.com/user-attachments/assets/48ddf66a-ad14-4b6b-9468-c8100c9d601b" />

Removed search above passages on document page:
<img width="1333" alt="Screenshot 2025-04-01 at 11 54 45" src="https://github.com/user-attachments/assets/8d8e9633-fce3-4f9b-b591-47b91b06ffa1" />

