### PR TITLE
Fix/sticky header partial revert

### DIFF
--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -29,7 +29,7 @@ const Layout: FC<TProps> = ({ children, title, theme, description, themeConfig, 
   const contextTheme = useContext(ThemeContext);
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden">
+    <div className="h-full min-h-screen flex flex-col">
       <Head>
         <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`}</title>
         <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`} />

--- a/src/components/modals/Popup.tsx
+++ b/src/components/modals/Popup.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@/components/atoms/icon/Icon";
 const Popup = ({ active, onCloseClick, children }) => {
   return (
     <div
-      className={`absolute bg-black/50 pointer-events-none top-0 left-0 p-2 transition duration-250 z-50 transform w-full h-full flex justify-center items-start items-center md:p-4 ${
+      className={`absolute bg-black/50 pointer-events-none top-0 left-0 p-2 transition duration-250 z-100 transform w-full h-full flex justify-center items-start items-center md:p-4 ${
         active ? "opacity-100 visible" : "opacity-0 invisible"
       }`}
     >

--- a/src/components/organisms/navBar/NavBar.tsx
+++ b/src/components/organisms/navBar/NavBar.tsx
@@ -10,7 +10,7 @@ interface NavBarProps {
 
 export const NavBar = ({ headerClasses = "", logo, menu, showLogo = true, showSearch = true }: NavBarProps) => {
   return (
-    <header data-cy="header" className={`w-full h-[128px] sm:h-[72px] ${headerClasses}`}>
+    <header data-cy="header" className={`w-full h-[128px] sm:h-[72px] sticky top-0 z-60 ${headerClasses}`}>
       <div className="max-w-maxSiteWidth sm:px-4 pt-2 sm:pb-2 mx-auto flex justify-between items-center flex-wrap sm:flex-nowrap gap-y-1 sm:gap-y-0">
         {showLogo && <div className="lg:flex-1 shrink-4 md:max-w-[30%] px-4 sm:pl-0 sm:pt-0">{logo}</div>}
         {showSearch && (

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -19,11 +19,6 @@ type TConfig = {
   };
 };
 
-const scrollToSearchTop = () => {
-  const container = document.querySelector("#search");
-  container?.scrollIntoView(true);
-};
-
 async function getSearch(query = initialSearchCriteria) {
   const config: TConfig = {
     headers: {
@@ -52,7 +47,6 @@ const useSearch = (query: TRouterQuery, familyId = "", documentId = "", runFresh
 
   useEffect(() => {
     setStatus("loading");
-    scrollToSearchTop();
 
     // If we don't want to trigger an API call, return early
     if (!runFreshSearch || !searchQuery.runSearch) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -430,7 +430,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 <Loader size="20px" />
               ) : (
                 <>
-                  <div className="sticky top-0 z-50">
+                  <div className="sticky top-[72px] z-50">
                     <div className="z-10 px-5 bg-white border-r border-gray-300 pt-5 sticky top-0 h-screen overflow-y-auto scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500">
                       <SearchFilters
                         searchCriteria={searchQuery}

--- a/themes/cclw/components/Header.tsx
+++ b/themes/cclw/components/Header.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 
 export const CCLWLogo = (
   <LinkWithQuery href={`/`} cypress="cclw-logo">
-    <div className="flex items-center flex-nowrap gap-2">
+    <div className="max-h-[56px] flex items-center flex-nowrap gap-2">
       <Image src="/images/cclw/cclw-logo-globe.png" alt="Climate Change Laws of the World logo globe" width={60} height={60} />
       <Image src="/images/cclw/cclw-logo-text-light.svg" alt="Climate Change Laws of the World logo text" width={197} height={30} />
     </div>

--- a/themes/cclw/layouts/main.tsx
+++ b/themes/cclw/layouts/main.tsx
@@ -9,12 +9,10 @@ type TProps = {
 const Main: FC<TProps> = ({ children }) => (
   <>
     <Header />
-    <div className="h-[calc(100vh-128px)] sm:h-[calc(100vh-72px)] flex flex-col justify-between overflow-y-auto">
-      <main id="main" className="flex flex-col flex-1">
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <main id="main" className="flex flex-col flex-1">
+      {children}
+    </main>
+    <Footer />
   </>
 );
 export default Main;

--- a/themes/cpr/layouts/main.tsx
+++ b/themes/cpr/layouts/main.tsx
@@ -18,10 +18,8 @@ type TProps = {
 const Main: FC<TProps> = ({ children }) => (
   <>
     <NavBar headerClasses="banner" logo={CPRLogo} menu={<MainMenu />} />
-    <div className="h-[calc(100vh-128px)] sm:h-[calc(100vh-72px)] flex flex-col justify-between overflow-y-auto">
-      <main className="flex flex-col flex-1">{children}</main>
-      <Footer />
-    </div>
+    <main className="flex flex-col flex-1">{children}</main>
+    <Footer />
   </>
 );
 export default Main;

--- a/themes/mcf/layouts/main.tsx
+++ b/themes/mcf/layouts/main.tsx
@@ -8,12 +8,10 @@ type TProps = {
 const Main: FC<TProps> = ({ children }) => (
   <>
     <Header />
-    <div className="h-[calc(100vh-128px)] sm:h-[calc(100vh-72px)] flex flex-col justify-between overflow-y-auto">
-      <main id="main" className="flex flex-col flex-1">
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <main id="main" className="flex flex-col flex-1">
+      {children}
+    </main>
+    <Footer />
   </>
 );
 export default Main;


### PR DESCRIPTION
# What's changed

- `<main>` and `Footer` are no longer wrapped by a scrollable div that occupies most of the page.
- `NavBar` is sticky again.
- Search page filters (which are sticky) have a `top` value equal to the height of `NavBar` so that when it sticks to the top, it doesn't get hidden underneath it.
- Tweak to CCLW logo positioning.
- Removed `scrollToSearchTop` from `useSearch` to prevent the breadcrumb/download bar from being hidden on page load.

## Why?

Bug fixes.

## Screenshots?

CCLW search showing the filters not being overlapped by NavBar:
<img width="1521" alt="Screenshot 2025-04-08 at 11 16 42" src="https://github.com/user-attachments/assets/9998eacc-6e7d-4a93-a0cf-68035e919447" />