### PR TITLE
fix: remove CPR.corpus.i00000001.n0000

### DIFF
--- a/themes/cclw/config.json
+++ b/themes/cclw/config.json
@@ -15,13 +15,13 @@
       {
         "label": "Policies",
         "slug": "policies",
-        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
+        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
         "category": ["Executive"]
       },
       {
         "label": "Laws",
         "slug": "laws",
-        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
+        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000"],
         "category": ["Legislative"],
         "alias": "LAWS"
       }

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -17,7 +17,6 @@
         "slug": "policies",
         "value": [
           "CCLW.corpus.i00000001.n0000",
-          "CPR.corpus.i00000001.n0000",
           "CPR.corpus.i00000589.n0000",
           "CPR.corpus.i00000591.n0000",
           "CPR.corpus.i00000592.n0000",
@@ -30,7 +29,6 @@
         "slug": "laws",
         "value": [
           "CCLW.corpus.i00000001.n0000",
-          "CPR.corpus.i00000001.n0000",
           "CPR.corpus.i00000589.n0000",
           "CPR.corpus.i00000591.n0000",
           "CPR.corpus.i00000592.n0000",
@@ -194,7 +192,6 @@
       "type": "radio",
       "category": [
         "CCLW.corpus.i00000001.n0000",
-        "CPR.corpus.i00000001.n0000",
         "CPR.corpus.i00000589.n0000",
         "CPR.corpus.i00000591.n0000",
         "CPR.corpus.i00000592.n0000",
@@ -210,7 +207,6 @@
       "type": "radio",
       "category": [
         "CCLW.corpus.i00000001.n0000",
-        "CPR.corpus.i00000001.n0000",
         "CPR.corpus.i00000589.n0000",
         "CPR.corpus.i00000591.n0000",
         "CPR.corpus.i00000592.n0000",


### PR DESCRIPTION
# What's changed
- removes `CPR.corpus.i00000001.n0000` from being shown on the frontend as the data as we are currently not happy with the data quality

I am not removing this from the app tokens as we might want to add it back in the next few weeks.