### PR TITLE
APP-524: Litigation thin slice: family page displays litigation and its documents

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -273,8 +273,8 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
               <>
                 <section className="mt-8">
                   <div className="flex items-center gap-2">
-                    <Heading level={2} extraClasses="mb-0">
-                      {theme === "mcf" ? "Project documents" : "Other documents in this entry"}
+                    <Heading level={2} extraClasses="!mb-0">
+                      {theme === "mcf" ? "Project documents" : mainDocuments.length > 0 ? "Other documents in this entry" : "Documents in this entry"}
                     </Heading>
                     {theme !== "mcf" && (
                       <Tooltip

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -376,18 +376,20 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
               </section>
             )}
 
-            <section className="mt-8">
-              <Heading level={4}>Note</Heading>
-              <div className="flex text-sm">
-                {corpusImage && (
-                  <div className="relative max-w-[144px] mt-1 mr-2">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={`${corpusImage}`} alt={corpusAltImage} className="h-auto w-full" />
-                  </div>
-                )}
-                <span dangerouslySetInnerHTML={{ __html: corpusNote }} className="" />
-              </div>
-            </section>
+            {corpusNote && (
+              <section className="mt-8">
+                <Heading level={4}>Note</Heading>
+                <div className="flex text-sm">
+                  {corpusImage && (
+                    <div className="relative max-w-[144px] mt-1 mr-2">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={`${corpusImage}`} alt={corpusAltImage} className="h-auto w-full" />
+                    </div>
+                  )}
+                  <span dangerouslySetInnerHTML={{ __html: corpusNote }} className="" />
+                </div>
+              </section>
+            )}
 
             {page.collections.length > 0 && (
               <div className="mt-8">


### PR DESCRIPTION
# What's changed

- "Other documents in this entry" document heading doesn't include "other" when there are no main documents.
- Removed padding on this heading to fix the tooltip alignment.
- Notes heading is hidden if there is no corpus note to show.

## Why?

Making litigation play nice with the existing CPR website.

## Screenshots?

<img width="1310" alt="Screenshot 2025-04-17 at 14 03 35" src="https://github.com/user-attachments/assets/737c6b71-d663-41e1-835d-2a391f74e794" />
