### PR TITLE
Fix: Revert accidental CCLW theme changes

### DIFF
--- a/themes/cclw/components/Footer.tsx
+++ b/themes/cclw/components/Footer.tsx
@@ -19,8 +19,124 @@ const Footer = () => {
   };
 
   return (
-    <footer className="flex justify-center bg-[rebeccapurple]">
-      <span className="my-12 text-text-light text-2xl font-medium">Climate Case Chart</span>
+    <footer className="flex flex-col">
+      <div className="py-12">
+        <SiteWidth>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="footer__section" data-cy="footer-cclw">
+              <div className="font-medium text-base">Climate Change Laws of the World</div>
+              <ul className="mb-6">
+                {MENU_LINKS.map((link) => (
+                  <li key={link.href} className="mb-2">
+                    {renderLink(link)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div key={GRI_LINKS.title} className="footer__section" data-cy="footer-gri">
+              <div className="font-medium text-base">{GRI_LINKS.title}</div>
+              <ul>
+                {GRI_LINKS.links.map((link) => (
+                  <li key={link.text} className="mb-2">
+                    {renderLink(link)}
+                  </li>
+                ))}
+              </ul>
+              <div className="footer__section">
+                <ul>
+                  <li className="mb-2">
+                    For media enquiries or queries about research and policy analysis contact{" "}
+                    <ExternalLink url="mailto:gri.cgl@lse.ac.uk">gri.cgl@lse.ac.uk</ExternalLink>
+                  </li>
+                </ul>
+              </div>
+              <div className="footer__section">
+                <div>Follow Grantham Research Institute</div>
+                <div className="flex items-start gap-6 footer__social-links">
+                  <ExternalLink url="https://twitter.com/GRI_LSE">
+                    <img src="/images/social/twitter_col.svg" alt="Twitter Logo" />
+                  </ExternalLink>
+                  <ExternalLink url="https://www.linkedin.com/company/grantham-research-institute-lse/">
+                    <img src="/images/social/linkedIn_col.svg" alt="LinkedIn Logo" />
+                  </ExternalLink>
+                  <ExternalLink url="https://www.youtube.com/user/GranthamResearch">
+                    <img src="/images/social/youtube_col.svg" alt="YouTube Logo" />
+                  </ExternalLink>
+                </div>
+              </div>
+            </div>
+
+            <div className="footer__section">
+              <div className="font-medium text-base">Climate Policy Radar</div>
+              <p>Using AI and data science to map the world's climate policies</p>
+              <ul className="mb-6" data-cy="footer-cpr-links">
+                <li className="mb-1">
+                  Visit the <ExternalLink url="https://www.climatepolicyradar.org">Climate Policy Radar website</ExternalLink>
+                </li>
+                <li className="mb-1">
+                  <ExternalLink url="https://3566c5a7.sibforms.com/serve/MUIEAPkXK4liqQjleE87527EfcD9gDzY26dQhnJOxNeXZK_TvEAjl_Qu7rrkysJS2ODrj1LioiH24HTGbul2vS1sAxYCPHtu7PgnhZrAE9yCfaFrJ7vzmvBc3u87cs_pkC_99nQ2AqBONHtLwErrV7mcVga2qNlO1xetSeqVVWYsrVPRjg6Rc978eQEMasGQc4PFgIfMFza8TJEv">
+                    Newsletter
+                  </ExternalLink>
+                </li>
+                <li className="mb-1">
+                  <ExternalLink url="https://www.climatepolicyradar.org/contact">Contact</ExternalLink>
+                </li>
+              </ul>
+              <div className="footer__section">
+                <div>Follow Climate Policy Radar</div>
+                <div className="flex items-start gap-6 footer__social-links">
+                  <ExternalLink url="https://twitter.com/climatepolradar">
+                    <img src="/images/social/twitter_col.svg" alt="Twitter Logo" />
+                  </ExternalLink>
+                  <ExternalLink url="https://www.linkedin.com/company/climate-policy-radar">
+                    <img src="/images/social/linkedIn_col.svg" alt="LinkedIn Logo" />
+                  </ExternalLink>
+                  <ExternalLink url="https://www.youtube.com/channel/UCjcQnXKzZmo7r9t-RnHjbnA">
+                    <img src="/images/social/youtube_col.svg" alt="YouTube Logo" />
+                  </ExternalLink>
+                  <ExternalLink url="https://github.com/climatepolicyradar/">
+                    <img src="/images/social/github-white.svg" alt="GitHub Logo" />
+                  </ExternalLink>
+                </div>
+              </div>
+              <div className="footer__section mt-4">
+                <Feedback />
+              </div>
+            </div>
+          </div>
+        </SiteWidth>
+      </div>
+      <div className="footer__base">
+        <SiteWidth extraClasses="flex flex-1 items-end h-full pt-[114px] flex-wrap text-sm lg:text-base lg:pt-0 lg:gap-6">
+          <p className="lg:mb-6">Copyright © LSE {new Date().getFullYear()}</p>
+          <div className="ml-6 flex flex-wrap gap-6 lg:mb-6 lg:ml-0">
+            <ExternalLink url="https://www.climatepolicyradar.org/privacy-policy" className="text-secondary-700 underline">
+              Privacy policy
+            </ExternalLink>
+            <LinkWithQuery href={"/terms-of-use"} className="text-secondary-700 underline">
+              Terms of use
+            </LinkWithQuery>
+          </div>
+          <div className="mb-6 items-center flex flex-nowrap flex-1 gap-6 basis-full lg:basis-auto lg:justify-end" data-cy="footer-partners">
+            <ExternalLink className="flex" url="https://www.lse.ac.uk/">
+              <span className="flex" data-cy="lse-logo">
+                <Image src="/images/partners/lse-logo.png" alt="London School of Economics logo" width={31} height={32} />
+              </span>
+            </ExternalLink>
+            <ExternalLink className="flex" url="https://www.lse.ac.uk/granthaminstitute/">
+              <span className="flex" data-cy="gri-logo">
+                <Image src="/images/cclw/partners/gri-logo.png" alt="Grantham Research Institute logo" width={169} height={32} />
+              </span>
+            </ExternalLink>
+            <ExternalLink className="flex" url="https://www.climatepolicyradar.org">
+              <span className="flex" data-cy="cpr-logo">
+                <Image src="/images/cclw/partners/cpr-logo.png" alt="Climate Policy Radar logo" width={232} height={42} />
+              </span>
+            </ExternalLink>
+          </div>
+        </SiteWidth>
+      </div>
     </footer>
   );
 };

--- a/themes/cclw/components/Header.tsx
+++ b/themes/cclw/components/Header.tsx
@@ -6,7 +6,10 @@ import { useRouter } from "next/router";
 
 export const CCLWLogo = (
   <LinkWithQuery href={`/`} cypress="cclw-logo">
-    <span className="text-text-light text-2xl font-medium">Climate Case Chart</span>
+    <div className="max-h-[56px] flex items-center flex-nowrap gap-2">
+      <Image src="/images/cclw/cclw-logo-globe.png" alt="Climate Change Laws of the World logo globe" width={60} height={60} />
+      <Image src="/images/cclw/cclw-logo-text-light.svg" alt="Climate Change Laws of the World logo text" width={197} height={30} />
+    </div>
   </LinkWithQuery>
 );
 
@@ -18,7 +21,7 @@ const Header = () => {
 
   return (
     <NavBar
-      headerClasses={`min-h-12 bg-[rebeccapurple] ${!showLogo && !showSearch ? "!h-[72px]" : ""}`}
+      headerClasses={`min-h-12 bg-cclw-dark ${!showLogo && !showSearch ? "!h-[72px]" : ""}`}
       logo={CCLWLogo}
       menu={<Menu />}
       showLogo={showLogo}


### PR DESCRIPTION
# What's changed

- Revert CCLW `Header` logo and background colour.
- Revert CCLW `Footer` removed content.

## Why?

Accidentally included in #487 when testing theme changes. Oops!