### PR TITLE
Emergency fix: remove world map from home pages

### DIFF
--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -39,12 +39,12 @@ const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
         <SiteWidth extraClasses="my-12" data-cy="powered-by">
           <PoweredBy />
         </SiteWidth>
-        <FullWidth id="world-map" extraClasses="hidden pt-6 md:block">
+        {/* <FullWidth id="world-map" extraClasses="hidden pt-6 md:block">
           <Heading level={2} extraClasses="text-center text-3xl xl:text-4xl">
             Explore by country
           </Heading>
-          {/* <WorldMap /> */}
-        </FullWidth>
+          <WorldMap />
+        </FullWidth> */}
         <SiteWidth extraClasses="my-12" data-cy="featured-content">
           <Heading level={2} extraClasses="text-center text-3xl xl:text-4xl">
             Featured content

--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -17,10 +17,11 @@ import { FeatureSearch } from "@/cclw/components/FeatureSearch";
 import { PAGE_DESCRIPTION, APP_NAME } from "@/cclw/constants/pageMetadata";
 import { Heading } from "@/components/typography/Heading";
 
-const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
-  loading: () => <p>Loading world map...</p>,
-  ssr: false,
-});
+// TODO temporarily disabled: https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349
+// const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
+//   loading: () => <p>Loading world map...</p>,
+//   ssr: false,
+// });
 
 type TProps = {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
@@ -42,7 +43,7 @@ const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
           <Heading level={2} extraClasses="text-center text-3xl xl:text-4xl">
             Explore by country
           </Heading>
-          <WorldMap />
+          {/* <WorldMap /> */}
         </FullWidth>
         <SiteWidth extraClasses="my-12" data-cy="featured-content">
           <Heading level={2} extraClasses="text-center text-3xl xl:text-4xl">

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -16,10 +16,11 @@ import Partners from "@/cpr/components/Partners";
 import Summary from "@/cpr/components/Summary";
 import LandingSearchForm from "@/cpr/components/LandingSearchForm";
 
-const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
-  loading: () => <p>Loading world map...</p>,
-  ssr: false,
-});
+// TODO temporarily disabled: https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349
+// const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
+//   loading: () => <p>Loading world map...</p>,
+//   ssr: false,
+// });
 
 /**
  * GOTCHA: we export this to be used in the src/pages/index.tsx file.
@@ -58,9 +59,9 @@ const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exact
             </SiteWidth>
           </section>
         </main>
-        <FullWidth extraClasses="hidden my-6 md:block">
+        {/* <FullWidth extraClasses="hidden my-6 md:block">
           <WorldMap showLitigation />
-        </FullWidth>
+        </FullWidth> */}
         <Summary />
         <Partners />
         <Footer />


### PR DESCRIPTION
# What's changed

- Commented out `WorldMap` on CPR and CCLW home pages.
- Associated API requests should be encapsulated in the component through the `useGeographies` React hook.

## Why?

Loading the map is potentially causing cascading infrastructure failures. [Slack thread](https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349).

## Screenshots?

CPR:
<img width="1455" alt="Screenshot 2025-04-29 at 17 01 12" src="https://github.com/user-attachments/assets/b5b22ae2-b63f-4893-a16f-07f9e28bc04b" />

CCLW:
<img width="1457" alt="Screenshot 2025-04-29 at 17 00 18" src="https://github.com/user-attachments/assets/31a3d2fe-4b4e-4345-898c-19f496270e9c" />

