### PR TITLE
Remove litigation corpus ID

### DIFF
--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -11,7 +11,6 @@
         "label": "All",
         "slug": "All",
         "value": [
-          "Academic.corpus.Litigation.n0000",
           "CCLW.corpus.i00000001.n0000",
           "CPR.corpus.Goldstandard.n0000",
           "CPR.corpus.i00000589.n0000",
@@ -82,7 +81,6 @@
       {
         "label": "Litigation",
         "slug": "Litigation",
-        "value": ["Academic.corpus.Litigation.n0000"],
         "category": ["Litigation"]
       }
     ]


### PR DESCRIPTION
# What's changed

Removes the Litigation corpus ID from config so that API responses don't include litigation data.

## Why?

Litigation data is currently showing in production.
