### PR TITLE
Feature/app 479 update jotform link for data contributors on CPR

### DIFF
--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -321,7 +321,6 @@ export const ConceptsDocumentViewer = ({
                           </span>
                         )}
                       </div>
-                      <p>Sorted by search relevance</p>
                     </div>
                     <div
                       id="document-passage-matches"

--- a/themes/cpr/constants/faqs.tsx
+++ b/themes/cpr/constants/faqs.tsx
@@ -41,7 +41,7 @@ export const FAQS: TFAQ[] = [
           New data, and updates to existing data, are collected from official sources such as government websites, parliamentary records and court
           documents. We add these to the database on a rolling basis. Submissions to the UNFCCC portals were first added on the 23rd of May 2023, and
           are checked for updates regularly. If you're aware of documents that are missing, please let us know using our{" "}
-          <ExternalLink url="https://eu.jotform.com/250402253775352">data contributors form</ExternalLink>.
+          <ExternalLink url="https://form.jotform.com/250974303048355">data contributors form</ExternalLink>.
         </p>
       </>
     ),


### PR DESCRIPTION
# What's changed

Updated a jotform link for the data contributors form on the CPR app.

## Why?

We were linking to an old jotform.
