### PR TITLE
Allow for more padding in the bottom of the nav menu on mobile

### DIFF
--- a/src/components/atoms/SlideOut/SlideOut.tsx
+++ b/src/components/atoms/SlideOut/SlideOut.tsx
@@ -41,7 +41,7 @@ export const SlideOut = ({ children, showCloseButton = true }: SlideOutProps) =>
           initial={{ translateX: "-100px" }}
           animate={{ opacity: 1, translateX: 0, transition: { duration: 0.25, ease: [0.04, 0.62, 0.23, 0.98] } }}
           exit={{ opacity: 0, transition: { duration: 0 } }}
-          className="absolute z-20 top-0 left-0 h-full bg-white p-5 pb-[70px] w-screen md:px-9 md:z-0 md:w-auto md:min-w-[460px] md:left-full md:pb-0 md:border-r md:border-gray-300"
+          className="absolute z-20 top-0 left-0 h-full bg-white p-5 pb-[180px] w-screen md:px-9 md:z-0 md:w-auto md:min-w-[460px] md:left-full md:pb-0 md:border-r md:border-gray-300"
         >
           {showCloseButton && (
             <button className="absolute z-20 top-5 right-5" onClick={() => setCurrentSlideOut("")}>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -387,7 +387,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                 <Loader size="20px" />
               ) : (
                 <>
-                  <div className="sticky md:top-[72px] h-screen md:h-[calc(100vh-72px)] px-5 bg-white border-r border-gray-300 pt-5 pb-[70px] overflow-y-auto scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 md:pb-0">
+                  <div className="sticky md:top-[72px] h-screen md:h-[calc(100vh-72px)] px-5 bg-white md:border-r border-gray-300 pt-5 pb-[180px] overflow-y-auto scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 md:pb-4">
                     <SearchFilters
                       searchCriteria={searchQuery}
                       query={router.query}
@@ -416,7 +416,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                       />
                     )}
                   </SlideOut>
-                  <div className="absolute z-50 bottom-0 left-0 w-full flex bg-white md:hidden">
+                  <div className="absolute z-50 bottom-0 left-0 w-full flex pb-[100px] bg-white md:hidden">
                     <Button
                       variant={searchDirty ? "solid" : "outlined"}
                       className="m-4 w-full"


### PR DESCRIPTION
# What's changed
- On mobile devices the "close" or "apply" button is not visible. This is a big issue as it means mobile users cannot close the menu when using search
- I have applied a bottom padding on the navigation to alleviate this

Note: this needs to be improved upon in future
- This is quite a heavy-handed approach of just applying a lot of padding at the bottom

## Why?
- Mobile users are blocked from using search correctly

## Screenshots?
First one shows the issue (hidden button), second one shows the solution on an android device (button visible)

![image](https://github.com/user-attachments/assets/02b964ad-9519-473c-b254-1e502bd6289c)
<img width="488" alt="Screenshot 2025-05-08 at 16 44 49" src="https://github.com/user-attachments/assets/3c77cfd9-8bd6-4937-af2a-6b19686aa1a2" />


