### PR TITLE
feat: add corporate reports behind a feature flag

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -55,6 +55,7 @@ type TSearchFiltersProps = {
   handleRegionChange(region: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
+  featureFlags: Record<string, string | boolean>;
 };
 
 const SearchFilters = ({
@@ -69,6 +70,7 @@ const SearchFilters = ({
   handleRegionChange,
   handleClearSearch,
   handleDocumentCategoryClick,
+  featureFlags,
 }: TSearchFiltersProps) => {
   const { status: themeConfigStatus, themeConfig } = useGetThemeConfig();
   const [showClear, setShowClear] = useState(false);
@@ -111,21 +113,24 @@ const SearchFilters = ({
       </div>
 
       <AppliedFilters filterChange={handleFilterChange} concepts={conceptsData} />
-
       {themeConfigStatus === "success" && themeConfig.categories && (
         <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} startOpen>
           <InputListContainer>
-            {themeConfig.categories?.options?.map((option) => (
-              <InputRadio
-                key={option.slug}
-                label={option.label}
-                checked={query && isCategoryChecked(query[QUERY_PARAMS.category] as string, option)}
-                onChange={() => {
-                  handleDocumentCategoryClick(option.slug);
-                }}
-                name={`${themeConfig.categories.label}-${option.slug}`}
-              />
-            ))}
+            {themeConfig.categories?.options?.map(
+              (option) =>
+                ((option.slug === "climate_policy_radar_reports" && featureFlags["corporate-reports"]) ||
+                  option.slug !== "climate_policy_radar_reports") && (
+                  <InputRadio
+                    key={option.slug}
+                    label={option.label}
+                    checked={query && isCategoryChecked(query[QUERY_PARAMS.category] as string, option)}
+                    onChange={() => {
+                      handleDocumentCategoryClick(option.slug);
+                    }}
+                    name={`${themeConfig.categories.label}-${option.slug}`}
+                  />
+                )
+            )}
           </InputListContainer>
         </Accordian>
       )}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -415,6 +415,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                     handleRegionChange={handleRegionChange}
                     handleClearSearch={handleClearSearch}
                     handleDocumentCategoryClick={handleDocumentCategoryClick}
+                    featureFlags={featureFlags}
                   />
                 </>
               )}
@@ -444,6 +445,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                         handleRegionChange={handleRegionChange}
                         handleClearSearch={handleClearSearch}
                         handleDocumentCategoryClick={handleDocumentCategoryClick}
+                        featureFlags={featureFlags}
                       />
                     </div>
                     <SlideOut showCloseButton={false}>

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -3,6 +3,11 @@
     "label": "Category",
     "options": [
       {
+        "label": "Climate Policy Radar Reports",
+        "slug": "climate_policy_radar_reports",
+        "value": ["CPR.corpus.i00000002.n0000"]
+      },
+      {
         "label": "All",
         "slug": "All",
         "value": [


### PR DESCRIPTION
# What's changed
- uses the `corporate-reports` feature flag to show the new corporate reports behind a feature flag

Depends on: https://github.com/climatepolicyradar/navigator-infra/pull/1016

## Why?

The policy team would like a way of previewing reports which they are working on them. This allows that.

## Screenshots?
| flag off | flag on |
|---|---|
| ![flag-off][] | ![flag-on][] |

[flag-off]: https://github.com/user-attachments/assets/08c2e59e-2031-4a99-8b8f-9818f9193e87

[flag-on]: https://github.com/user-attachments/assets/f3621fad-965f-4118-b5ce-1d1cca5a11b2


Thanks @PatFawbertMills for the pairing.
