### PR TITLE
APP-497 hard code filters for UNFCCC category

### DIFF
--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -104,6 +104,7 @@ const handleFilterDisplay = (
     case "fund":
     case "fund_doc_type":
     case "framework_laws":
+    case "_document.type":
       filterLabel = getFilterDisplayValue(key, value, themeConfig);
       break;
   }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -229,6 +229,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     delete router.query[QUERY_PARAMS.framework_laws];
     // Reports filters
     delete router.query[QUERY_PARAMS.author_type];
+    // UNFCCC filters
+    delete router.query[QUERY_PARAMS["_document.type"]];
     // Only reset the topic and sector filters if we are not moving between laws or policies categories
     if (category !== "policies" && category !== "laws") {
       delete router.query[QUERY_PARAMS.topic];

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -254,7 +254,53 @@
       "apiMetaDataKey": "document.type",
       "type": "radio",
       "category": ["UNFCCC.corpus.i00000001.n0000"],
-      "quickSearch": "true"
+      "options": [
+        {
+          "label": "Adaptation Communication",
+          "slug": "Adaptation Communication",
+          "value": "Adaptation Communication"
+        },
+        {
+          "label": "Biennial Report",
+          "slug": "Biennial Report",
+          "value": "Biennial Report"
+        },
+        {
+          "label": "Biennial Transparency Report",
+          "slug": "Biennial Transparency Report",
+          "value": "Biennial Transparency Report"
+        },
+        {
+          "label": "Biennial Update Report",
+          "slug": "Biennial Update Report",
+          "value": "Biennial Update Report"
+        },
+        {
+          "label": "Long-Term Low-Emission Development Strategy",
+          "slug": "Long-Term Low-Emission Development Strategy",
+          "value": "Long-Term Low-Emission Development Strategy"
+        },
+        {
+          "label": "National Adaptation Plan",
+          "slug": "National Adaptation Plan",
+          "value": "National Adaptation Plan"
+        },
+        {
+          "label": "National Communication",
+          "slug": "National Communication",
+          "value": "National Communication"
+        },
+        {
+          "label": "Nationally Determined Contribution",
+          "slug": "Nationally Determined Contribution",
+          "value": "Nationally Determined Contribution"
+        },
+        {
+          "label": "National Inventory Report",
+          "slug": "National Inventory Report",
+          "value": "National Inventory Report"
+        }
+      ]
     },
     {
       "label": "Author Type",

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -248,7 +248,15 @@
       "corporaKey": "Reports"
     },
     {
-      "label": "Type",
+      "label": "Author Type",
+      "corporaKey": "Intl. agreements",
+      "taxonomyKey": "author_type",
+      "apiMetaDataKey": "family.author.type",
+      "type": "radio",
+      "category": ["UNFCCC.corpus.i00000001.n0000"]
+    },
+    {
+      "label": "Type of submission",
       "corporaKey": "Intl. agreements",
       "taxonomyKey": "_document.type",
       "apiMetaDataKey": "document.type",
@@ -256,59 +264,51 @@
       "category": ["UNFCCC.corpus.i00000001.n0000"],
       "options": [
         {
-          "label": "Adaptation Communication",
+          "label": "Adaptation Communication (AC)",
           "slug": "Adaptation Communication",
           "value": "Adaptation Communication"
         },
         {
-          "label": "Biennial Report",
+          "label": "Biennial Report (BR)",
           "slug": "Biennial Report",
           "value": "Biennial Report"
         },
         {
-          "label": "Biennial Transparency Report",
+          "label": "Biennial Transparency Report (BTR)",
           "slug": "Biennial Transparency Report",
           "value": "Biennial Transparency Report"
         },
         {
-          "label": "Biennial Update Report",
+          "label": "Biennial Update Report (BUR)",
           "slug": "Biennial Update Report",
           "value": "Biennial Update Report"
         },
         {
-          "label": "Long-Term Low-Emission Development Strategy",
+          "label": "Long-Term Low-Emission Development Strategy (LT-LEDS)",
           "slug": "Long-Term Low-Emission Development Strategy",
           "value": "Long-Term Low-Emission Development Strategy"
         },
         {
-          "label": "National Adaptation Plan",
+          "label": "National Adaptation Plan (NAP)",
           "slug": "National Adaptation Plan",
           "value": "National Adaptation Plan"
         },
         {
-          "label": "National Communication",
+          "label": "National Communication (NC)",
           "slug": "National Communication",
           "value": "National Communication"
         },
         {
-          "label": "Nationally Determined Contribution",
+          "label": "Nationally Determined Contribution (NDC)",
           "slug": "Nationally Determined Contribution",
           "value": "Nationally Determined Contribution"
         },
         {
-          "label": "National Inventory Report",
+          "label": "National Inventory Report (NIR)",
           "slug": "National Inventory Report",
           "value": "National Inventory Report"
         }
       ]
-    },
-    {
-      "label": "Author Type",
-      "corporaKey": "Intl. agreements",
-      "taxonomyKey": "author_type",
-      "apiMetaDataKey": "family.author.type",
-      "type": "radio",
-      "category": ["UNFCCC.corpus.i00000001.n0000"]
     }
   ],
   "labelVariations": [


### PR DESCRIPTION
# What's changed
- Filters for "submission type" are now hardcoded into the config

## Why?
- Previously we were displaying all the values in the taxonomy, which were copied over from the other types, most of which are not applicable.

## Screenshots?
