### PR TITLE
fix: remove link to non-existing map

### DIFF
--- a/themes/ccc/components/Instructions.tsx
+++ b/themes/ccc/components/Instructions.tsx
@@ -41,14 +41,15 @@ const Instructions = () => {
           </div>
         ))}
       </div>
-      <div className="hidden md:block absolute top-0 right-0 -translate-y-[140%] 2xl:top-auto 2xl:bottom-0 2xlright-full 2xl:translate-y-0 2xl:translate-x-[110%]">
+      {/* TODO: reinstate when the world map API is back */}
+      {/* <div className="hidden md:block absolute top-0 right-0 -translate-y-[140%] 2xl:top-auto 2xl:bottom-0 2xlright-full 2xl:translate-y-0 2xl:translate-x-[110%]">
         <Button content="both" rounded className="!bg-blueGray-800  hover:!bg-blueGray-700 border !border-blueGray-700" onClick={scrollToMap}>
           Or try exploring by country
           <span className={`hover:animate-none ${isAnimated ? "animate-bounce" : ""}`}>
             <Icon name="downArrow" />
           </span>
         </Button>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/themes/cclw/components/Instructions.tsx
+++ b/themes/cclw/components/Instructions.tsx
@@ -41,14 +41,15 @@ const Instructions = () => {
           </div>
         ))}
       </div>
-      <div className="hidden md:block absolute top-0 right-0 -translate-y-[140%] 2xl:top-auto 2xl:bottom-0 2xlright-full 2xl:translate-y-0 2xl:translate-x-[110%]">
+      {/* TODO: reinstate when the world map API is back */}
+      {/* <div className="hidden md:block absolute top-0 right-0 -translate-y-[140%] 2xl:top-auto 2xl:bottom-0 2xlright-full 2xl:translate-y-0 2xl:translate-x-[110%]">
         <Button content="both" rounded className="!bg-blueGray-800  hover:!bg-blueGray-700 border !border-blueGray-700" onClick={scrollToMap}>
           Or try exploring by country
           <span className={`hover:animate-none ${isAnimated ? "animate-bounce" : ""}`}>
             <Icon name="downArrow" />
           </span>
         </Button>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -39,6 +39,7 @@ const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
         <SiteWidth extraClasses="my-12" data-cy="powered-by">
           <PoweredBy />
         </SiteWidth>
+        {/* TODO: reinstate when the world map API is back */}
         {/* <FullWidth id="world-map" extraClasses="hidden pt-6 md:block">
           <Heading level={2} extraClasses="text-center text-3xl xl:text-4xl">
             Explore by country

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -59,6 +59,7 @@ const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exact
             </SiteWidth>
           </section>
         </main>
+        {/* TODO: reinstate when the world map API is back */}
         {/* <FullWidth extraClasses="hidden my-6 md:block">
           <WorldMap showLitigation />
         </FullWidth> */}


### PR DESCRIPTION
# What's changed
- tmp removes link to map, which is also tmp removed

## Why?
- APIs powering the maps are unavailable due to performance reasons

## Screenshots?
| before | after |
|---|---|
| ![Screenshot 2025-05-01 at 15 03 17](https://github.com/user-attachments/assets/600377f4-9f47-4852-afe8-19f1b93bcabe) | ![Screenshot 2025-05-01 at 15 03 34](https://github.com/user-attachments/assets/820b2d04-e86f-49f5-aae3-8d1fc30e81a3) |
