### PR TITLE
APP-561: Add document passage sorting options

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -8,12 +8,13 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { sortOptions, sortOptionsBrowse } from "@/constants/sortOptions";
 
 type TProps = {
-  queryParams: ParsedUrlQuery;
-  handleSortClick?: (sortOption: string) => void;
+  extraClasses?: string;
+  handlePassagesClick?: (passagesOption: string) => void;
   handleSearchChange?: (key: string, value: string) => void;
+  handleSortClick?: (sortOption: string) => void;
+  queryParams: ParsedUrlQuery;
   setShowOptions?: (value: boolean) => void;
   settingsButtonRef?: MutableRefObject<any>;
-  extraClasses?: string;
 };
 
 const getCurrentSortChoice = (queryParams: ParsedUrlQuery, isBrowsing: boolean) => {
@@ -34,27 +35,41 @@ const getCurrentSemanticSearchChoice = (queryParams: ParsedUrlQuery) => {
   return exactMatch as string;
 };
 
+const getCurrentPassagesOrderChoice = (queryParams: ParsedUrlQuery) => {
+  return queryParams[QUERY_PARAMS.sort_within_page] === "true";
+};
+
 export const SearchSettings = ({
-  queryParams,
-  handleSortClick,
+  extraClasses = "",
+  handlePassagesClick,
   handleSearchChange,
+  handleSortClick,
+  queryParams,
   setShowOptions,
   settingsButtonRef,
-  extraClasses = "",
 }: TProps) => {
   const searchOptionsRef = useRef(null);
   const [options, setOptions] = useState(sortOptions);
 
+  // no query string OR query string is empty
   const isBrowsing = !queryParams[QUERY_PARAMS.query_string] || queryParams[QUERY_PARAMS.query_string]?.toString().trim() === "";
 
   const handleSemanticSearchClick = (e: React.MouseEvent<HTMLAnchorElement>, value: string) => {
     e.preventDefault();
-    if (handleSearchChange) handleSearchChange(QUERY_PARAMS.exact_match, value);
+    setShowOptions(false);
+    handleSearchChange?.(QUERY_PARAMS.exact_match, value);
   };
 
   const handleSortOptionClick = (e: React.MouseEvent<HTMLAnchorElement>, sortOption: string) => {
     e.preventDefault();
-    if (handleSortClick) handleSortClick(sortOption);
+    setShowOptions(false);
+    handleSortClick?.(sortOption);
+  };
+
+  const handlePassagesOrderClick = (e: React.MouseEvent<HTMLAnchorElement>, value: string) => {
+    e.preventDefault();
+    setShowOptions(false);
+    handlePassagesClick?.(value);
   };
 
   useEffect(() => {
@@ -89,7 +104,7 @@ export const SearchSettings = ({
       {queryParams[QUERY_PARAMS.category]?.toString().toLowerCase() !== "litigation" && (
         <>
           {handleSearchChange && (
-            <div className={`${handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>
+            <div className={`${handlePassagesClick || handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>
               <SearchSettingsList data-cy="semantic-search" aria-label="Semantic search">
                 <SearchSettingsItem
                   onClick={(e) => handleSemanticSearchClick(e, "false")}
@@ -102,6 +117,24 @@ export const SearchSettings = ({
                   isActive={getCurrentSemanticSearchChoice(queryParams) === "true"}
                 >
                   Exact phrases only
+                </SearchSettingsItem>
+              </SearchSettingsList>
+            </div>
+          )}
+          {handlePassagesClick && (
+            <div className={`${handleSortClick ? "border-b border-white/[0.24] pb-4 mb-4" : ""}`}>
+              <SearchSettingsList data-cy="passages-sort" aria-label="Passages sort">
+                <SearchSettingsItem
+                  onClick={(e) => handlePassagesOrderClick(e, "false")}
+                  isActive={getCurrentPassagesOrderChoice(queryParams) === false}
+                >
+                  Relevance
+                </SearchSettingsItem>
+                <SearchSettingsItem
+                  onClick={(e) => handlePassagesOrderClick(e, "true")}
+                  isActive={getCurrentPassagesOrderChoice(queryParams) === true}
+                >
+                  Document position
                 </SearchSettingsItem>
               </SearchSettingsList>
             </div>

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -1,25 +1,26 @@
 export const QUERY_PARAMS = {
   // Core
-  query_string: "q",
-  exact_match: "e",
+  active_continuation_token: "act",
   category: "c",
-  region: "r",
+  continuation_tokens: "cts",
   country: "l",
-  year_range: "y",
+  exact_match: "e",
+  offset: "o",
+  query_string: "q",
+  region: "r",
   sort_field: "sf",
   sort_order: "so",
-  offset: "o",
-  active_continuation_token: "act",
-  continuation_tokens: "cts",
+  sort_within_page: "sp",
+  year_range: "y",
   // Multilateral Climate Funds (MCF)
-  fund: "fd",
-  status: "st",
-  implementing_agency: "ia",
   fund_doc_type: "fdt",
+  fund: "fd",
+  implementing_agency: "ia",
+  status: "st",
   // Laws and Policies
   framework_laws: "fl",
-  topic: "tp",
   sector: "sc",
+  topic: "tp",
   // Reports
   author_type: "at",
   // UNFCCC

--- a/src/constants/searchCriteria.ts
+++ b/src/constants/searchCriteria.ts
@@ -3,17 +3,18 @@ import { minYear, currentYear } from "@/constants/timedate";
 import { RESULTS_PER_PAGE, PASSAGES_PER_DOC } from "@/constants/paging";
 
 export const initialSearchCriteria: TSearchCriteria = {
-  query_string: "",
+  concept_filters: [],
+  corpus_import_ids: [],
   exact_match: false,
-  max_passages_per_doc: PASSAGES_PER_DOC,
   keyword_filters: {},
-  year_range: [minYear.toString(), currentYear().toString()],
+  limit: 100,
+  max_passages_per_doc: PASSAGES_PER_DOC,
+  metadata: [],
+  offset: 0,
+  page_size: RESULTS_PER_PAGE,
+  query_string: "",
   sort_field: null,
   sort_order: "desc",
-  page_size: RESULTS_PER_PAGE,
-  limit: 100,
-  offset: 0,
-  corpus_import_ids: [],
-  metadata: [],
-  concept_filters: [],
+  sort_within_page: false,
+  year_range: [minYear.toString(), currentYear().toString()],
 };

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -55,19 +55,20 @@ const useSearch = (query: TRouterQuery, familyId = "", documentId = "", runFresh
     }
 
     const cacheId = {
-      query_string: searchQuery.query_string,
-      exact_match: searchQuery.exact_match,
-      keyword_filters: searchQuery.keyword_filters,
-      year_range: searchQuery.year_range,
-      sort_field: searchQuery.sort_field,
-      sort_order: searchQuery.sort_order,
-      offset: searchQuery.offset,
-      family_ids: searchQuery.family_ids,
-      document_ids: searchQuery.document_ids,
+      concept_filters: searchQuery.concept_filters,
       continuation_tokens: searchQuery.continuation_tokens,
       corpus_import_ids: searchQuery.corpus_import_ids,
-      concept_filters: searchQuery.concept_filters,
+      document_ids: searchQuery.document_ids,
+      exact_match: searchQuery.exact_match,
+      family_ids: searchQuery.family_ids,
+      keyword_filters: searchQuery.keyword_filters,
       metadata: searchQuery.metadata,
+      offset: searchQuery.offset,
+      query_string: searchQuery.query_string,
+      sort_field: searchQuery.sort_field,
+      sort_order: searchQuery.sort_order,
+      sort_within_page: searchQuery.sort_within_page,
+      year_range: searchQuery.year_range,
     };
 
     // Check if we have a cached result before calling the API

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -132,6 +132,13 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     );
   };
 
+  const handlePassagesOrderChange = (orderValue: string) => {
+    setPassageIndex(0);
+    const queryObj = { ...router.query };
+    queryObj[QUERY_PARAMS.sort_within_page] = orderValue;
+    router.push({ query: queryObj }, undefined, { shallow: true });
+  };
+
   // Handlers to update router
 
   const handleExactMatchChange = useCallback(
@@ -207,7 +214,9 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                 </div>
                 <div
                   id="document-sidebar"
-                  className={`py-4 order-first max-h-[90vh] md:pb-0 md:order-last md:max-h-full md:max-w-[480px] md:min-w-[400px] md:grow-0 md:shrink-0 flex flex-col ${passageClasses(canPreview)}`}
+                  className={`py-4 order-first max-h-[90vh] md:pb-0 md:order-last md:max-h-full md:max-w-[480px] md:min-w-[400px] md:grow-0 md:shrink-0 flex flex-col ${passageClasses(
+                    canPreview
+                  )}`}
                 >
                   {status !== "success" ? (
                     <div className="w-full flex justify-center flex-1 bg-white">
@@ -253,6 +262,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                                   queryParams={router.query}
                                   handleSearchChange={handleSemanticSearchChange}
                                   setShowOptions={setShowOptions}
+                                  handlePassagesClick={handlePassagesOrderChange}
                                 />
                               </motion.div>
                             )}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,22 +17,23 @@ export type TSearchCriteriaMeta = {
 };
 
 export type TSearchCriteria = {
-  query_string: string;
-  exact_match: boolean;
-  max_passages_per_doc: number;
-  keyword_filters?: TSearchKeywordFilters;
-  year_range: [string, string];
-  sort_field: string | null;
-  sort_order: string;
-  page_size: number;
-  limit: number;
-  offset: number;
-  family_ids?: string[] | null;
-  document_ids?: string[] | null;
+  concept_filters: { name: string; value: string }[];
   continuation_tokens?: string[] | null;
   corpus_import_ids: string[];
+  document_ids?: string[] | null;
+  exact_match: boolean;
+  family_ids?: string[] | null;
+  keyword_filters?: TSearchKeywordFilters;
+  limit: number;
+  max_passages_per_doc: number;
   metadata: TSearchCriteriaMeta[];
-  concept_filters: { name: string; value: string }[];
+  offset: number;
+  page_size: number;
+  query_string: string;
+  sort_field: string | null;
+  sort_order: string;
+  sort_within_page: boolean;
+  year_range: [string, string];
   // for internal use
   runSearch?: boolean;
 };

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -47,6 +47,10 @@ export default function buildSearchQuery(
     query.exact_match = routerQuery[QUERY_PARAMS.exact_match] === "true";
   }
 
+  if (routerQuery[QUERY_PARAMS.sort_within_page]) {
+    query.sort_within_page = routerQuery[QUERY_PARAMS.sort_within_page] === "true";
+  }
+
   if (routerQuery[QUERY_PARAMS.offset]) {
     query.offset = Number(routerQuery[QUERY_PARAMS.offset]);
   }


### PR DESCRIPTION
# What's changed

- Added `sp` query param for `sort_within_page` search API param.
- `sp` is treated as `false` by default (sort by relevance).
- Added support for this query param when performing searches.
- Updated `SearchSettings` component to render "Relevance" and "Document position" options on the document page.

## Why?

Following a recent demo, there is a strong need to change the default passage searching back to relevance, but also provide the user flexibility.

## Screenshots?

Document page with default passage sorting (by relevance):
<img width="1335" alt="Screenshot 2025-05-01 at 14 37 46" src="https://github.com/user-attachments/assets/28d90474-e5f0-49c7-ae34-81911be2ce0d" />

Search settings dropdown options:
<img width="449" alt="Screenshot 2025-05-01 at 14 37 54" src="https://github.com/user-attachments/assets/fac54f80-eb8b-4c2f-a3df-6d1d02c2ab6e" />

Document page with passages sorted by document position:
<img width="1337" alt="Screenshot 2025-05-01 at 14 38 06" src="https://github.com/user-attachments/assets/c630aaab-714d-47fe-9ac5-473fb7235153" />
