### PR TITLE
Feature/app 304 update faqs page for app.cpr

### DIFF
--- a/src/constants/conceptsFaqs.tsx
+++ b/src/constants/conceptsFaqs.tsx
@@ -109,14 +109,11 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     title: "Should I be concerned about the climate impact of this feature?",
     content: (
       <>
-        <p>
-          We prioritise sustainability in our technology choices:
-          <ul>
-            <li>When two models produce similar results, we use the simpler, less energy-intensive option.</li>
-            <li>Most of our models rely on efficient keyword-based detection rather than resource-heavy AI.</li>
-          </ul>
-        </p>
-
+        <p>We prioritise sustainability in our technology choices:</p>
+        <ul>
+          <li>When two models produce similar results, we use the simpler, less energy-intensive option.</li>
+          <li>Most of our models rely on efficient keyword-based detection rather than resource-heavy AI.</li>
+        </ul>
         <p>Nevertheless, we’re working to measure, minimise, and report on the precise energy intensity of our data science work.</p>
       </>
     ),

--- a/src/constants/conceptsFaqs.tsx
+++ b/src/constants/conceptsFaqs.tsx
@@ -11,7 +11,7 @@ type TFAQ = {
 export const CONCEPTS_FAQS: TFAQ[] = [
   {
     id: "concepts",
-    title: "Automatic Detection of key concepts in documents",
+    title: "Automatic detection of key concepts in documents",
     headContent: <Label>Beta</Label>,
     content: (
       <>
@@ -109,12 +109,13 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     title: "Should I be concerned about the climate impact of this feature?",
     content: (
       <>
-        <p>We prioritise sustainability in our technology choices:</p>
-
-        <ul>
-          <li>When two models produce similar results, we use the simpler, less energy-intensive option.</li>
-          <li>Most of our models rely on efficient keyword-based detection rather than resource-heavy AI.</li>
-        </ul>
+        <p>
+          We prioritise sustainability in our technology choices:
+          <ul>
+            <li>When two models produce similar results, we use the simpler, less energy-intensive option.</li>
+            <li>Most of our models rely on efficient keyword-based detection rather than resource-heavy AI.</li>
+          </ul>
+        </p>
 
         <p>Nevertheless, we’re working to measure, minimise, and report on the precise energy intensity of our data science work.</p>
       </>
@@ -138,10 +139,10 @@ export const CONCEPTS_FAQS: TFAQ[] = [
         <p>We are expanding our concept database, improving accuracy, and developing new structured data features.</p>
 
         <p>
-          See our
+          See our{" "}
           <ExternalLink url="https://www.notion.so/Climate-Policy-Radar-Public-Product-Roadmap-250fdc6416824160b7b34aef4ef29e1c?pvs=21">
             public product roadmap
-          </ExternalLink>
+          </ExternalLink>{" "}
           for more details.
         </p>
       </>

--- a/src/constants/platformFaqs.tsx
+++ b/src/constants/platformFaqs.tsx
@@ -1,0 +1,159 @@
+type TFAQ = {
+  id?: string;
+  title: string;
+  content: JSX.Element;
+};
+
+export const PLATFORM_FAQS: TFAQ[] = [
+  {
+    title: "Why is the number of search results limited?",
+    content: (
+      <>
+        <p>
+          The number of search results is currently limited to 500 to optimise system performance. We’re working to remove this limit. Please note
+          that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What happens if I choose 'exact phrase' only?",
+    content: (
+      <>
+        <p>
+          Toggling (or clicking on) this option in the sidebar will narrow down your search to only show documents that include the exact words you
+          typed in the search bar. However, doing this can mean you will miss out on relevant content, as a search for ‘electric vehicles’ wouldn't
+          pick up 'EVs' in the text.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What happens if I don't choose 'exact phrase only'?",
+    content: (
+      <>
+        <p>
+          If you don't toggle (or click on) 'exact phrase only', our new search feature searches the database for similar and related terms to the
+          query you typed into the search bar. You will get a richer search experience. Often climate or policy concepts are described in different
+          ways by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
+          gasoline-powered cars, etc). This feature uses a technique called natural language processing, which trains computers to understand text and
+          the meaning of words and phrases in context. Climate Policy Radar's team of policy experts is continually working to improve the performance
+          and accuracy of the models.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I filter my results?",
+    content: (
+      <>
+        <p>
+          After typing your search terms into the search bar, narrow down your results by using the sidebar on the left side of the page. You can
+          filter for 'only exact matches', regions of the world, specific jurisdictions (or countries), and date ranges.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What are document matches?",
+    content: (
+      <>
+        <p>
+          This highlights where in the document your search term or relevant text appears. It uses a subfield of AI called Natural Language
+          Processing, which identifies related words and phrases.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What do matches: title, summary, document, mean?",
+    content: (
+      <>
+        <p>
+          This shows you where your search term, or related phrases, appear in the document: in the title, the summary or the main text of the
+          document.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Why can't I see matches in some documents?",
+    content: (
+      <>
+        <p>
+          In the future, our tools will scan all the text of all of the documents to highlight references to your search query. At the moment, this
+          takes a long time for documents published in different languages and HTML sources, which is why we have chosen to only allow search on the
+          title and summary.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Why am I being redirected to an external site for some documents?",
+    content: (
+      <>
+        <p>
+          Some of our documents aren't yet machine-readable: our tool can't extract their text and make it searchable. When this happens, our tool
+          will look for matches to your search term in the documents' title and summary. To access the full text you'll be taken to the document's
+          source.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I link to one of your documents?",
+    content: (
+      <>
+        <p>
+          The best way to share documents is by using the URL of a document page. You can also share documents by downloading and then attaching them
+          to an email. Click the 'download' button when viewing the document on our tool. Or click the three horizontal dots on the top right of a
+          document view, and download the PDF from there.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I report bugs?",
+    content: (
+      <>
+        <p>
+          Get in touch with the Climate Policy Radar team via email at support@climatepolicyradar.org. We appreciate you taking the time to do this!
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How are the documents translated to English?",
+    content: (
+      <>
+        <p>
+          Documents are translated to English using Google's Cloud Translation API. Auto-translation does not always capture full meaning and nuance
+          from the original language, but we hope it is a useful first step to making documents available to more people.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I download search results?",
+    content: (
+      <>
+        <p>
+          You can download a csv file for "this search" or the "whole database" from the top right of the search results page. A csv file for “this
+          search” will contain all documents related to the top 500 entries returned by your search. (The actual number of entries may be 1 or 2 below
+          the total indicated on the search results page.)
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What map and boundaries are used?",
+    content: (
+      <>
+        <p>
+          This map was made with the Admin 0 - Countries map package by Natural Earth. Climate Policy Radar's use of this map does not represent an
+          opinion on any disputed boundaries.
+        </p>
+      </>
+    ),
+  },
+];

--- a/themes/cpr/constants/faqs.tsx
+++ b/themes/cpr/constants/faqs.tsx
@@ -1,0 +1,95 @@
+import { ExternalLink } from "@/components/ExternalLink";
+import { PLATFORM_FAQS } from "@/constants/platformFaqs";
+
+type TFAQ = {
+  id?: string;
+  title: string;
+  content: JSX.Element;
+};
+
+export const FAQS: TFAQ[] = [
+  {
+    title: "What is Climate Policy Radar?",
+    content: (
+      <>
+        <p>
+          Climate Policy Radar builds responsible AI tools for climate action. A UK-based not-for-profit, our data and tools help governments,
+          researchers, international organisations, civil society, and the private sector create effective climate policies and deploy climate
+          finance.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Am I free to download and use the data?",
+    content: (
+      <>
+        <p>
+          Yes - and we encourage you to do so! The content of our database is available under the Creative Commons Attribution Licence{" "}
+          <ExternalLink url="https://creativecommons.org/licenses/by/4.0/">(CC-BY)</ExternalLink>. Before doing so, you should read our Terms of Use
+          for more information and to find out how to cite and credit the resources. If you wish to download the data as a .csv file, please{" "}
+          <ExternalLink url="https://form.jotform.com/250202141318339">fill out our form</ExternalLink>.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How up-to-date is the data?",
+    content: (
+      <>
+        <p>
+          New data, and updates to existing data, are collected from official sources such as government websites, parliamentary records and court
+          documents. We add these to the database on a rolling basis. Submissions to the UNFCCC portals were first added on the 23rd of May 2023, and
+          are checked for updates regularly. If you're aware of documents that are missing, please let us know using our{" "}
+          <ExternalLink url="https://eu.jotform.com/250402253775352">data contributors form</ExternalLink>.
+        </p>
+      </>
+    ),
+  },
+];
+
+export const PLATFORMFAQS: TFAQ[] = [
+  {
+    title: "What can I do with your tool?",
+    content: (
+      <>
+        <ul>
+          <li>
+            Find climate and climate-related laws, policies, strategies and action plans from every country and submissions to the UNFCCC relevant to
+            country level action
+          </li>
+          <li>Find data from 4 biggest Multilateral Climate Funds, including project summaries, implementation documents and project guidance</li>
+          <li>Search for keywords and policy concepts (like 'electric vehicles' or 'gender equality') across the full text of all documents</li>
+          <li>View your search term (and related phrases) highlighted in search results</li>
+          <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
+          <li>Access the raw data: you just need to fill out this form to request a copy of the entire dataset</li>
+        </ul>
+      </>
+    ),
+  },
+
+  {
+    title: "How do I download all your data?",
+    content: (
+      <>
+        <p>
+          Please <ExternalLink url="https://form.jotform.com/250202141318339">fill out this form </ExternalLink>
+          to request our entire dataset.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What are the limitations of our search?",
+    content: (
+      <>
+        <p>
+          The database is not exhaustive and we are continuously looking for new documents. Some documents aren't currently machine-readable: we can't
+          yet extract the text from them. We also limit the number of matches you can see in a document to 500, so you get quickest, most accurate
+          results. For very long documents, or very broad search terms, you might miss some matches.
+        </p>
+      </>
+    ),
+  },
+  ...PLATFORM_FAQS,
+];

--- a/themes/cpr/constants/faqs.tsx
+++ b/themes/cpr/constants/faqs.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from "@/components/ExternalLink";
-import { PLATFORM_FAQS } from "@/constants/platformFaqs";
+import { PLATFORM_FAQS as GENERIC_PLATFORM_FAQS } from "@/constants/platformFaqs";
 
 type TFAQ = {
   id?: string;
@@ -48,7 +48,7 @@ export const FAQS: TFAQ[] = [
   },
 ];
 
-export const PLATFORMFAQS: TFAQ[] = [
+export const PLATFORM_FAQS: TFAQ[] = [
   {
     title: "What can I do with your tool?",
     content: (
@@ -91,5 +91,5 @@ export const PLATFORMFAQS: TFAQ[] = [
       </>
     ),
   },
-  ...PLATFORM_FAQS,
+  ...GENERIC_PLATFORM_FAQS,
 ];

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -1,9 +1,18 @@
+import { Fragment } from "react";
+
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { SubNav } from "@/components/nav/SubNav";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
+import { Accordian } from "@/components/accordian/Accordian";
+import { SingleCol } from "@/components/panels/SingleCol";
+import { Heading } from "@/components/typography/Heading";
+import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
+import { FAQS, PLATFORMFAQS } from "@/cpr/constants/faqs";
+
+const ACCORDIAN_MAX_HEIGHT = "464px";
 
 const FAQ = () => {
   return (
@@ -16,7 +25,41 @@ const FAQ = () => {
       </SubNav>
       <section className="pt-8">
         <SiteWidth>
-          <FaqSection title="FAQs" faqs={CONCEPTS_FAQS} />
+          <SingleCol>
+            <Heading level={1} extraClasses="custom-header">
+              FAQs
+            </Heading>
+            <VerticalSpacing size="md" />
+            <div className="text-content mb-14">
+              {FAQS.map((faq, i) => (
+                <Fragment key={faq.title}>
+                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
+                    {faq.content}
+                  </Accordian>
+                  <hr />
+                </Fragment>
+              ))}
+            </div>
+          </SingleCol>
+
+          <SingleCol>
+            <Heading level={1} extraClasses="custom-header">
+              Platform FAQs
+            </Heading>
+            <VerticalSpacing size="md" />
+            <div className="text-content mb-14">
+              {PLATFORMFAQS.map((faq, i) => (
+                <Fragment key={faq.title}>
+                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
+                    {faq.content}
+                  </Accordian>
+                  <hr />
+                </Fragment>
+              ))}
+            </div>
+          </SingleCol>
+
+          <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />
         </SiteWidth>
       </section>
     </Layout>

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -1,18 +1,10 @@
-import { Fragment } from "react";
-
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { SubNav } from "@/components/nav/SubNav";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
-import { Accordian } from "@/components/accordian/Accordian";
-import { SingleCol } from "@/components/panels/SingleCol";
-import { Heading } from "@/components/typography/Heading";
-import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
-import { FAQS, PLATFORMFAQS } from "@/cpr/constants/faqs";
-
-const ACCORDIAN_MAX_HEIGHT = "464px";
+import { FAQS, PLATFORM_FAQS } from "@/cpr/constants/faqs";
 
 const FAQ = () => {
   return (
@@ -25,40 +17,8 @@ const FAQ = () => {
       </SubNav>
       <section className="pt-8">
         <SiteWidth>
-          <SingleCol>
-            <Heading level={1} extraClasses="custom-header">
-              FAQs
-            </Heading>
-            <VerticalSpacing size="md" />
-            <div className="text-content mb-14">
-              {FAQS.map((faq, i) => (
-                <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
-                    {faq.content}
-                  </Accordian>
-                  <hr />
-                </Fragment>
-              ))}
-            </div>
-          </SingleCol>
-
-          <SingleCol>
-            <Heading level={1} extraClasses="custom-header">
-              Platform FAQs
-            </Heading>
-            <VerticalSpacing size="md" />
-            <div className="text-content mb-14">
-              {PLATFORMFAQS.map((faq, i) => (
-                <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
-                    {faq.content}
-                  </Accordian>
-                  <hr />
-                </Fragment>
-              ))}
-            </div>
-          </SingleCol>
-
+          <FaqSection title="FAQs" faqs={FAQS} />
+          <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
           <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />
         </SiteWidth>
       </section>

--- a/themes/mcf/constants/faqs.tsx
+++ b/themes/mcf/constants/faqs.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from "@/components/ExternalLink";
+import { PLATFORM_FAQS } from "@/constants/platformFaqs";
 
 type TFAQ = {
   id?: string;
@@ -151,165 +152,16 @@ export const PLATFORMFAQS: TFAQ[] = [
     ),
   },
   {
-    title: "Why is the number of search results limited?",
-    content: (
-      <>
-        <p>
-          The number of search results is currently limited to 500 to optimise system performance. We’re working to remove this limit. Please note
-          that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "What happens if I choose ‘exact phrase only’?",
-    content: (
-      <>
-        <p>
-          Toggling (or clicking on) this option in the sidebar will narrow down your search to only show documents that include the exact words you
-          typed in the search bar. However, doing this can mean you will miss out on relevant content, as a search for ‘electric vehicles’ wouldn’t
-          pick up ‘EVs’ in the text.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "What happens if I don’t choose ‘exact phrase only’?",
-    content: (
-      <>
-        <p>
-          If you don’t toggle (or click on) ‘exact phrase only’, our new search feature searches the database for similar and related terms to the
-          query you typed into the search bar. You will get a richer search experience. Often climate or policy concepts are described in different
-          ways by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
-          gasoline-powered cars, etc). This feature uses a technique called natural language processing, which trains computers to understand text and
-          the meaning of words and phrases in context. Climate Policy Radar’s team of policy experts is continually working to improve the performance
-          and accuracy of the models.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "How do I filter my results?",
-    content: (
-      <>
-        <p>
-          After typing your search terms into the search bar, narrow down your results by using the sidebar on the left side of the page. . You can
-          filter for ‘only exact matches’, regions of the world, specific jurisdictions (or countries), and date ranges.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "What are document matches?",
-    content: (
-      <>
-        <p>
-          This highlights where in the document your search term or relevant text appears. It uses a subfield of AI called Natural Language
-          Processing, which identifies related words and phrases..
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "What do matches: title, summary, document, mean?",
-    content: (
-      <>
-        <p>
-          This shows you where your search term, or related phrases, appear in the document: in the title, the summary or the main text of the
-          document.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "Why can’t I see matches in some documents?",
-    content: (
-      <>
-        <p>
-          In the future, our tools will scan all the text of all of the documents to highlight references to your search query. At the moment, this
-          takes a long time for documents published in different languages and HTML sources, which is why we have chosen to only allow search on the
-          title and summary.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "Why am I being redirected to an external site for some documents?",
-    content: (
-      <>
-        <p>
-          Some of our documents aren't yet machine-readable:our tool can’t extract their text and make it searchable. When this happens, our tool will
-          look for matches to your search term in the documents’ title and summary. To access the full text you’ll be taken to the document’s source.
-        </p>
-      </>
-    ),
-  },
-  {
     title: "What are the limitations of our search?",
     content: (
       <>
         <p>
-          The database is not exhaustive. We don’t have access to some MCFs documents. Others aren’t currently machine-readable:we can’t yet extract
+          The database is not exhaustive. We don't have access to some MCF documents. Others aren't currently machine-readable: we can't yet extract
           the text from them. We also limit the number of matches you can see in a document to 500, so you get quickest, most accurate results. For
           very long documents, or very broad search terms, you might miss some matches.
         </p>
       </>
     ),
   },
-  {
-    title: "How do I link to one of your documents?",
-    content: (
-      <>
-        <p>
-          The best way to share documents is by using the URL of a document page. You can also share documents by downloading and then attaching them
-          to an email. Click the ‘download’ button when viewing the document on our tool. Or click the three horizontal dots on the top right of a
-          document view, and download the PDF from there.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "How do I report bugs?",
-    content: (
-      <>
-        <p>
-          Get in touch with the Climate Policy Radar team via email at support@climatepolicyradar.org. We appreciate you taking the time to do this!
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "How are the documents translated to English?",
-    content: (
-      <>
-        <p>
-          Documents are translated to English using Google’s Cloud Translation API. Auto-translation does not always capture full meaning and nuance
-          from the original language, but we hope it is a useful first step to making documents available to more people.
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "How do I download search results?",
-    content: (
-      <>
-        <p>
-          You can download a csv file for "this search" or the "whole database" from the top right of the search results page. A csv file for “this
-          search”will contain all documents related to the top 500 entries returned by your search. (The actual number of entries may be 1 or 2 below
-          the total indicated on the search results page.)
-        </p>
-      </>
-    ),
-  },
-  {
-    title: "What map and boundaries are used?",
-    content: (
-      <>
-        <p>
-          This map was made with the Admin 0 - Countries map package by Natural Earth. Climate Policy Radar's use of this map does not represent an
-          opinion on any disputed boundaries.
-        </p>
-      </>
-    ),
-  },
+  ...PLATFORM_FAQS,
 ];

--- a/themes/mcf/constants/faqs.tsx
+++ b/themes/mcf/constants/faqs.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from "@/components/ExternalLink";
-import { PLATFORM_FAQS } from "@/constants/platformFaqs";
+import { PLATFORM_FAQS as GENERIC_PLATFORM_FAQS } from "@/constants/platformFaqs";
 
 type TFAQ = {
   id?: string;
@@ -22,8 +22,7 @@ export const FAQS: TFAQ[] = [
         <ul>
           <li>Conduct searches in the database using the full text of documents. This improves the comprehensiveness of your search results.</li>
           <li>
-            Find relevant information more easily. The new search function looks for similar and related phrases to search queries (‘semantic
-            search’).
+            Find relevant information more easily. The new search function looks for similar and related phrases to search queries (semantic search).
           </li>
           <li>
             See where a search term or relevant text appears in a document, with relevant passages of text automatically highlighted in yellow to help
@@ -121,7 +120,7 @@ export const FAQS: TFAQ[] = [
   },
 ];
 
-export const PLATFORMFAQS: TFAQ[] = [
+export const PLATFORM_FAQS: TFAQ[] = [
   {
     title: "What can I do with the Climate Project Explorer?",
     content: (
@@ -163,5 +162,5 @@ export const PLATFORMFAQS: TFAQ[] = [
       </>
     ),
   },
-  ...PLATFORM_FAQS,
+  ...GENERIC_PLATFORM_FAQS,
 ];

--- a/themes/mcf/constants/platformFaqs.tsx
+++ b/themes/mcf/constants/platformFaqs.tsx
@@ -1,0 +1,201 @@
+import { ExternalLink } from "@/components/ExternalLink";
+
+type TFAQ = {
+  id?: string;
+  title: string;
+  content: JSX.Element;
+};
+
+export const PLATFORM_FAQS: TFAQ[] = [
+  {
+    title: "What can I do with the Climate Project Explorer?",
+    content: (
+      <>
+        <p>The Climate Project Explorer makes it easier for you to:</p>
+        <ul>
+          <li>Find data from all 4 MCF funds, including project summaries, implementation documents and project guidance.</li>
+          <li>Search for keywords and focus areas across the full text of documents from all 4 funds.</li>
+          <li>See where your search terms show up in your results.</li>
+          <li>Browse country profiles to find and compare initiatives from all 4 funds.</li>
+          <li>
+            Contact CPR for a copy of the raw data by{" "}
+            <ExternalLink url="https://form.jotform.com/242902819253357">filling out this form</ExternalLink>
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    title: "How do I download all your data?",
+    content: (
+      <>
+        <p>
+          Please <ExternalLink url="https://form.jotform.com/242902819253357">fill out this form </ExternalLink>
+          to request our entire dataset.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Why is the number of search results limited?",
+    content: (
+      <>
+        <p>
+          The number of search results is currently limited to 500 to optimise system performance. We’re working to remove this limit. Please note
+          that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What happens if I choose ‘exact phrase only’?",
+    content: (
+      <>
+        <p>
+          Toggling (or clicking on) this option in the sidebar will narrow down your search to only show documents that include the exact words you
+          typed in the search bar. However, doing this can mean you will miss out on relevant content, as a search for ‘electric vehicles’ wouldn’t
+          pick up ‘EVs’ in the text.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What happens if I don’t choose ‘exact phrase only’?",
+    content: (
+      <>
+        <p>
+          If you don’t toggle (or click on) ‘exact phrase only’, our new search feature searches the database for similar and related terms to the
+          query you typed into the search bar. You will get a richer search experience. Often climate or policy concepts are described in different
+          ways by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
+          gasoline-powered cars, etc). This feature uses a technique called natural language processing, which trains computers to understand text and
+          the meaning of words and phrases in context. Climate Policy Radar’s team of policy experts is continually working to improve the performance
+          and accuracy of the models.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I filter my results?",
+    content: (
+      <>
+        <p>
+          After typing your search terms into the search bar, narrow down your results by using the sidebar on the left side of the page. . You can
+          filter for ‘only exact matches’, regions of the world, specific jurisdictions (or countries), and date ranges.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What are document matches?",
+    content: (
+      <>
+        <p>
+          This highlights where in the document your search term or relevant text appears. It uses a subfield of AI called Natural Language
+          Processing, which identifies related words and phrases..
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What do matches: title, summary, document, mean?",
+    content: (
+      <>
+        <p>
+          This shows you where your search term, or related phrases, appear in the document: in the title, the summary or the main text of the
+          document.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Why can’t I see matches in some documents?",
+    content: (
+      <>
+        <p>
+          In the future, our tools will scan all the text of all of the documents to highlight references to your search query. At the moment, this
+          takes a long time for documents published in different languages and HTML sources, which is why we have chosen to only allow search on the
+          title and summary.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Why am I being redirected to an external site for some documents?",
+    content: (
+      <>
+        <p>
+          Some of our documents aren't yet machine-readable:our tool can’t extract their text and make it searchable. When this happens, our tool will
+          look for matches to your search term in the documents’ title and summary. To access the full text you’ll be taken to the document’s source.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What are the limitations of our search?",
+    content: (
+      <>
+        <p>
+          The database is not exhaustive. We don’t have access to some MCFs documents. Others aren’t currently machine-readable:we can’t yet extract
+          the text from them. We also limit the number of matches you can see in a document to 500, so you get quickest, most accurate results. For
+          very long documents, or very broad search terms, you might miss some matches.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I link to one of your documents?",
+    content: (
+      <>
+        <p>
+          The best way to share documents is by using the URL of a document page. You can also share documents by downloading and then attaching them
+          to an email. Click the ‘download’ button when viewing the document on our tool. Or click the three horizontal dots on the top right of a
+          document view, and download the PDF from there.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I report bugs?",
+    content: (
+      <>
+        <p>
+          Get in touch with the Climate Policy Radar team via email at support@climatepolicyradar.org. We appreciate you taking the time to do this!
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How are the documents translated to English?",
+    content: (
+      <>
+        <p>
+          Documents are translated to English using Google’s Cloud Translation API. Auto-translation does not always capture full meaning and nuance
+          from the original language, but we hope it is a useful first step to making documents available to more people.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "How do I download search results?",
+    content: (
+      <>
+        <p>
+          You can download a csv file for "this search" or the "whole database" from the top right of the search results page. A csv file for “this
+          search”will contain all documents related to the top 500 entries returned by your search. (The actual number of entries may be 1 or 2 below
+          the total indicated on the search results page.)
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "What map and boundaries are used?",
+    content: (
+      <>
+        <p>
+          This map was made with the Admin 0 - Countries map package by Natural Earth. Climate Policy Radar's use of this map does not represent an
+          opinion on any disputed boundaries.
+        </p>
+      </>
+    ),
+  },
+];

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 
+import FaqSection from "@/components/FaqSection";
 import { Accordian } from "@/components/accordian/Accordian";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
@@ -7,13 +8,11 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { SingleCol } from "@/components/panels/SingleCol";
 import { SubNav } from "@/components/nav/SubNav";
 import { Heading } from "@/components/typography/Heading";
-
-import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
-import FaqSection from "@/components/FaqSection";
 import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
+import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { FAQS, PLATFORMFAQS } from "@/mcf/constants/faqs";
 
-const ACCORDIANMAXHEIGHT = "464px";
+const ACCORDIAN_MAX_HEIGHT = "464px";
 
 const FAQ = () => {
   return (
@@ -34,7 +33,7 @@ const FAQ = () => {
             <div className="text-content mb-14">
               {FAQS.map((faq, i) => (
                 <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIANMAXHEIGHT}>
+                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
                     {faq.content}
                   </Accordian>
                   <hr />
@@ -42,6 +41,7 @@ const FAQ = () => {
               ))}
             </div>
           </SingleCol>
+
           <SingleCol>
             <Heading level={1} extraClasses="custom-header">
               Platform FAQs
@@ -50,7 +50,7 @@ const FAQ = () => {
             <div className="text-content mb-14">
               {PLATFORMFAQS.map((faq, i) => (
                 <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIANMAXHEIGHT}>
+                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
                     {faq.content}
                   </Accordian>
                   <hr />

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -1,18 +1,10 @@
-import { Fragment } from "react";
-
 import FaqSection from "@/components/FaqSection";
-import { Accordian } from "@/components/accordian/Accordian";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
 import { SiteWidth } from "@/components/panels/SiteWidth";
-import { SingleCol } from "@/components/panels/SingleCol";
 import { SubNav } from "@/components/nav/SubNav";
-import { Heading } from "@/components/typography/Heading";
-import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
-import { FAQS, PLATFORMFAQS } from "@/mcf/constants/faqs";
-
-const ACCORDIAN_MAX_HEIGHT = "464px";
+import { FAQS, PLATFORM_FAQS } from "@/mcf/constants/faqs";
 
 const FAQ = () => {
   return (
@@ -25,40 +17,8 @@ const FAQ = () => {
       </SubNav>
       <section className="pt-8">
         <SiteWidth>
-          <SingleCol>
-            <Heading level={1} extraClasses="custom-header">
-              FAQs
-            </Heading>
-            <VerticalSpacing size="md" />
-            <div className="text-content mb-14">
-              {FAQS.map((faq, i) => (
-                <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
-                    {faq.content}
-                  </Accordian>
-                  <hr />
-                </Fragment>
-              ))}
-            </div>
-          </SingleCol>
-
-          <SingleCol>
-            <Heading level={1} extraClasses="custom-header">
-              Platform FAQs
-            </Heading>
-            <VerticalSpacing size="md" />
-            <div className="text-content mb-14">
-              {PLATFORMFAQS.map((faq, i) => (
-                <Fragment key={faq.title}>
-                  <Accordian title={faq.title} startOpen={i === 0} fixedHeight={ACCORDIAN_MAX_HEIGHT}>
-                    {faq.content}
-                  </Accordian>
-                  <hr />
-                </Fragment>
-              ))}
-            </div>
-          </SingleCol>
-
+          <FaqSection title="FAQs" faqs={FAQS} />
+          <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
           <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />
         </SiteWidth>
       </section>


### PR DESCRIPTION
# What's changed

Update the FAQs for the CPR app and push out common FAQs into constants so we only need to update some of them in one place.

## Why?

Climate-laws and climateprojectexplorer both have a FAQs page. CPR app does not

We're bringing over some FAQs from CPE to the CPR App and making sure the language is adjusted for the CPR app. This should mostly be a copy and paste job with a few additions.

## Screenshots?
