### PR TITLE
fix: use categories from 'All' as default in searchQuery

### DIFF
--- a/src/utils/buildSearchQuery.test.ts
+++ b/src/utils/buildSearchQuery.test.ts
@@ -1,0 +1,37 @@
+import buildSearchQuery from "./buildSearchQuery";
+
+describe("buildSearchQuery: ", () => {
+  it("should use All.categories if there's no category in the routerQuery", () => {
+    const allCategories = ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000", "MCF.corpus.AF.Guidance"];
+    const unfcccCategories = ["UNFCCC.corpus.i00000001.n0000"];
+    const themeConfig = {
+      defaultCorpora: undefined,
+      categories: {
+        label: "Category",
+        options: [
+          {
+            label: "All",
+            slug: "All",
+            value: allCategories,
+          },
+          {
+            label: "UNFCCC",
+            slug: "UNFCCC",
+            value: unfcccCategories,
+          },
+        ],
+      },
+      filters: [],
+      labelVariations: [],
+      links: [],
+      metadata: [],
+      documentCategories: [],
+    };
+
+    const searchQueryWithNoCategory = buildSearchQuery({}, themeConfig);
+    expect(searchQueryWithNoCategory.corpus_import_ids).toBe(allCategories);
+
+    const searchQueryWithCategory = buildSearchQuery({ c: "UNFCCC" }, themeConfig);
+    expect(searchQueryWithCategory.corpus_import_ids).toBe(unfcccCategories);
+  });
+});

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -71,20 +71,18 @@ export default function buildSearchQuery(
       : [{ name: "name", value: conceptFilters }];
   }
 
-  if (routerQuery[QUERY_PARAMS.category]) {
-    const qCategory = routerQuery[QUERY_PARAMS.category] as string;
-    let category: string[];
-    let corpusIds: string[] = [];
-    if (themeConfig?.categories) {
-      const configCategory = themeConfig.categories.options.find((c) => c.slug.toLowerCase() === qCategory.toLowerCase());
-      category = configCategory?.category;
-      if (configCategory?.value) corpusIds = configCategory.value;
-    }
-    // Set the category if we have one (TODO: remove this at some point)
-    keyword_filters.categories = category;
-    // Set the corpus import ids if we have them
-    query.corpus_import_ids = corpusIds;
+  const qCategory = (routerQuery[QUERY_PARAMS.category] as string) ?? "All";
+  let category: string[];
+  let corpusIds: string[] = [];
+  if (themeConfig?.categories) {
+    const configCategory = themeConfig.categories.options.find((c) => c.slug.toLowerCase() === qCategory.toLowerCase());
+    category = configCategory?.category;
+    if (configCategory?.value) corpusIds = configCategory.value;
   }
+  // Set the category if we have one (TODO: remove this at some point)
+  keyword_filters.categories = category;
+  // Set the corpus import ids if we have them
+  query.corpus_import_ids = corpusIds;
 
   if (routerQuery[QUERY_PARAMS.region]) {
     const regions = routerQuery[QUERY_PARAMS.region];

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     exclude: ["**/node_modules/**", "**/.trunk/**", "**/tests/**"],
-    reporters: [["junit", { outputFile: "./vitest.xml" }]],
+    reporters: [process.env.CI ? ["junit", { outputFile: "./vitest.xml" }] : "verbose"],
   },
 });

--- a/vitest.xml
+++ b/vitest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1" failures="1" errors="0" time="0.605">
+    <testsuite name="src/utils/buildSearchQuery.test.ts" timestamp="2025-04-07T12:21:48.898Z" hostname="Jamess-MacBook-Pro.local" tests="1" failures="1" errors="0" skipped="0" time="0.002795667">
+        <testcase classname="src/utils/buildSearchQuery.test.ts" name="buildSearchQuery:  &gt; should use All.categories if there&apos;s no category in the routerQuery" time="0.002338375">
+            <failure message="buildSearchQuery is not a function" type="TypeError">
+TypeError: buildSearchQuery is not a function
+ ❯ src/utils/buildSearchQuery.test.ts:14:25
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
# What's changed
- sets "All" as the default category if one isn't supplied by the search query

## Why?
This ensures that the categories are attached to the search query => backend.

Fixes https://linear.app/climate-policy-radar/issue/APP-458/make-all-filter-use-an-explicit-list-of-corpus-ids