### PR TITLE
Fix: Iterate passage sorting options text

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -134,7 +134,7 @@ export const SearchSettings = ({
                   onClick={(e) => handlePassagesOrderClick(e, "true")}
                   isActive={getCurrentPassagesOrderChoice(queryParams) === true}
                 >
-                  Position in document
+                  Page number
                 </SearchSettingsItem>
               </SearchSettingsList>
             </div>

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -83,6 +83,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   const router = useRouter();
   const qsSearchString = router.query[QUERY_PARAMS.query_string];
   const exactMatchQuery = !!router.query[QUERY_PARAMS.exact_match];
+  const passagesByPosition = router.query[QUERY_PARAMS.passages_by_position] === "true";
   const startingPassage = Number(router.query.passage) || 0;
 
   // TODO: Remove this once we have hard launched concepts in product.
@@ -238,7 +239,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                                   </span>
                                 )}
                               </div>
-                              <p className="text-sm">Sorted by search relevance</p>
+                              <p className="text-sm">Sorted by {passagesByPosition ? "page number" : "search relevance"}</p>
                             </>
                           )}
                         </div>


### PR DESCRIPTION
# What's changed

- Sort option text changes.
- "Sorted by" text updates accordingly.

## Why?

Alan feedback.

## Screenshots?

<img width="449" alt="Screenshot 2025-05-01 at 17 09 07" src="https://github.com/user-attachments/assets/4f31ac91-3176-477e-9560-5bf75b2088a3" />
