### PR TITLE
APP-531: Litigation thin slice: add litigation count to the map on homepage

### DIFF
--- a/public/data/map/world-countries-50m.json
+++ b/public/data/map/world-countries-50m.json
@@ -167,7 +167,7 @@
             [[219]]
           ],
           "id": "840",
-          "properties": { "name": "United States of America" }
+          "properties": { "name": "United States" }
         },
         { "type": "MultiPolygon", "arcs": [[[220]], [[221]]], "id": "239", "properties": { "name": "South Georgia and the Islands" } },
         { "type": "Polygon", "arcs": [[222]], "id": "086", "properties": { "name": "British Indian Ocean Territory" } },
@@ -236,7 +236,7 @@
           "type": "MultiPolygon",
           "arcs": [[[303]], [[304, 305, 306, 307, 308, 309, 310]], [[311, 312, 313]]],
           "id": "792",
-          "properties": { "name": "Turkey" }
+          "properties": { "name": "Türkiye" }
         },
         { "type": "MultiPolygon", "arcs": [[[314, 315, 316]], [[317]], [[318]]], "id": "788", "properties": { "name": "Tunisia" } },
         { "type": "MultiPolygon", "arcs": [[[319]], [[320]]], "id": "780", "properties": { "name": "Trinidad and Tobago" } },
@@ -455,7 +455,7 @@
             [[-283, 639]]
           ],
           "id": "643",
-          "properties": { "name": "Russia" }
+          "properties": { "name": "Russian Federation" }
         },
         { "type": "Polygon", "arcs": [[-285, 640, 641, -491, 642, -287, 643]], "id": "642", "properties": { "name": "Romania" } },
         { "type": "Polygon", "arcs": [[-506, 644]], "id": "634", "properties": { "name": "Qatar" } },
@@ -609,7 +609,7 @@
           "id": "578",
           "properties": { "name": "Norway" }
         },
-        { "type": "MultiPolygon", "arcs": [[[-422, 797, 798, -540, 799]], [[800]]], "id": "408", "properties": { "name": "Korea, North" } },
+        { "type": "MultiPolygon", "arcs": [[[-422, 797, 798, -540, 799]], [[800]]], "id": "408", "properties": { "name": "North Korea" } },
         { "type": "MultiPolygon", "arcs": [[[801]], [[802, 803, 804, 805, 806]]], "id": "566", "properties": { "name": "Nigeria" } },
         { "type": "Polygon", "arcs": [[-807, 807, 808, 809, 810, 811, 812]], "id": "562", "properties": { "name": "Niger" } },
         { "type": "Polygon", "arcs": [[813, 814, 815, 816]], "id": "558", "properties": { "name": "Nicaragua" } },
@@ -694,7 +694,7 @@
         { "type": "Polygon", "arcs": [[-439]], "id": "426", "properties": { "name": "Lesotho" } },
         { "type": "Polygon", "arcs": [[-368, 941, 942]], "id": "422", "properties": { "name": "Lebanon" } },
         { "type": "Polygon", "arcs": [[-932, 943, 944, -550, 945]], "id": "428", "properties": { "name": "Latvia" } },
-        { "type": "Polygon", "arcs": [[-21, 946, -337, 947, 948]], "id": "418", "properties": { "name": "Lao People's Democratic Republic" } },
+        { "type": "Polygon", "arcs": [[-21, 946, -337, 947, 948]], "id": "418", "properties": { "name": "Laos" } },
         { "type": "Polygon", "arcs": [[-52, 949, 950, -359], [-58], [-59], [-362]], "id": "417", "properties": { "name": "Kyrgyzstan" } },
         { "type": "MultiPolygon", "arcs": [[[951]], [[-504, 952, 953]]], "id": "414", "properties": { "name": "Kuwait" } },
         { "type": "Polygon", "arcs": [[-486, -926, 954, -866]], "properties": { "name": "Kosovo" } },
@@ -1115,7 +1115,7 @@
         { "type": "Polygon", "arcs": [[-393, -401, 1385, 1386, -445, -442, -976]], "id": "231", "properties": { "name": "Ethiopia" } },
         { "type": "MultiPolygon", "arcs": [[[-945, 1387, -551]], [[1388]], [[1389]], [[1390]]], "id": "233", "properties": { "name": "Estonia" } },
         { "type": "MultiPolygon", "arcs": [[[-400, 1391, 1392, -1386]], [[1393]], [[1394]]], "id": "232", "properties": { "name": "Eritrea" } },
-        { "type": "MultiPolygon", "arcs": [[[1395]], [[-1301, 1396, 1397]]], "id": "226", "properties": { "name": "Eq. Guinea" } },
+        { "type": "MultiPolygon", "arcs": [[[1395]], [[-1301, 1396, 1397]]], "id": "226", "properties": { "name": "Equatorial Guinea" } },
         { "type": "Polygon", "arcs": [[-1210, 1398, -1233]], "id": "222", "properties": { "name": "El Salvador" } },
         { "type": "Polygon", "arcs": [[-398, -936, 1399, -1038, -1035, 1400]], "id": "818", "properties": { "name": "Egypt" } },
         {
@@ -1203,7 +1203,7 @@
           "type": "Polygon",
           "arcs": [[-7, 1479, 1480, 1481, 1482, 1483, -390, -296, -522, 1484, -351]],
           "id": "180",
-          "properties": { "name": "Democratic Republic of Congo" }
+          "properties": { "name": "Congo, Democratic Republic of the" }
         },
         { "type": "Polygon", "arcs": [[-1299, 1485, 1486, -1483, 1487, 1488]], "id": "178", "properties": { "name": "Congo" } },
         { "type": "MultiPolygon", "arcs": [[[1489]], [[1490]], [[1491]]], "id": "174", "properties": { "name": "Comoros" } },
@@ -1526,7 +1526,7 @@
             [[1785]]
           ],
           "id": "044",
-          "properties": { "name": "Bahamas, The" }
+          "properties": { "name": "Bahamas" }
         },
         {
           "type": "MultiPolygon",

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -1,8 +1,10 @@
-import { useMcfData } from "@/hooks/useMcfData";
+type TLegendProps = {
+  max: number;
+  showLitigation: boolean;
+  showMcf: boolean;
+};
 
-export const Legend = ({ max }: { max: number }) => {
-  const showMcf = useMcfData();
-
+export const Legend = ({ max, showLitigation, showMcf }: TLegendProps) => {
   const scale = [1, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), max];
 
   return (
@@ -31,7 +33,10 @@ export const Legend = ({ max }: { max: number }) => {
           <p>{scale[4]}</p>
         </div>
       </div>
-      <p>Size and colour show the number of laws, policies, reports{showMcf ? ", MCF projects" : ""} or UNFCCC submissions in our databases.</p>
+      <p>
+        Size and colour show the number of laws, policies, reports{showLitigation ? ", litigation" : ""}
+        {showMcf ? ", MCF projects" : ""} or UNFCCC submissions in our databases.
+      </p>
     </div>
   );
 };

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -33,6 +33,7 @@ type TGeoFamilyCounts = {
   LEGISLATIVE: number;
   MCF: number;
   REPORTS: number;
+  LITIGATION: number;
 };
 
 type TGeoMarkers = {
@@ -51,6 +52,7 @@ type TMapData = {
   maxUnfccc: number;
   maxMcf: number;
   maxReports: number;
+  maxLitigation: number;
   geographies: TGeographiesWithCoords;
 };
 
@@ -114,12 +116,13 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
   return (
     <>
       <p className="text-textDark font-medium">{geography.display_value}</p>
-      {(geography.familyCounts?.EXECUTIVE || geography.familyCounts?.LEGISLATIVE) && (
+      {(geography.familyCounts?.EXECUTIVE > 0 || geography.familyCounts?.LEGISLATIVE > 0) && (
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}
       {geography.familyCounts?.UNFCCC > 0 && <p>UNFCCC: {geography.familyCounts?.UNFCCC || 0}</p>}
       {geography.familyCounts?.MCF > 0 && <p>MCF projects: {geography.familyCounts?.MCF || 0}</p>}
       {geography.familyCounts?.REPORTS > 0 && <p>Reports: {geography.familyCounts?.REPORTS || 0}</p>}
+      {geography.familyCounts?.LITIGATION > 0 && <p>Litigation: {geography.familyCounts?.LITIGATION || 0}</p>}
       <p>
         <LinkWithQuery href={`/geographies/${geography.slug}`} className="text-blue-600 underline hover:text-blue-800">
           View more
@@ -129,7 +132,11 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
   );
 };
 
-export default function MapChart() {
+type TMapChartProps = {
+  showLitigation?: boolean;
+};
+
+export default function MapChart({ showLitigation = false }: TMapChartProps) {
   const configQuery = useConfig();
   const geographiesQuery = useGeographies();
   const { data: { countries: configCountries = [] } = {} } = configQuery;
@@ -140,7 +147,7 @@ export default function MapChart() {
   const [mapCenter, setMapCenter] = useState<TPoint>([0, 0]);
   const [mapZoom, setMapZoom] = useState(1);
   const [showUnifiedEU, setShowUnifiedEU] = useState(false);
-  const [selectedFamCategory, setSelectedFamCategory] = useState<"lawsPolicies" | "unfccc" | "mcf" | "reports">("lawsPolicies");
+  const [selectedFamCategory, setSelectedFamCategory] = useState<"lawsPolicies" | "unfccc" | "mcf" | "reports" | "litigation">("lawsPolicies");
   const showMcf = useMcfData();
 
   useEffect(() => {
@@ -163,12 +170,16 @@ export default function MapChart() {
     const maxUnfccc = mapDataRaw.length
       ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.UNFCCC || 0)))
       : 0;
+    const maxLitigation = mapDataRaw.length
+      ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.LITIGATION || 0)))
+      : 0;
 
     const mapDataConstructor: TMapData = {
       maxLawsPolicies,
       maxUnfccc,
       maxMcf,
       maxReports,
+      maxLitigation,
       geographies: {},
     };
 
@@ -180,6 +191,7 @@ export default function MapChart() {
       const unfcccCount = geoStats?.family_counts?.UNFCCC || 0;
       const mcfCount = geoStats?.family_counts?.MCF || 0;
       const reportsCount = geoStats?.family_counts?.REPORTS || 0;
+      const litigationCount = geoStats?.family_counts?.LITIGATION || 0;
 
       acc[country.value] = {
         ...country,
@@ -190,6 +202,7 @@ export default function MapChart() {
           unfccc: maxUnfccc > 0 ? Math.max(minMarkerSize, (unfcccCount / maxUnfccc) * maxMarkerSize) : 0,
           mcf: maxMcf > 0 ? Math.max(minMarkerSize, (mcfCount / maxMcf) * maxMarkerSize) : 0,
           reports: maxReports > 0 ? Math.max(minMarkerSize, (reportsCount / maxReports) * maxMarkerSize) : 0,
+          litigation: maxLitigation > 0 ? Math.max(minMarkerSize, (litigationCount / maxLitigation) * maxMarkerSize) : 0,
         },
       };
       return acc;
@@ -259,7 +272,7 @@ export default function MapChart() {
           <select
             className="border border-gray-300 small rounded-full !pl-4"
             onChange={(e) => {
-              setSelectedFamCategory(e.currentTarget.value as "lawsPolicies" | "unfccc" | "mcf" | "reports");
+              setSelectedFamCategory(e.currentTarget.value as "lawsPolicies" | "unfccc" | "mcf" | "reports" | "litigation");
             }}
             value={selectedFamCategory}
             aria-label="Select a document type to display on the map"
@@ -269,6 +282,7 @@ export default function MapChart() {
             <option value="unfccc">UNFCCC</option>
             {showMcf && <option value="mcf">MCF projects</option>}
             <option value="reports">Reports</option>
+            {showLitigation && <option value="litigation">Litigation</option>}
           </select>
         </div>
         <div>
@@ -401,8 +415,12 @@ export default function MapChart() {
                 ? mapData.maxUnfccc
                 : selectedFamCategory === "reports"
                   ? mapData.maxReports
-                  : mapData.maxMcf
+                  : selectedFamCategory === "mcf"
+                    ? mapData.maxMcf
+                    : mapData.maxLitigation
           }
+          showMcf={showMcf}
+          showLitigation={showLitigation}
         />
       )}
     </>

--- a/src/hooks/useGeographies.ts
+++ b/src/hooks/useGeographies.ts
@@ -11,6 +11,7 @@ type TMapGeographyStats = {
     LEGISLATIVE: number;
     MCF: number;
     REPORTS: number;
+    LITIGATION: number;
   };
 };
 

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -59,7 +59,7 @@ const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exact
           </section>
         </main>
         <FullWidth extraClasses="hidden my-6 md:block">
-          <WorldMap />
+          <WorldMap showLitigation />
         </FullWidth>
         <Summary />
         <Partners />


### PR DESCRIPTION
# What's changed

- Updated various world map country names to avoid "We do not have any information for this area yet" from showing when mousing over the country area.
- Added litigation data to the world map:
  - Tooltip shows litigation count if above 0.
  - Dropdown includes Litigation option.
  - Correctly sizes and colours country circles to litigation data only (currently only 4 cases in the US).

## Why?

Getting the current CPR site happy with incoming litigation data.

## Screenshots?

United States correctly showing data when mousing over its area. Includes litigation count:
<img width="1506" alt="Screenshot 2025-04-22 at 16 28 07" src="https://github.com/user-attachments/assets/9df8a9b0-5eaa-4e0e-b4aa-e2f1843764d5" />

Litigation filter dropdown selected:
<img width="1512" alt="Screenshot 2025-04-22 at 16 28 22" src="https://github.com/user-attachments/assets/142d9c1f-e1f4-44a5-8c9c-14e20df4f44f" />