### PR TITLE
feat: make all filter use explicit values

### DIFF
--- a/themes/cclw/config.json
+++ b/themes/cclw/config.json
@@ -4,7 +4,8 @@
     "options": [
       {
         "label": "All",
-        "slug": "All"
+        "slug": "All",
+        "value": ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000591.n0000", "CPR.corpus.i00000592.n0000", "UNFCCC.corpus.i00000001.n0000"]
       },
       {
         "label": "UNFCCC",

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -4,7 +4,24 @@
     "options": [
       {
         "label": "All",
-        "slug": "All"
+        "slug": "All",
+        "value": [
+          "CCLW.corpus.i00000001.n0000",
+          "CPR.corpus.Goldstandard.n0000",
+          "CPR.corpus.i00000589.n0000",
+          "CPR.corpus.i00000591.n0000",
+          "CPR.corpus.i00000592.n0000",
+          "MCF.corpus.AF.Guidance",
+          "MCF.corpus.AF.n0000",
+          "MCF.corpus.CIF.Guidance",
+          "MCF.corpus.CIF.n0000",
+          "MCF.corpus.GCF.Guidance",
+          "MCF.corpus.GCF.n0000",
+          "MCF.corpus.GEF.Guidance",
+          "MCF.corpus.GEF.n0000",
+          "OEP.corpus.i00000001.n0000",
+          "UNFCCC.corpus.i00000001.n0000"
+        ]
       },
       {
         "label": "UNFCCC",


### PR DESCRIPTION
# What's changed
- sets the "All" filter values explicitly
- removes the `CPR.corpus.i00000001.n0000` from that list

This does not remove access to the family & document pages. I'll be seeing if this necessary.

## Why?

The quality of the data in the corpus is not considered good enough.
