### PR TITLE
APP-518: Litigation thin slice - search displays results

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -2,6 +2,6 @@ module.exports = [
   {
     name: "Next static files",
     path: [".next/static/chunks/**/*.js"],
-    limit: "375 KB",
+    limit: "400 KB",
   },
 ];

--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -16,22 +16,27 @@ type TCountriesLink = {
 
 export const CountryLinks = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
-    {geographies?.map((geography) => (
-      <Fragment key={geography}>
-        {isSystemInternational(geography) && (
-          <span className="flex gap-1">
-            <>{getCountryName(geography, countries)}</>
-          </span>
-        )}
-        {!isSystemGeo(geography) && (
-          <span className="flex gap-1">
-            <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
-              <span>{getCountryName(geography, countries)}</span>
-            </CountryLink>
-          </span>
-        )}
-      </Fragment>
-    ))}
+    {geographies?.map((geography) => {
+      const countryName = getCountryName(geography, countries);
+      if (!countryName) return null;
+
+      return (
+        <Fragment key={geography}>
+          {isSystemInternational(geography) && (
+            <span className="flex gap-1">
+              <>{countryName}</>
+            </span>
+          )}
+          {!isSystemGeo(geography) && (
+            <span className="flex gap-1">
+              <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
+                <span>{countryName}</span>
+              </CountryLink>
+            </span>
+          )}
+        </Fragment>
+      );
+    })}
   </>
 );
 

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -7,6 +7,7 @@ type TQueryResponse = {
   geographies: TDataNode<TGeography>[];
   regions: TGeography[];
   countries: TGeography[];
+  subdivisions: TGeography[];
   languages: TLanguages;
   corpus_types: TCorpusTypeDictionary;
 };
@@ -19,15 +20,14 @@ export default function useConfig() {
       const client = new ApiClient(data?.env?.api_url, data?.env?.app_token);
       const query_response = await client.getConfig();
       const geographies = query_response.data.geographies;
-      const response_geo = extractNestedData<TGeography>(geographies, 2, "");
-      const regions = response_geo.level1;
-      const countries = response_geo.level2;
+      const [regions, countries, subdivisions] = extractNestedData<TGeography>(geographies);
       const corpus_types = query_response.data.corpus_types;
 
       const resp_end: TQueryResponse = {
         geographies,
         regions,
         countries,
+        subdivisions,
         languages: query_response.data.languages,
         corpus_types,
       };

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -477,8 +477,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (familyData) {
     try {
       const configRaw = await client.getConfig();
-      const response_geo = extractNestedData<TGeography>(configRaw.data.geographies, 2, "");
-      countriesData = response_geo.level2;
+      const response_geo = extractNestedData<TGeography>(configRaw.data.geographies);
+      countriesData = response_geo[1];
       corpus_types = configRaw.data.corpus_types;
     } catch (error) {}
   }

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -405,8 +405,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
     let countries: TGeography[] = [];
     const configData = await client.getConfig();
-    const response_geo = extractNestedData<TGeography>(configData.data?.geographies, 2, "");
-    countries = response_geo.level2;
+    const response_geo = extractNestedData<TGeography>(configData.data?.geographies || []);
+    countries = response_geo[1];
     const country = getCountryCode(id as string, countries);
     if (country) {
       const targetsRaw = await axios.get<TTarget[]>(`${process.env.TARGETS_URL}/geographies/${country.toLowerCase()}.json`);

--- a/src/utils/extractNestedData.ts
+++ b/src/utils/extractNestedData.ts
@@ -1,27 +1,26 @@
 import { TDataNode } from "@/types";
-import { removeDuplicates } from "@/utils/removeDuplicates";
+import { groupBy, sortBy, toPairs, uniqBy } from "lodash/fp";
 
-export function extractNestedData<T>(response: TDataNode<T>[], levels: number, filterProp: string): { level1: T[]; level2: T[] } {
-  let level1 = [];
-  let level2Nested = [];
-  let level2 = [];
-  let data = response;
-  if (data) {
-    level1 = data.map((item) => {
-      return item.node;
-    });
-    if (levels === 2) {
-      level2Nested = data.map((item) => {
-        return [...level2Nested, ...item.children];
-      });
+type TNodeAndDepth<T> = {
+  node: T;
+  nodeDepth: number;
+};
 
-      level2 = level2Nested.flat().map((item) => item.node);
-    }
-    if (filterProp.length) {
-      level1 = removeDuplicates(level1, filterProp);
-      level2 = removeDuplicates(level2, filterProp);
-    }
+// Unrolls nested nodes into a flat array of nodes + their original depth
+const flattenNodesWithDepth = <T>(dataNodes: TDataNode<T>[], nodeDepth = 0): TNodeAndDepth<T>[] =>
+  dataNodes.reduce(
+    (reducedNodes, dataNode) => [...reducedNodes, { node: dataNode.node, nodeDepth }, ...flattenNodesWithDepth(dataNode.children, nodeDepth + 1)],
+    []
+  );
 
-    return { level1, level2 };
-  }
-}
+// Returns a 2D array of nodes grouped by their level in the dataNodes tree, highest to lowest
+export const extractNestedData = <T>(dataNodes: TDataNode<T>[], uniqueByPath?: string): T[][] => {
+  const nodesWithLevels = flattenNodesWithDepth<T>(dataNodes);
+  const nodesByLevelObject = groupBy("nodeDepth", nodesWithLevels);
+  const nodeAndLevelPairs = toPairs(nodesByLevelObject);
+  const nodesByLevelArray = sortBy("0", nodeAndLevelPairs).map((level) => level[1].map((levelNode) => levelNode.node));
+
+  if (!uniqueByPath) return nodesByLevelArray;
+
+  return nodesByLevelArray.map((level) => uniqBy(uniqueByPath, level));
+};

--- a/src/utils/removeDuplicates.ts
+++ b/src/utils/removeDuplicates.ts
@@ -1,5 +1,0 @@
-export const removeDuplicates = (arr, prop) => {
-  return arr.filter((obj, pos, arr) => {
-    return arr.map((mapObj) => mapObj[prop]).indexOf(obj[prop]) === pos;
-  });
-};


### PR DESCRIPTION
# What's changed

1. `CountryLinks` doesn't render an empty React node when it fails to find a name for a geographical subdivision.
2. `extractNestedData` is no longer hard coded to only extract 2 levels, but instead is recursive and returns an array of `n` levelled nodes.

## Why?

1. Prevents a double bullet (• •) as part of the country display on a search result.
2. Preparation for displaying the geographical subdivision on the new search result card, family page, and geography page. As each of these involves redesigns, I feel it's sufficient to stop here for now.

## Screenshots?

Litigation results' country, year, and category are only separated by single bullets:
<img width="1348" alt="Screenshot 2025-04-17 at 11 12 47" src="https://github.com/user-attachments/assets/8d0d046a-9053-4d62-831a-6afa6c5619fc" />

