### PR TITLE
APP 540: concept picker changes

### DIFF
--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -7,6 +7,7 @@ import { start } from "repl";
 
 type TProps = {
   title: string;
+  startOpen?: boolean;
   open?: boolean;
   overflowOverride?: boolean;
   children: React.ReactNode;
@@ -18,7 +19,8 @@ type TProps = {
 
 export const Accordian = ({
   title,
-  open = false,
+  startOpen = false,
+  open,
   overflowOverride,
   fixedHeight = "300px",
   children,
@@ -26,9 +28,10 @@ export const Accordian = ({
   headContent,
   ...props
 }: TProps) => {
-  const [isOpen, setIsOpen] = useState(open);
+  const [isOpen, setIsOpen] = useState(startOpen);
 
   useEffect(() => {
+    if (open === undefined) return;
     setIsOpen(open);
   }, [open]);
 

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -22,7 +22,7 @@ export function Select({ defaultValue, value, options, onValueChange, container 
 
   return (
     <BaseSelect.Root defaultValue={defaultValue} onValueChange={handleValueChange} value={value} alignItemToTrigger={false}>
-      <BaseSelect.Trigger className="flex items-center justify-between gap-2 px-2 h-[30px] rounded-sm text-sm m-0 outline-0 select-none cursor-default hover:border-inputSelected active:bg-surface-ui data-popup-open:bg-surface-ui focus:border-inputSelected">
+      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-inputSelected active:bg-surface-ui data-popup-open:bg-surface-ui focus:border-inputSelected">
         <BaseSelect.Value placeholder="" />
         <BaseSelect.Icon className="flex">
           <LuChevronsUpDown height="12" width="12" />

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -112,7 +112,7 @@ const SearchFilters = ({
 
       <AppliedFilters filterChange={handleFilterChange} concepts={conceptsData} />
       {themeConfigStatus === "success" && themeConfig.categories && (
-        <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} open>
+        <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} startOpen>
           <InputListContainer>
             {themeConfig.categories?.options?.map(
               (option) =>
@@ -149,7 +149,7 @@ const SearchFilters = ({
               title={filter.label}
               data-cy={filter.label}
               key={filter.label}
-              open={filter.startOpen === "true" || !!query[QUERY_PARAMS[filter.taxonomyKey]]}
+              startOpen={filter.startOpen === "true" || !!query[QUERY_PARAMS[filter.taxonomyKey]]}
               showFade={filter.showFade}
             >
               <InputListContainer>
@@ -191,7 +191,7 @@ const SearchFilters = ({
       <Accordian
         title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="regions"
-        open={!!query[QUERY_PARAMS.region]}
+        startOpen={!!query[QUERY_PARAMS.region]}
       >
         <InputListContainer>
           {regions.map((region) => (
@@ -229,7 +229,7 @@ const SearchFilters = ({
       <Accordian
         title={getFilterLabel("Date", "date", query[QUERY_PARAMS.category], themeConfig)}
         data-cy="date-range"
-        open={!!query[QUERY_PARAMS.year_range]}
+        startOpen={!!query[QUERY_PARAMS.year_range]}
       >
         <DateRange type="year_range" handleChange={handleYearChange} defaultValues={searchCriteria.year_range} min={minYear} max={thisYear} />
       </Accordian>

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -96,9 +96,9 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
       <div>{title}</div>
       {/* SCROLL AREA */}
       <div className="flex-1 flex flex-col gap-5 overflow-y-scroll scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker">
-        <p className="text-xs">
-          This feature automatically detects climste concepts in documents. Accuracy is not 100%.{" "}
-          <LinkWithQuery href="/faq" className="underline">
+        <p className="text-sm">
+          This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+          <LinkWithQuery href="/faq" className="underline" target="_blank">
             Learn more
           </LinkWithQuery>
         </p>
@@ -112,7 +112,8 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
               className="py-1 text-xs h-[30px]"
             />
           )}
-          <div className="basis-3/10 shrink-0 relative">
+          <div className="basis-3/10 shrink-0 relative flex items-center">
+            <label className="text-sm text-text-tertiary">Sort:</label>
             <Select
               defaultValue="A-Z"
               value={sort}

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -95,7 +95,7 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
     <div className={`relative flex flex-col gap-5 max-h-full pb-5 ${containerClasses}`} ref={ref}>
       <div>{title}</div>
       {/* SCROLL AREA */}
-      <div className="flex-1 flex flex-col gap-5 overflow-y-scroll scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker">
+      <div className="flex-1 flex flex-col gap-5 overflow-y-auto scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker">
         <p className="text-sm">
           This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
           <LinkWithQuery href="/faq" className="underline" target="_blank">

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -127,16 +127,23 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
         <div className={`flex flex-col text-sm border-t border-border-light ${sort === "A-Z" ? "gap-2 border-t-0" : ""}`}>
           {/* GROUPED SORT */}
           {sort === "Grouped" &&
-            rootConcepts.map((rootConcept) => {
+            rootConcepts.map((rootConcept, rootConceptIndex) => {
               const filteredConcepts = filterConcepts(conceptsGrouped[rootConcept.wikibase_id] || [], search);
               if (filteredConcepts.length === 0) return null;
-              const isAnySelected = filteredConcepts.some((concept) => isSelected(router.query[QUERY_PARAMS.concept_name], concept.preferred_label));
+              // Starts open if:
+              // - any of the concepts in the root concept are selected
+              // OR
+              // - it is the first root concept
+              const startOpen =
+                filteredConcepts.some((concept) => isSelected(router.query[QUERY_PARAMS.concept_name], concept.preferred_label)) ||
+                rootConceptIndex === 0;
               return (
                 <Accordian
                   title={rootConcept.preferred_label.slice(0, 1).toUpperCase() + rootConcept.preferred_label.slice(1)}
                   key={rootConcept.wikibase_id}
                   fixedHeight="100%"
-                  open={isAnySelected || search !== ""}
+                  startOpen={startOpen}
+                  open={search === "" ? undefined : true}
                   className="py-3 border-b border-border-lighter"
                 >
                   <div className="flex flex-col gap-2 pb-2">


### PR DESCRIPTION
# What's changed
- Fix typo
- Default to open "targets" root concept by default
- Add "Sort:" label to the sort select
- Fix an inadvertent issue I created by removing "startOpen" with "open" to control the accordion from outside of the component. I have restored "startOpen" so that both the start state and the change of state are supported.

## Why?
- Feedback from Conor and the team

## Screenshots?
![Screenshot 2025-05-07 at 12 05 16](https://github.com/user-attachments/assets/60b4ab9d-9727-4fa7-b021-c61336de91a3)
