### PR TITLE
feat: add isomorphic runtime env vars

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,35 @@
+export const publicRuntimeEnvConfig = ["API_URL", "THEME", "BACKEND_API_URL", "BACKEND_API_TOKEN"] as const;
+
+/**
+ * This is a custom config that is makes runtime env variables available to the the client environment.
+ *
+ * As per the docs:
+ * > public environment variables will be inlined into the JavaScript bundle during next build
+ *
+ * This does not allow us to "build once, deploy everywhere" - which we would like to do.
+ *
+ * @see: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#runtime-environment-variables
+ */
+export function generateBrowserEnvConfig() {
+  const config = {};
+  for (const key of publicRuntimeEnvConfig) {
+    config[`RUNTIME_ENV_PUBLIC_${key}`] = process.env[key];
+  }
+
+  return config;
+}
+
+export const config = {} as Record<(typeof publicRuntimeEnvConfig)[number], string>;
+declare global {
+  interface Window {
+    __ENV__: Record<string, string>;
+  }
+}
+
+for (const key of publicRuntimeEnvConfig) {
+  if (typeof window !== "undefined") {
+    config[key] = window.__ENV__[`RUNTIME_ENV_PUBLIC_${key}`];
+  } else {
+    config[key] = process.env[key];
+  }
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { Html, Head, Main, NextScript } from "next/document";
+import { generateBrowserEnvConfig } from "@/config";
 
 export default function Document() {
   return (
@@ -7,6 +8,11 @@ export default function Document() {
         <link rel="preconnect" href="https://rsms.me/" />
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
         <link rel="stylesheet" href="https://use.typekit.net/qeq0int.css" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.__ENV__ = ${JSON.stringify(generateBrowserEnvConfig())};`,
+          }}
+        />
       </Head>
       <body>
         <Main />

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/atoms/button/Button";
+import { config } from "@/config";
 import { setFeatureFlags } from "@/utils/featureFlags";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
@@ -7,6 +8,9 @@ export default function FeatureFlags() {
   const posthog = usePostHog();
 
   useEffect(() => {
+    /* trunk-ignore(eslint/no-console) */
+    console.info("test config", config);
+
     /**
      * This key is a public key.
      * @see: https://posthog.com/docs/privacy#is-it-ok-for-my-api-key-to-be-exposed-and-public

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
       "@/utils/*": ["src/utils/*"],
       "@/cclw/*": ["themes/cclw/*"],
       "@/cpr/*": ["themes/cpr/*"],
-      "@/mcf/*": ["themes/mcf/*"]
+      "@/mcf/*": ["themes/mcf/*"],
+      "@/config": ["src/config/index"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/api/pdf.js", "vitest.config.mts"],


### PR DESCRIPTION
# What's changed
- adds a way for us to access env vars, isomorphically

## Why?
- NextJS supports runtime env vars on the server
- NextJS supports build-time env vars on the browser vars via the `NEXT_PUBLIC_` interface
- NextJS **DOES NOT** support run time browser vars

**Option A** could be that we move the env vars to build time. This is against the "[Build once, deploy many](https://www.mikemcgarr.com/blog/build-once-deploy-many.html)" that docker gives us, and we use across all of our other services, so I wouldn't want to go against that.

**Option B** this option ✨ 
- supports runtime env vars
- supports them isomorphically

I've used a subset of the `process.env` variables so we have to explicitly add them to expose them as this will make them public.

I have not hijacked the `NEXT_PUBLIC_` prefix as that already has build in functionality.  

### Hasn't this been done before?
There is an implementation here: https://github.com/expatfile/next-runtime-env.

I've chosen not to go with this as the other options in this thread https://github.com/vercel/next.js/discussions/44628 are relatively simple, and we don't have top worry about updates etc.

Dependant on: https://github.com/climatepolicyradar/navigator-infra/pull/1018
Part of: https://linear.app/climate-policy-radar/issue/APP-468/tame-env-vars-in-navigator-frontend