### PR TITLE
Add trunk reporting for tests

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -59,6 +59,15 @@ jobs:
         env:
           NODE_ENV: production
       - run: npm run test
+      - name: Upload results
+        # Run this step even if the test step ahead fails
+        if: ${{ !cancelled() }}
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "**/junit.xml"
+          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
+          token: ${{ secrets.TRUNK_TOKEN }}
+        continue-on-error: true
 
   test-e2e:
     timeout-minutes: 60

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -75,6 +75,15 @@ jobs:
           NODE_ENV: production
       - run: npx playwright install --with-deps
       - run: npx playwright test
+      - name: Upload Test Result
+        # Upload the results even if the tests fails to Trunk.io
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "**/playwright.xml"
+          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
+          token: ${{ secrets.TRUNK_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: trunk-io/analytics-uploader@main
         with:
-          junit-paths: "**/junit.xml"
+          junit-paths: "**/vitest.xml"
           org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
           token: ${{ secrets.TRUNK_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,6 +87,15 @@ jobs:
           NODE_ENV: production
       - run: npx playwright install --with-deps
       - run: npx playwright test
+      - name: Upload Test Result
+        # Upload the results even if the tests fails to Trunk.io
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "**/playright.xml"
+          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
+          token: ${{ secrets.TRUNK_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,6 +71,15 @@ jobs:
         env:
           NODE_ENV: production
       - run: npm run test
+      - name: Upload results
+        # Run this step even if the test step ahead fails
+        if: ${{ !cancelled() }}
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "**/junit.xml"
+          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
+          token: ${{ secrets.TRUNK_TOKEN }}
+        continue-on-error: true
 
   test-e2e:
     timeout-minutes: 60

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: trunk-io/analytics-uploader@main
         with:
-          junit-paths: "**/junit.xml"
+          junit-paths: "**/vitest.xml"
           org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
           token: ${{ secrets.TRUNK_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -20,6 +20,15 @@ jobs:
       - run: npx playwright test
         env:
           PLAYWRIGHT_ENV: production
+      - name: Upload Test Result
+        # Upload the results even if the tests fails to Trunk.io
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "**/playwright.xml"
+          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
+          token: ${{ secrets.TRUNK_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "line",
+  reporter: [["junit", { outputFile: "playright.xml" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,5 +13,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     exclude: ["**/node_modules/**", "**/.trunk/**", "**/tests/**"],
+    reporters: [["junit", { outputFile: "./junit.xml" }]],
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     exclude: ["**/node_modules/**", "**/.trunk/**", "**/tests/**"],
-    reporters: [["junit", { outputFile: "./junit.xml" }]],
+    reporters: [["junit", { outputFile: "./vitest.xml" }]],
   },
 });


### PR DESCRIPTION
# What's changed

Made playright & vitest tests output as Junit XML files, which we then upload to Trunk.io to spike their flaky test functionality.

https://app.trunk.io/climatepolicyradar/flaky-tests?repo=climatepolicyradar%2Fnavigator-frontend (sign in with Google SSO to your work account)

## Why?

Trunk has a few other features than just code quality, namely CI analytics, merge queues and [flaky test analysis](https://trunk.io/flaky-tests). I thought as a spike we could connect the flaky test analysis feature up as we suffer with this in some of our playwright tests, and see whether we get any use out of it as it's free.

## Screenshots?

![image](https://github.com/user-attachments/assets/0d088690-741e-4b69-bf59-8c91b9b660a9)

More screenshots once we've had more reports - it runs on PR and on main.