### PR TITLE
Hide concept FAQs behind feature flag

### DIFF
--- a/src/components/menus/MainMenu.tsx
+++ b/src/components/menus/MainMenu.tsx
@@ -33,6 +33,7 @@ const MainMenu = ({ iconClass = "text-white" }: TProps) => {
               title="Methodology"
               setShowMenu={setShowMenu}
             />
+            <DropdownMenuItem href="/faq" title="FAQ" setShowMenu={setShowMenu} />
           </DropdownMenuWrapper>
         </div>
       )}

--- a/themes/cclw/pages/faq.tsx
+++ b/themes/cclw/pages/faq.tsx
@@ -12,8 +12,14 @@ import { Heading } from "@/components/typography/Heading";
 
 import { FAQS } from "@/cclw/constants/faqs";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
+import { getFeatureFlags } from "@/utils/featureFlags";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-const FAQ = () => {
+type TProps = {
+  featureFlags: Record<string, string | boolean>;
+};
+
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
   return (
     <Layout
       title="FAQ"
@@ -60,22 +66,35 @@ const FAQ = () => {
             </div>
           </SingleCol>
 
-          <SingleCol>
-            <div className="text-content mb-12">
-              <Heading level={2}>Concepts FAQs</Heading>
-              {CONCEPTS_FAQS.map((faq, i) => (
-                <Fragment key={faq.title}>
-                  <AccordianItem id={faq.id} title={faq.title} headContent={faq.headContent ?? null} startOpen={i === 0}>
-                    {faq.content}
-                  </AccordianItem>
-                  <hr />
-                </Fragment>
-              ))}
-            </div>
-          </SingleCol>
+          {featureFlags["concepts-v1"] === true && (
+            <SingleCol>
+              <div className="text-content mb-12">
+                <Heading level={2}>Concepts FAQs</Heading>
+                {CONCEPTS_FAQS.map((faq, i) => (
+                  <Fragment key={faq.title}>
+                    <AccordianItem id={faq.id} title={faq.title} headContent={faq.headContent ?? null} startOpen={i === 0}>
+                      {faq.content}
+                    </AccordianItem>
+                    <hr />
+                  </Fragment>
+                ))}
+              </div>
+            </SingleCol>
+          )}
         </SiteWidth>
       </section>
+      <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />
     </Layout>
   );
 };
 export default FAQ;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const featureFlags = await getFeatureFlags(context.req.cookies);
+
+  return {
+    props: {
+      featureFlags: featureFlags || {},
+    },
+  };
+};

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -1,3 +1,5 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
@@ -5,8 +7,13 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { SubNav } from "@/components/nav/SubNav";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { FAQS, PLATFORM_FAQS } from "@/cpr/constants/faqs";
+import { getFeatureFlags } from "@/utils/featureFlags";
 
-const FAQ = () => {
+type TProps = {
+  featureFlags: Record<string, string | boolean>;
+};
+
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
   return (
     <Layout
       title="FAQ"
@@ -19,11 +26,22 @@ const FAQ = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />
+          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
+      <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />
     </Layout>
   );
 };
 
 export default FAQ;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const featureFlags = await getFeatureFlags(context.req.cookies);
+
+  return {
+    props: {
+      featureFlags: featureFlags || {},
+    },
+  };
+};

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -1,3 +1,5 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
@@ -5,8 +7,13 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { SubNav } from "@/components/nav/SubNav";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { FAQS, PLATFORM_FAQS } from "@/mcf/constants/faqs";
+import { getFeatureFlags } from "@/utils/featureFlags";
 
-const FAQ = () => {
+type TProps = {
+  featureFlags: Record<string, string | boolean>;
+};
+
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
   return (
     <Layout
       title="FAQ"
@@ -19,10 +26,21 @@ const FAQ = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />
+          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
+      <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />
     </Layout>
   );
 };
 export default FAQ;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const featureFlags = await getFeatureFlags(context.req.cookies);
+
+  return {
+    props: {
+      featureFlags: featureFlags || {},
+    },
+  };
+};


### PR DESCRIPTION
# What's changed

Hide concept FAQs behind feature flag instead of showing them permanently.

## Why?

We don't want to show these until we launch concepts.
