### PR TITLE
Revert 471 feature/display litigation in search

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -85,39 +85,42 @@ export const SearchSettings = ({
       ref={searchOptionsRef}
       data-cy="search-settings"
     >
-      <>
-        {handleSearchChange && (
-          <div className={`${handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>
-            <SearchSettingsList data-cy="semantic-search" aria-label="Semantic search">
-              <SearchSettingsItem
-                onClick={(e) => handleSemanticSearchClick(e, "false")}
-                isActive={getCurrentSemanticSearchChoice(queryParams) === "false"}
-              >
-                Related phrases
-              </SearchSettingsItem>
-              <SearchSettingsItem
-                onClick={(e) => handleSemanticSearchClick(e, "true")}
-                isActive={getCurrentSemanticSearchChoice(queryParams) === "true"}
-              >
-                Exact phrases only
-              </SearchSettingsItem>
+      {queryParams[QUERY_PARAMS.category]?.toString() === "Litigation" && <p>No filters available</p>}
+      {queryParams[QUERY_PARAMS.category]?.toString() !== "Litigation" && (
+        <>
+          {handleSearchChange && (
+            <div className={`${handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>
+              <SearchSettingsList data-cy="semantic-search" aria-label="Semantic search">
+                <SearchSettingsItem
+                  onClick={(e) => handleSemanticSearchClick(e, "false")}
+                  isActive={getCurrentSemanticSearchChoice(queryParams) === "false"}
+                >
+                  Related phrases
+                </SearchSettingsItem>
+                <SearchSettingsItem
+                  onClick={(e) => handleSemanticSearchClick(e, "true")}
+                  isActive={getCurrentSemanticSearchChoice(queryParams) === "true"}
+                >
+                  Exact phrases only
+                </SearchSettingsItem>
+              </SearchSettingsList>
+            </div>
+          )}
+          {handleSortClick && (
+            <SearchSettingsList data-cy="sort" aria-label="Sort">
+              {options.map((item) => (
+                <SearchSettingsItem
+                  key={item.value}
+                  onClick={(e) => handleSortOptionClick(e, item.value)}
+                  isActive={item.value === getCurrentSortChoice(queryParams, isBrowsing)}
+                >
+                  {item.label}
+                </SearchSettingsItem>
+              ))}
             </SearchSettingsList>
-          </div>
-        )}
-        {handleSortClick && (
-          <SearchSettingsList data-cy="sort" aria-label="Sort">
-            {options.map((item) => (
-              <SearchSettingsItem
-                key={item.value}
-                onClick={(e) => handleSortOptionClick(e, item.value)}
-                isActive={item.value === getCurrentSortChoice(queryParams, isBrowsing)}
-              >
-                {item.label}
-              </SearchSettingsItem>
-            ))}
-          </SearchSettingsList>
-        )}
-      </>
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -85,8 +85,8 @@ export const SearchSettings = ({
       ref={searchOptionsRef}
       data-cy="search-settings"
     >
-      {queryParams[QUERY_PARAMS.category]?.toString() === "Litigation" && <p>No filters available</p>}
-      {queryParams[QUERY_PARAMS.category]?.toString() !== "Litigation" && (
+      {queryParams[QUERY_PARAMS.category]?.toString().toLowerCase() === "litigation" && <p>No filters available</p>}
+      {queryParams[QUERY_PARAMS.category]?.toString().toLowerCase() !== "litigation" && (
         <>
           {handleSearchChange && (
             <div className={`${handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/ExternalLink";
 import SearchResult from "./SearchResult";
 
 import { TMatchedFamily } from "@/types";
@@ -22,8 +23,25 @@ const renderEmptyMessage = (category: string) => {
 };
 
 const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TProps) => {
-  if (category && category === "Litigation" && families.length === 0) {
-    return renderEmptyMessage(category);
+  if (category && category === "Litigation") {
+    return (
+      <>
+        <p className="my-4 md:mt-0">
+          Climate litigation case documents are coming soon.{" "}
+          <ExternalLink url="https://form.jotform.com/233294371485361" className="underline text-blue-600 hover:text-blue-800">
+            Get notified when they arrive
+          </ExternalLink>
+          .
+        </p>
+        <p className="my-4 md:mt-0">
+          In the meantime, visit the Sabin Center's{" "}
+          <ExternalLink url="http://climatecasechart.com/" className="underline text-blue-600 hover:text-blue-800">
+            Climate Change Litigation Databases
+          </ExternalLink>
+          .
+        </p>
+      </>
+    );
   }
   if (category && category === "Laws" && families.length === 0) {
     return renderEmptyMessage(category);

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -23,7 +23,7 @@ const renderEmptyMessage = (category: string) => {
 };
 
 const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TProps) => {
-  if (category && category === "Litigation") {
+  if (category && category.toLowerCase() === "litigation") {
     return (
       <>
         <p className="my-4 md:mt-0">

--- a/themes/cpr/config.json
+++ b/themes/cpr/config.json
@@ -81,7 +81,8 @@
       {
         "label": "Litigation",
         "slug": "Litigation",
-        "category": ["Litigation"]
+        "category": ["Litigation"],
+        "value": ["LITIGATION-COMING-SOON"]
       }
     ]
   },


### PR DESCRIPTION
# What's changed
- Reverts the change that was exposing litigation docs to users on the CPR version of the app

## Why?
- We have no intention of showcasing the documents there yet

## Screenshots?
