### PR TITLE
APP-438: default sort

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -20,7 +20,7 @@ const getCurrentSortChoice = (queryParams: ParsedUrlQuery, isBrowsing: boolean) 
   const field = queryParams[QUERY_PARAMS.sort_field];
   const order = queryParams[QUERY_PARAMS.sort_order];
   if (field === undefined && order === undefined) {
-    if (isBrowsing) return "null";
+    if (isBrowsing) return "date:desc";
     return "relevance";
   }
   return `${field}:${order}`;

--- a/src/constants/sortOptions.ts
+++ b/src/constants/sortOptions.ts
@@ -23,10 +23,6 @@ export const sortOptions = [
 
 export const sortOptionsBrowse = [
   {
-    label: "Default",
-    value: "null",
-  },
-  {
     label: "Title: A - Z",
     value: "title:asc",
   },

--- a/src/utils/buildSearchQuery.test.ts
+++ b/src/utils/buildSearchQuery.test.ts
@@ -34,4 +34,23 @@ describe("buildSearchQuery: ", () => {
     const searchQueryWithCategory = buildSearchQuery({ c: "UNFCCC" }, themeConfig);
     expect(searchQueryWithCategory.corpus_import_ids).toBe(unfcccCategories);
   });
+
+  it("should set the sort order to 'date' 'descending' if no query or sort is provided", () => {
+    const themeConfig = {
+      defaultCorpora: undefined,
+      categories: {
+        label: "Category",
+        options: [],
+      },
+      filters: [],
+      labelVariations: [],
+      links: [],
+      metadata: [],
+      documentCategories: [],
+    };
+
+    const searchQuery = buildSearchQuery({}, themeConfig);
+    expect(searchQuery.sort_field).toEqual("date");
+    expect(searchQuery.sort_order).toEqual("desc");
+  });
 });

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -29,20 +29,26 @@ export default function buildSearchQuery(
     query.query_string = routerQuery[QUERY_PARAMS.query_string]?.toString();
   }
 
-  if (routerQuery[QUERY_PARAMS.exact_match]) {
-    query.exact_match = routerQuery[QUERY_PARAMS.exact_match] === "true";
-  }
-
-  if (routerQuery[QUERY_PARAMS.offset]) {
-    query.offset = Number(routerQuery[QUERY_PARAMS.offset]);
+  if (routerQuery[QUERY_PARAMS.sort_order]) {
+    query.sort_order = routerQuery[QUERY_PARAMS.sort_order]?.toString();
   }
 
   if (routerQuery[QUERY_PARAMS.sort_field]) {
     query.sort_field = routerQuery[QUERY_PARAMS.sort_field]?.toString();
   }
 
-  if (routerQuery[QUERY_PARAMS.sort_order]) {
-    query.sort_order = routerQuery[QUERY_PARAMS.sort_order]?.toString();
+  // If no sort order is provided, and we are in "browse" mode, we want to set the sort order to latest date "date:desc"
+  if (!routerQuery[QUERY_PARAMS.sort_field] && !routerQuery[QUERY_PARAMS.sort_order] && !routerQuery[QUERY_PARAMS.query_string]) {
+    query.sort_order = "desc";
+    query.sort_field = "date";
+  }
+
+  if (routerQuery[QUERY_PARAMS.exact_match]) {
+    query.exact_match = routerQuery[QUERY_PARAMS.exact_match] === "true";
+  }
+
+  if (routerQuery[QUERY_PARAMS.offset]) {
+    query.offset = Number(routerQuery[QUERY_PARAMS.offset]);
   }
 
   if (routerQuery[QUERY_PARAMS.year_range]) {


### PR DESCRIPTION
# What's changed
- Default sort when the user is browsing documents in search is now date - descending
- Previously we default to passing `null` to the API, which was resulting in an unpredictable "random" set of results

## Why?
- More predictable and easier to understand for the user
- Removes the confusing & vague "default" sort order option

## Screenshots?
