### PR TITLE
Add CCC to build CI matrix

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        theme: [cpr, cclw, mcf]
+        theme: [cpr, cclw, mcf, ccc]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
# What's changed

Add CCC to build CI matrix

## Why?

So we can build CCC images.

## Screenshots?
