### PR TITLE
Add timeout to the geography check due to API speed

### DIFF
--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -41,7 +41,7 @@ test("search", async ({ page }) => {
   await expect(firstSearchResult.locator('[data-cy="family-metadata-category"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="family-metadata-year"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="family-description"]')).toBeVisible();
-  await expect(firstSearchResult.locator('[data-cy="country-link"]')).toBeVisible();
+  await expect(firstSearchResult.locator('[data-cy="country-link"]')).toBeVisible({ timeout: 10000 });
 
   await searchResults.getByRole("link").first().click();
 


### PR DESCRIPTION
# What's changed
- Add timeout for the country lookup in case the /geographies endpoint is slow

## Why?
- e2e tests are flakey because they are dependant on API response times

## Screenshots?
