### PR TITLE
APP 470: unfccc filters

### DIFF
--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ParsedUrlQuery } from "querystring";
-import { find as Lfind, get as Lget } from "lodash";
+import { get } from "lodash";
 
 import { InputCheck } from "@/components/forms/Checkbox";
 import { InputRadio } from "@/components/forms/Radio";
@@ -11,7 +11,7 @@ import { TCorpusTypeDictionary, TThemeConfig, TThemeConfigFilter } from "@/types
 import { TextInput } from "@/components/forms/TextInput";
 
 const getTaxonomyAllowedValues = (corporaKey: string, taxonomyKey: string, corpus_types: TCorpusTypeDictionary) => {
-  const allowedValues = Lget(corpus_types[corporaKey].taxonomy, taxonomyKey)?.allowed_values || [];
+  const allowedValues = get(corpus_types[corporaKey].taxonomy, taxonomyKey)?.allowed_values || [];
 
   return allowedValues;
 };

--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ParsedUrlQuery } from "querystring";
+import { find as Lfind, get as Lget } from "lodash";
 
 import { InputCheck } from "@/components/forms/Checkbox";
 import { InputRadio } from "@/components/forms/Radio";
@@ -10,7 +11,7 @@ import { TCorpusTypeDictionary, TThemeConfig, TThemeConfigFilter } from "@/types
 import { TextInput } from "@/components/forms/TextInput";
 
 const getTaxonomyAllowedValues = (corporaKey: string, taxonomyKey: string, corpus_types: TCorpusTypeDictionary) => {
-  const allowedValues = corpus_types[corporaKey].taxonomy[taxonomyKey]?.allowed_values;
+  const allowedValues = Lget(corpus_types[corporaKey].taxonomy, taxonomyKey)?.allowed_values || [];
 
   return allowedValues;
 };
@@ -106,7 +107,9 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
   }
 
   // De-duplicate and sort the options
-  const optionsDeDuped: string[] = [...new Set(options.sort())].filter((option) => option.toLowerCase().includes(search.toLowerCase()));
+  const optionsDeDuped: string[] = options
+    ? [...new Set(options.sort())].filter((option) => option.toLowerCase().includes(search.toLowerCase()))
+    : [];
 
   let optionsAsComponents = optionsDeDuped.map((option: string) =>
     filter.type === "radio" ? (

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -137,6 +137,13 @@ const SearchFilters = ({
 
       {themeConfigStatus === "success" &&
         themeConfig.filters.map((filter) => {
+          // TODO: remove FF and logic for UNFCCC filters
+          if (
+            ["_document.type", "author_type"].includes(filter.taxonomyKey) &&
+            filter.corporaKey === "Intl. agreements" &&
+            !featureFlags["unfccc-filters"]
+          )
+            return;
           // If the filter is not in the selected category, don't display it
           if (!canDisplayFilter(filter, query, themeConfig)) return;
           return (

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -22,6 +22,8 @@ export const QUERY_PARAMS = {
   sector: "sc",
   // Reports
   author_type: "at",
+  // UNFCCC
+  "_document.type": "t",
   // Pass through
   concept_id: "cfi",
   concept_name: "cfn",

--- a/src/pages/_feature-flags.tsx
+++ b/src/pages/_feature-flags.tsx
@@ -13,7 +13,7 @@ export default function FeatureFlags() {
      */
     posthog.init("phc_zaZYaLxsAeMjCLPsU2YvFqu4oaXRJ8uAkgXY8DancyL", {
       api_host: "https://eu.i.posthog.com",
-      opt_in_site_apps: true,
+      opt_in_site_apps: true, // enables the beta feature popup
     });
 
     posthog.onFeatureFlags((featureFlags) => {

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -37,7 +37,7 @@ export default function buildSearchQuery(
     query.sort_field = routerQuery[QUERY_PARAMS.sort_field]?.toString();
   }
 
-  // If no sort order is provided, and we are in "browse" mode, we want to set the sort order to latest date "date:desc"
+  // If no sort order is provided, and we are in "browse" mode (i.e. no search term), we want to set the sort order to latest date "date:desc"
   if (!routerQuery[QUERY_PARAMS.sort_field] && !routerQuery[QUERY_PARAMS.sort_order] && !routerQuery[QUERY_PARAMS.query_string]) {
     query.sort_order = "desc";
     query.sort_field = "date";
@@ -225,6 +225,13 @@ export default function buildSearchQuery(
   // These are the filters that are specific to the Reports corpus type
   if (routerQuery[QUERY_PARAMS.author_type]) {
     query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig);
+  }
+  // ---- End of Reports specific ----
+
+  // ---- UNFCCC specific ----
+  // These are the filters that are specific to the UNFCCC corpus type
+  if (routerQuery[QUERY_PARAMS["_document.type"]]) {
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS["_document.type"]], "_document.type", themeConfig);
   }
 
   query = {

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -246,6 +246,23 @@
       "type": "radio",
       "category": ["OEP.corpus.i00000001.n0000"],
       "corporaKey": "Reports"
+    },
+    {
+      "label": "Type",
+      "corporaKey": "Intl. agreements",
+      "taxonomyKey": "_document.type",
+      "apiMetaDataKey": "document.type",
+      "type": "radio",
+      "category": ["UNFCCC.corpus.i00000001.n0000"],
+      "quickSearch": "true"
+    },
+    {
+      "label": "Author Type",
+      "corporaKey": "Intl. agreements",
+      "taxonomyKey": "author_type",
+      "apiMetaDataKey": "family.author.type",
+      "type": "radio",
+      "category": ["UNFCCC.corpus.i00000001.n0000"]
     }
   ],
   "labelVariations": [


### PR DESCRIPTION
# What's changed
- Adding 2 new filters for UNFCCC category: author type and type
- Add new feature flag called "unfccc-filters" which must be switched on in order to see them
- Support new `_document.type` taxonomy in `QUERY_PARAM` and the api query builder

## Why?
- So that policy can test new filter functionality

## Screenshots?
