### PR TITLE
APP-582: Standardise TypeScript type/interface naming

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,9 +1,9 @@
-type TProps = {
+interface IProps {
   message: string | React.ReactNode;
   icon?: React.ReactNode;
-};
+}
 
-export const Alert = ({ message, icon }: TProps) => {
+export const Alert = ({ message, icon }: IProps) => {
   return (
     <div className="flex">
       <div className="w-[6px] h-full bg-blue-400 rounded-l-lg"></div>

--- a/src/components/EmbeddedPDF.tsx
+++ b/src/components/EmbeddedPDF.tsx
@@ -9,14 +9,14 @@ import Loader from "./Loader";
 
 import { TDocumentPage, TPassage } from "@/types";
 
-type TProps = {
+interface IProps {
   document: TDocumentPage;
   documentPassageMatches?: TPassage[];
   passageIndex?: number;
   startingPassageIndex?: number;
-};
+}
 
-const EmbeddedPDF = ({ document, documentPassageMatches = [], passageIndex = null, startingPassageIndex = 0 }: TProps) => {
+const EmbeddedPDF = ({ document, documentPassageMatches = [], passageIndex = null, startingPassageIndex = 0 }: IProps) => {
   const isLoading = useState(true);
   const containerRef = useRef(null);
   const adobeKey = useContext(AdobeContext);

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,13 +1,13 @@
 import { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   url: string;
   className?: string;
   children?: ReactNode;
   cy?: string;
-};
+}
 
-export const ExternalLink: FC<TProps> = ({ url, className, children, cy }) => {
+export const ExternalLink: FC<IProps> = ({ url, className, children, cy }) => {
   return (
     <a href={url} target="_blank" rel="noopener noreferrer" className={className} data-cy={cy}>
       {children}

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -5,7 +5,7 @@ import { SingleCol } from "@/components/panels/SingleCol";
 import { Heading } from "@/components/typography/Heading";
 import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
 
-type TProps = {
+interface IProps {
   title: string;
   faqs: {
     id?: string;
@@ -14,9 +14,9 @@ type TProps = {
     headContent?: JSX.Element;
   }[];
   accordionMaxHeight?: string;
-};
+}
 
-export const FaqSection = ({ title, faqs, accordionMaxHeight = "464px" }: TProps) => {
+export const FaqSection = ({ title, faqs, accordionMaxHeight = "464px" }: IProps) => {
   return (
     <SingleCol>
       <Heading level={1} extraClasses="custom-header">

--- a/src/components/LinkWithQuery.tsx
+++ b/src/components/LinkWithQuery.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 
 import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
 
-type TProps = {
+interface IProps {
   href: string;
   hash?: string;
   children: React.ReactNode;
@@ -11,9 +11,9 @@ type TProps = {
   passHref?: boolean;
   target?: string;
   cypress?: string;
-};
+}
 
-export const LinkWithQuery = ({ href, hash, children, cypress, ...props }: TProps) => {
+export const LinkWithQuery = ({ href, hash, children, cypress, ...props }: IProps) => {
   const router = useRouter();
   const queryObj = CleanRouterQuery({ ...router.query });
 

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,8 +1,8 @@
-type TProps = {
+interface IProps {
   size?: string;
-};
+}
 
-const Loader = ({ size = "80px" }: TProps) => {
+const Loader = ({ size = "80px" }: IProps) => {
   return (
     <>
       <div className="flex items-start justify-center">

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,10 +1,10 @@
-interface OverlayProps {
+interface IProps {
   active: boolean;
   onClick(): void;
   children?: JSX.Element | string;
 }
 
-const Overlay = ({ active, onClick, children }: OverlayProps): JSX.Element => {
+const Overlay = ({ active, onClick, children }: IProps): JSX.Element => {
   return (
     <div
       onClick={onClick}

--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -4,16 +4,16 @@ import { TPassage } from "@/types";
 import { Icon } from "./atoms/icon/Icon";
 import { usePostHog } from "posthog-js/react";
 
-type TProps = {
+interface IProps {
   passages: TPassage[];
   onClick: (index: number) => void;
   activeIndex?: number;
   pageColour?: string;
-};
+}
 
 const COPY_TIMEOUT = 1000;
 
-const PassageMatches = ({ passages, onClick, activeIndex, pageColour = "textDark" }: TProps) => {
+const PassageMatches = ({ passages, onClick, activeIndex, pageColour = "textDark" }: IProps) => {
   const [hasCopied, setHasCopied] = useState<number | null>(null);
 
   const copyOnClick = (e: React.MouseEvent<HTMLDivElement>, index: number, text: string) => {

--- a/src/components/Pill.stories.tsx
+++ b/src/components/Pill.stories.tsx
@@ -11,35 +11,35 @@ const meta = {
     children: { control: "text" },
   },
 } satisfies Meta<typeof Pill>;
-type Story = StoryObj<typeof Pill>;
+type TStory = StoryObj<typeof Pill>;
 
 export default meta;
 
-export const SearchQuery: Story = {
+export const SearchQuery: TStory = {
   args: {
     children: "Search: electric vehicles",
   },
 };
 
-export const SearchCategory: Story = {
+export const SearchCategory: TStory = {
   args: {
     children: "UNFCCC",
   },
 };
 
-export const SearchRegion: Story = {
+export const SearchRegion: TStory = {
   args: {
     children: "North America",
   },
 };
 
-export const SearchJurisdiction: Story = {
+export const SearchJurisdiction: TStory = {
   args: {
     children: "Canada",
   },
 };
 
-export const SearchDate: Story = {
+export const SearchDate: TStory = {
   args: {
     children: "2020 - 2025",
   },

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,16 +1,16 @@
 import { Icon } from "./atoms/icon/Icon";
 import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
 
-type TProps = {
+interface IProps {
   onClick?: () => void;
   children: React.ReactNode;
   extraClasses?: string;
-};
+}
 
 /**
  * A pill with a remove button. Represents a search query parameter.
  */
-const Pill = ({ children, onClick, extraClasses = "" }: TProps) => {
+const Pill = ({ children, onClick, extraClasses = "" }: IProps) => {
   const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.preventDefault();
     if (onClick) {

--- a/src/components/accordian/Accordian.tsx
+++ b/src/components/accordian/Accordian.tsx
@@ -3,9 +3,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { LuChevronDown, LuChevronUp } from "react-icons/lu";
 
 import { Heading } from "./Heading";
-import { start } from "repl";
 
-type TProps = {
+interface IProps {
   title: string;
   startOpen?: boolean;
   open?: boolean;
@@ -15,7 +14,7 @@ type TProps = {
   showFade?: "true" | "false";
   fixedHeight?: string;
   headContent?: React.ReactNode;
-};
+}
 
 export const Accordian = ({
   title,
@@ -27,7 +26,7 @@ export const Accordian = ({
   showFade = "false",
   headContent,
   ...props
-}: TProps) => {
+}: IProps) => {
   const [isOpen, setIsOpen] = useState(startOpen);
 
   useEffect(() => {

--- a/src/components/accordian/Heading.tsx
+++ b/src/components/accordian/Heading.tsx
@@ -1,7 +1,7 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
-};
+}
 
-export const Heading = ({ children }: TProps) => {
+export const Heading = ({ children }: IProps) => {
   return <div className="text-[15px] font-medium text-textDark">{children}</div>;
 };

--- a/src/components/atoms/SlideOut/SlideOut.stories.tsx
+++ b/src/components/atoms/SlideOut/SlideOut.stories.tsx
@@ -3,9 +3,9 @@ import { SlideOut } from "./SlideOut";
 import { SlideOutContext } from "@/context/SlideOutContext";
 import { useState } from "react";
 
-type TStorybookProps = {
+interface IProps {
   open: boolean;
-};
+}
 
 const meta = {
   title: "Atoms/SlideOut",
@@ -14,12 +14,12 @@ const meta = {
     children: { control: "text" },
     open: { control: "boolean" },
   },
-} satisfies Meta<typeof SlideOut | TStorybookProps>;
-type Story = StoryObj<typeof SlideOut | TStorybookProps>;
+} satisfies Meta<typeof SlideOut | IProps>;
+type TStory = StoryObj<typeof SlideOut | IProps>;
 
 export default meta;
 
-export const Default: Story = {
+export const Default: TStory = {
   args: {
     children: "SlideOut content",
   },

--- a/src/components/atoms/SlideOut/SlideOut.tsx
+++ b/src/components/atoms/SlideOut/SlideOut.tsx
@@ -8,12 +8,12 @@ import { SlideOutContext } from "@/context/SlideOutContext";
 
 import { SLIDE_OUT_DATA_KEY } from "@/constants/dataAttributes";
 
-interface SlideOutProps {
+interface IProps {
   children: React.ReactNode;
   showCloseButton?: boolean;
 }
 
-export const SlideOut = ({ children, showCloseButton = true }: SlideOutProps) => {
+export const SlideOut = ({ children, showCloseButton = true }: IProps) => {
   const ref = useRef(null);
   const { currentSlideOut, setCurrentSlideOut } = useContext(SlideOutContext);
 

--- a/src/components/atoms/button/Button.stories.tsx
+++ b/src/components/atoms/button/Button.stories.tsx
@@ -14,11 +14,11 @@ const meta = {
     disabled: { control: "boolean" },
   },
 } satisfies Meta<typeof Button>;
-type Story = StoryObj<typeof Button>;
+type TStory = StoryObj<typeof Button>;
 
 export default meta;
 
-export const Medium: Story = {
+export const Medium: TStory = {
   args: {
     children: "Button",
     color: "brand",
@@ -30,7 +30,7 @@ export const Medium: Story = {
   },
 };
 
-export const Small: Story = {
+export const Small: TStory = {
   args: {
     children: "Small",
     color: "brand",
@@ -42,7 +42,7 @@ export const Small: Story = {
   },
 };
 
-export const Large: Story = {
+export const Large: TStory = {
   args: {
     children: "Large",
     color: "brand",
@@ -54,7 +54,7 @@ export const Large: Story = {
   },
 };
 
-export const Rounded: Story = {
+export const Rounded: TStory = {
   args: {
     children: "Rounded",
     color: "brand",
@@ -66,7 +66,7 @@ export const Rounded: Story = {
   },
 };
 
-export const Faded: Story = {
+export const Faded: TStory = {
   args: {
     children: "Faded",
     color: "brand",
@@ -78,7 +78,7 @@ export const Faded: Story = {
   },
 };
 
-export const Outlined: Story = {
+export const Outlined: TStory = {
   args: {
     children: "Outlined",
     color: "mono",
@@ -90,7 +90,7 @@ export const Outlined: Story = {
   },
 };
 
-export const Ghost: Story = {
+export const Ghost: TStory = {
   args: {
     children: "Ghost",
     color: "mono",
@@ -102,7 +102,7 @@ export const Ghost: Story = {
   },
 };
 
-export const Disabled: Story = {
+export const Disabled: TStory = {
   args: {
     children: "Disabled",
     color: "brand",
@@ -114,7 +114,7 @@ export const Disabled: Story = {
   },
 };
 
-export const IconAndText: Story = {
+export const IconAndText: TStory = {
   args: {
     color: "brand",
     content: "both",
@@ -141,7 +141,7 @@ export const IconAndText: Story = {
   ),
 };
 
-export const IconOnly: Story = {
+export const IconOnly: TStory = {
   args: {
     children: <Icon name="search2" height="16" width="16" />,
     color: "brand",
@@ -156,7 +156,7 @@ export const IconOnly: Story = {
   },
 };
 
-export const Close: Story = {
+export const Close: TStory = {
   args: {
     content: "icon",
     children: <Icon name="close" />,

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -1,7 +1,7 @@
 import { joinTailwindClasses } from "@/utils/tailwind";
 import { useMemo } from "react";
 
-interface ButtonClassArgs {
+interface IButtonClassArgs {
   className?: string;
   color?: "brand" | "mono";
   content?: "text" | "icon" | "both";
@@ -11,7 +11,7 @@ interface ButtonClassArgs {
   variant?: "solid" | "faded" | "outlined" | "ghost";
 }
 
-type ButtonProps = ButtonClassArgs & React.ComponentProps<"button">;
+type TProps = IButtonClassArgs & React.ComponentProps<"button">;
 
 export const getButtonClasses = ({
   className,
@@ -21,7 +21,7 @@ export const getButtonClasses = ({
   rounded = false,
   size = "medium",
   variant = "solid",
-}: ButtonClassArgs) => {
+}: IButtonClassArgs) => {
   const baseClasses =
     "flex flex-row items-center justify-center text-sm leading-3.5 font-medium transition duration-200 focus-visible:outline-2 outline-offset-2";
 
@@ -89,7 +89,7 @@ export const Button = ({
   rounded = false,
   variant = "solid",
   ...props
-}: ButtonProps) => {
+}: TProps) => {
   const classes = useMemo(
     () => getButtonClasses({ className, color, content, disabled, size, rounded, variant }),
     [className, color, content, disabled, size, rounded, variant]

--- a/src/components/atoms/icon/Icon.stories.tsx
+++ b/src/components/atoms/icon/Icon.stories.tsx
@@ -18,10 +18,10 @@ const meta = {
   },
 } satisfies Meta<typeof Icon>;
 
-type Story = StoryObj<typeof Icon>;
+type TStory = StoryObj<typeof Icon>;
 export default meta;
 
-export const AllIcons: Story = {
+export const AllIcons: TStory = {
   args: {
     color: "#505050",
     height: "40",
@@ -42,7 +42,7 @@ export const AllIcons: Story = {
   ),
 };
 
-export const Primary: Story = {
+export const Primary: TStory = {
   args: {
     color: "#505050",
     name: "close",

--- a/src/components/atoms/icon/Icon.tsx
+++ b/src/components/atoms/icon/Icon.tsx
@@ -43,7 +43,7 @@ export const iconNames = [
   "viewDocumentCoverPage",
 ] as const;
 
-export type IconName = (typeof iconNames)[number];
+export type TIconName = (typeof iconNames)[number];
 
 interface IconProps {
   color?: string;
@@ -52,7 +52,7 @@ interface IconProps {
 }
 
 // Should never be exported. Import the Icon component instead.
-const allIcons: Record<IconName, (IconProps) => JSX.Element> = {
+const allIcons: Record<TIconName, (IconProps) => JSX.Element> = {
   accordionClose: ({ color = "currentColor", height = "20", width = "20" }) => (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" style={{ width: `${width}px`, height: `${height}px` }}>
       <g>
@@ -616,11 +616,11 @@ const allIcons: Record<IconName, (IconProps) => JSX.Element> = {
   ),
 };
 
-interface IconComponentProps extends IconProps {
-  name: IconName;
+interface IProps extends IconProps {
+  name: TIconName;
 }
 
 /**
  * Renders an SVG icon from our internal icons library. All icons are SVG markup as JSX, allowing us to set currentColor to colour them.
  */
-export const Icon = ({ name, ...iconProps }: IconComponentProps) => allIcons[name](iconProps);
+export const Icon = ({ name, ...iconProps }: IProps) => allIcons[name](iconProps);

--- a/src/components/atoms/input/Input.stories.tsx
+++ b/src/components/atoms/input/Input.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     placeholder: { control: "text" },
   },
 } satisfies Meta<typeof Input>;
-type Story = StoryObj<typeof Input>;
+type TStory = StoryObj<typeof Input>;
 
 export default meta;
 
@@ -27,12 +27,12 @@ const useInputContext = ({ ...props }) => {
   return <Input value={value} onChange={handleChange} onClear={handleClear} {...props} />;
 };
 
-export const Default: Story = {
+export const Default: TStory = {
   args: {},
   render: useInputContext,
 };
 
-export const Clearable: Story = {
+export const Clearable: TStory = {
   args: {
     clearable: true,
     icon: undefined,
@@ -43,7 +43,7 @@ export const Clearable: Story = {
   render: useInputContext,
 };
 
-export const IconRight: Story = {
+export const IconRight: TStory = {
   args: {
     clearable: false,
     icon: "search",
@@ -54,7 +54,7 @@ export const IconRight: Story = {
   render: useInputContext,
 };
 
-export const IconLeft: Story = {
+export const IconLeft: TStory = {
   args: {
     clearable: false,
     icon: "add",

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -1,20 +1,20 @@
 import { Input as BaseInput } from "@base-ui-components/react";
-import { Icon, IconName, iconNames } from "@/components/atoms/icon/Icon";
+import { Icon, TIconName, iconNames } from "@/components/atoms/icon/Icon";
 import { joinTailwindClasses } from "@/utils/tailwind";
 import { useMemo } from "react";
 
-interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
+interface IProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
   clearable?: boolean;
   containerClasses?: string;
   color?: "brand" | "mono";
-  icon?: IconName | React.ReactNode;
+  icon?: TIconName | React.ReactNode;
   iconOnLeft?: boolean;
   inputClasses?: string;
   onClear?: () => void;
   size?: "small" | "medium" | "large";
 }
 
-const isIconName = (icon: unknown): icon is IconName => iconNames.includes(icon as IconName);
+const isIconName = (icon: unknown): icon is TIconName => iconNames.includes(icon as TIconName);
 
 export const Input = ({
   className: _className,
@@ -28,7 +28,7 @@ export const Input = ({
   onClear,
   value,
   ...props
-}: InputProps) => {
+}: IProps) => {
   const classes = useMemo(() => {
     /* Colour */
 

--- a/src/components/atoms/popover/Popover.stories.tsx
+++ b/src/components/atoms/popover/Popover.stories.tsx
@@ -12,13 +12,13 @@ const meta = {
     trigger: { control: false },
   },
 } satisfies Meta<typeof Popover>;
-type Story = StoryObj<typeof Popover>;
+type TStory = StoryObj<typeof Popover>;
 
 export default meta;
 
 const trigger = <Button>Trigger</Button>;
 
-export const WithChildren: Story = {
+export const WithChildren: TStory = {
   args: {
     children: "Hello, I am a popover!",
     openOnHover: false,
@@ -26,7 +26,7 @@ export const WithChildren: Story = {
   },
 };
 
-export const WithElements: Story = {
+export const WithElements: TStory = {
   args: {
     description: "This is the popover description. Lots of text can go here, if you'd like.",
     link: {

--- a/src/components/atoms/popover/Popover.tsx
+++ b/src/components/atoms/popover/Popover.tsx
@@ -34,9 +34,9 @@ interface IPopoverChildrenProps extends IPopoverGenericProps {
   link?: never;
 }
 
-type TPopoverProps = IPopoverElementProps | IPopoverChildrenProps;
+type TProps = IPopoverElementProps | IPopoverChildrenProps;
 
-export const Popover = ({ children, description, link, onOpenChange, openOnHover = false, popupClasses = "", title, trigger }: TPopoverProps) => {
+export const Popover = ({ children, description, link, onOpenChange, openOnHover = false, popupClasses = "", title, trigger }: TProps) => {
   const allPopupClasses = joinTailwindClasses(
     "p-3 max-w-[350px] bg-surface-light border border-border-light rounded-md shadow-md text-sm leading-normal select-none focus-visible:outline-0",
     popupClasses

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -7,7 +7,7 @@ type TSelectOption = {
   value: string;
 };
 
-interface SelectProps {
+interface IProps {
   defaultValue?: string;
   value?: string;
   options?: TSelectOption[];
@@ -15,7 +15,7 @@ interface SelectProps {
   container?: HTMLElement | RefObject<HTMLElement> | null;
 }
 
-export function Select({ defaultValue, value, options, onValueChange, container = null }: SelectProps) {
+export function Select({ defaultValue, value, options, onValueChange, container = null }: IProps) {
   const handleValueChange = (value: string) => {
     onValueChange?.(value);
   };

--- a/src/components/blocks/CountryHeader.tsx
+++ b/src/components/blocks/CountryHeader.tsx
@@ -6,15 +6,15 @@ import { Heading } from "@/components/typography/Heading";
 
 import { TGeographyStats, TGeography, TTheme } from "@/types";
 
-type TProps = {
+interface IProps {
   country: TGeographyStats;
   targetCount: number;
   onTargetClick: () => void;
   theme: TTheme;
   totalProjects: number;
-};
+}
 
-export const CountryHeader = ({ country, targetCount, onTargetClick, theme, totalProjects }: TProps) => {
+export const CountryHeader = ({ country, targetCount, onTargetClick, theme, totalProjects }: IProps) => {
   const configQuery = useConfig();
   const { data: { regions = [], countries = [] } = {} } = configQuery;
 

--- a/src/components/blocks/FilterOptions.tsx
+++ b/src/components/blocks/FilterOptions.tsx
@@ -16,13 +16,13 @@ const getTaxonomyAllowedValues = (corporaKey: string, taxonomyKey: string, corpu
   return allowedValues;
 };
 
-type TProps = {
+interface IProps {
   filter: TThemeConfigFilter;
   query: ParsedUrlQuery;
   handleFilterChange: Function;
   corpus_types: TCorpusTypeDictionary;
   themeConfig: TThemeConfig;
-};
+}
 
 const filterIsSelected = (queryValue: string | string[] | undefined, option: string) => {
   if (!queryValue) {
@@ -35,7 +35,7 @@ const filterIsSelected = (queryValue: string | string[] | undefined, option: str
   }
 };
 
-export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types, themeConfig }: TProps) => {
+export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types, themeConfig }: IProps) => {
   const [search, setSearch] = useState("");
 
   // If the filter has its own options defined, display them

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -42,7 +42,7 @@ const isCategoryChecked = (selectedCatgeory: string | undefined, themeConfigCate
   return false;
 };
 
-type TSearchFiltersProps = {
+interface IProps {
   searchCriteria: TSearchCriteria;
   query: ParsedUrlQuery;
   regions: TGeography[];
@@ -55,7 +55,7 @@ type TSearchFiltersProps = {
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
   featureFlags: Record<string, string | boolean>;
-};
+}
 
 const SearchFilters = ({
   searchCriteria,
@@ -70,7 +70,7 @@ const SearchFilters = ({
   handleClearSearch,
   handleDocumentCategoryClick,
   featureFlags,
-}: TSearchFiltersProps) => {
+}: IProps) => {
   const { status: themeConfigStatus, themeConfig } = useGetThemeConfig();
   const [showClear, setShowClear] = useState(false);
   const { currentSlideOut, setCurrentSlideOut } = useContext(SlideOutContext);

--- a/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -8,23 +8,23 @@ const meta = {
     layout: "centered",
   },
 } satisfies Meta<typeof BreadCrumbs>;
-type Story = StoryObj<typeof BreadCrumbs>;
+type TStory = StoryObj<typeof BreadCrumbs>;
 
 export default meta;
 
-export const SearchResults: Story = {
+export const SearchResults: TStory = {
   args: {
     label: "Search results",
   },
 };
 
-export const Geography: Story = {
+export const Geography: TStory = {
   args: {
     label: "United Kingdom",
   },
 };
 
-export const Document: Story = {
+export const Document: TStory = {
   args: {
     category: {
       href: "/search",

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -10,12 +10,12 @@ type TBreadcrumbLink = {
   cy?: string;
 };
 
-type TProps = {
+interface IProps {
   category?: TBreadcrumbLink;
   family?: TBreadcrumbLink;
   geography?: TBreadcrumbLink;
   label: string | React.ReactNode;
-};
+}
 
 const BreadCrumb = ({ last = false, label, href = null, cy = "" }: TBreadcrumbLink) => {
   const labelShort =
@@ -41,7 +41,7 @@ const BreadCrumb = ({ last = false, label, href = null, cy = "" }: TBreadcrumbLi
 /**
  * Lists the page hierarchy back to the homepage so that the user can better understand where they are, and to easily go back to a previous page.
  */
-export const BreadCrumbs = ({ geography = null, category = null, family = null, label }: TProps) => {
+export const BreadCrumbs = ({ geography = null, category = null, family = null, label }: IProps) => {
   return (
     <ul className="flex items-baseline flex-wrap gap-2 text-sm" data-cy="breadcrumbs">
       <BreadCrumb label="Home" href="/" cy="home" />

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -10,15 +10,15 @@ import { groupByRootConcept } from "@/utils/conceptsGroupedbyRootConcept";
 
 import { TConcept } from "@/types";
 
-type TProps = {
+interface IProps {
   concepts: TConcept[];
   rootConcepts: TConcept[];
   conceptCountsById: Record<string, number>;
   showCounts?: boolean;
   onConceptClick?: (conceptLabel: string) => void;
-};
+}
 
-export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showCounts = true, onConceptClick }: TProps) => {
+export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showCounts = true, onConceptClick }: IProps) => {
   const [openPopoverIds, setOpenPopoverIds] = useState<string[]>([]);
 
   const handleConceptClick = useCallback(

--- a/src/components/controls/ShowHide.tsx
+++ b/src/components/controls/ShowHide.tsx
@@ -1,11 +1,11 @@
-type TShowHideControlProps = {
+interface IProps {
   show: boolean;
   label?: string;
   onClick: () => void;
   className?: string;
-};
+}
 
-export const ShowHide = ({ show, label, onClick, className }: TShowHideControlProps) => {
+export const ShowHide = ({ show, label, onClick, className }: IProps) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     e.preventDefault();
     onClick();

--- a/src/components/cookies/CookieConsent.tsx
+++ b/src/components/cookies/CookieConsent.tsx
@@ -13,10 +13,12 @@ import dynamic from "next/dynamic";
 const ThemeAnalytics = dynamic<{ enableAnalytics: boolean }>(() => import(`/themes/${process.env.THEME}/components/Analytics`));
 
 declare let gtag: Function;
-type Props = {
+
+interface IProps {
   onConsentChange: (consent: boolean) => void;
-};
-export const CookieConsent = ({ onConsentChange }: Props) => {
+}
+
+export const CookieConsent = ({ onConsentChange }: IProps) => {
   const [hide, setHide] = useState(true);
   const [enableAnalytics, setEnableAnalytics] = useState(false);
 

--- a/src/components/dividers/Divider.tsx
+++ b/src/components/dividers/Divider.tsx
@@ -1,11 +1,11 @@
 import { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   color?: string;
   children?: ReactNode;
-};
+}
 
-export const Divider: FC<TProps> = ({ children, color }) => {
+export const Divider: FC<IProps> = ({ children, color }) => {
   const dividerColor = color ?? "bg-gray-200";
 
   return (

--- a/src/components/document/FamilyDocument.tsx
+++ b/src/components/document/FamilyDocument.tsx
@@ -5,12 +5,12 @@ import { getLanguage } from "@/helpers/getLanguage";
 import { TDocumentPage, TLoadingStatus } from "@/types";
 import { getDocumentType } from "@/helpers/getDocumentType";
 
-type TProps = {
+interface IProps {
   document: TDocumentPage;
   matches?: number;
   status?: TLoadingStatus;
   familyMatches?: number;
-};
+}
 
 const loadingIndicator = (
   <span className="flex gap-2 items-center">
@@ -19,7 +19,7 @@ const loadingIndicator = (
   </span>
 );
 
-export const FamilyDocument = ({ document, matches, status, familyMatches }: TProps) => {
+export const FamilyDocument = ({ document, matches, status, familyMatches }: IProps) => {
   const { title, slug, document_role, language, content_type, variant } = document;
   const configQuery = useConfig();
   const { data: { languages = {} } = {} } = configQuery;

--- a/src/components/document/FamilyHead.tsx
+++ b/src/components/document/FamilyHead.tsx
@@ -5,12 +5,12 @@ import { Heading } from "@/components/typography/Heading";
 
 import { MetadataRenderer } from "./renderers/MetadataRenderer";
 
-type TProps = {
+interface IProps {
   family: TFamilyPage;
   onCollectionClick?: (e: any, i: number) => void;
-};
+}
 
-export const FamilyHead = ({ family, onCollectionClick }: TProps) => {
+export const FamilyHead = ({ family, onCollectionClick }: IProps) => {
   // don't show 'more details' if there is no extra metadata
   const hasExtraMetadata = family.metadata?.keyword && family.metadata?.keyword.length > 0;
   const [showMoreDetails, setShowMoreDetails] = useState(!hasExtraMetadata);

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -6,12 +6,12 @@ import { FamilyMeta } from "./FamilyMeta";
 
 import { truncateString } from "@/utils/truncateString";
 
-type TProps = {
+interface IProps {
   family: TFamily;
   children?: ReactNode;
-};
+}
 
-export const FamilyListItem: FC<TProps> = ({ family, children }) => {
+export const FamilyListItem: FC<IProps> = ({ family, children }) => {
   const {
     corpus_type_name,
     family_slug,

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -4,7 +4,7 @@ import { convertDate } from "@/utils/timedate";
 import { TCategory, TCorpusTypeSubCategory } from "@/types";
 import { CountryLinks } from "@/components/CountryLinks";
 
-type TProps = {
+interface IProps {
   category: TCategory;
   corpus_type_name: TCorpusTypeSubCategory;
   source?: string;
@@ -13,9 +13,9 @@ type TProps = {
   topics?: string[];
   author?: string[];
   document_type?: string;
-};
+}
 
-export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name, document_type, source }: TProps) => {
+export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name, document_type, source }: IProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
 

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -5,8 +5,7 @@ import { CountryLinksAsList } from "@/components/CountryLinks";
 
 import { mapFamilyMetadata } from "@/helpers/mapFamilyMetadata";
 
-import { TConcept, TFamilyMetadata, TMCFFamilyMetadata } from "@/types";
-import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { TFamilyMetadata, TMCFFamilyMetadata } from "@/types";
 
 interface MetadataItemProps {
   label: string;

--- a/src/components/document/renderers/MetadataRenderer.tsx
+++ b/src/components/document/renderers/MetadataRenderer.tsx
@@ -6,13 +6,13 @@ import { getApprovedYearFromEvents } from "@/helpers/getApprovedYearFromEvents";
 
 const MultilateralClimateFunds = "MCF";
 
-interface TProps {
+interface IProps {
   family: TFamilyPage;
 }
 
 type TFamilyMetadataUnion = TFamilyMetadata | TMCFFamilyMetadata;
 
-export const MetadataRenderer = ({ family }: TProps) => {
+export const MetadataRenderer = ({ family }: IProps) => {
   const { metadata, organisation, category, geographies, corpus_type_name, published_date, documents } = family || {};
   const document_type = documents && documents.length > 0 ? documents[0].document_type : undefined;
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -28,7 +28,7 @@ type TState = {
   totalNoOfMatches: number;
 };
 
-type TProps = {
+interface IProps {
   initialQueryTerm?: string | string[];
   initialExactMatch?: boolean;
   initialPassage?: number;
@@ -39,7 +39,7 @@ type TProps = {
   familySlug: string;
   // Callback props for state changes
   onExactMatchChange?: (isExact: boolean) => void;
-};
+}
 
 const passageClasses = (canPreview: boolean) => {
   if (canPreview) {
@@ -62,7 +62,7 @@ export const ConceptsDocumentViewer = ({
   vespaFamilyData,
   vespaDocumentData,
   onExactMatchChange,
-}: TProps) => {
+}: IProps) => {
   const router = useRouter();
   const [showSearchOptions, setShowSearchOptions] = useState(false);
   const [showConcepts, setShowConcepts] = useState(false);

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -21,18 +21,18 @@ import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
 import { TDocumentPage, TFamilyPage } from "@/types";
 import { DocumentMetaRenderer } from "./renderers/DocumentMetaRenderer";
 
-type TProps = {
+interface IProps {
   document: TDocumentPage;
   family: TFamilyPage;
   handleViewOtherDocsClick: (e: React.FormEvent<HTMLButtonElement>) => void;
   handleViewSourceClick: (e: React.FormEvent<HTMLButtonElement>) => void;
-};
+}
 
 const containsNonEnglish = (languages: string[]) => {
   return languages.some((lang) => lang !== "eng");
 };
 
-export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handleViewSourceClick }: TProps) => {
+export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handleViewSourceClick }: IProps) => {
   const [showFullSummary, setShowFullSummary] = useState(false);
   const [summary, setSummary] = useState("");
 

--- a/src/components/documents/EmptyPassages.tsx
+++ b/src/components/documents/EmptyPassages.tsx
@@ -1,10 +1,10 @@
 import { Icon } from "@/components/atoms/icon/Icon";
 
-type TProps = {
+interface IProps {
   hasQueryString: boolean;
-};
+}
 
-export const EmptyPassages = ({ hasQueryString }: TProps) => (
+export const EmptyPassages = ({ hasQueryString }: IProps) => (
   <div className="flex flex-col gap-4 flex-1 pt-10 text-center text-gray-600 px-4">
     <div className="text-blue-800 flex justify-center items-center">
       <div className="rounded-full bg-blue-50 p-6 mb-2">

--- a/src/components/documents/UnavailableConcepts.tsx
+++ b/src/components/documents/UnavailableConcepts.tsx
@@ -1,12 +1,12 @@
 import { Icon } from "@/components/atoms/icon/Icon";
 import Link from "next/link";
 
-type TProps = {
+interface IProps {
   unavailableConcepts: string[];
   familySlug: string;
-};
+}
 
-export const UnavailableConcepts = ({ unavailableConcepts, familySlug }: TProps) => (
+export const UnavailableConcepts = ({ unavailableConcepts, familySlug }: IProps) => (
   <div className="border-gray-200 flex flex-col gap-4 flex-1 mt-4 pt-10 border-t text-center text-gray-600 px-4">
     <div className="text-blue-800 flex justify-center items-center">
       <div className="rounded-full bg-blue-50 p-6 mb-2">

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -2,13 +2,13 @@ import { useRef, useEffect } from "react";
 import { Icon } from "@/components/atoms/icon/Icon";
 import { Button } from "@/components/atoms/button/Button";
 
-interface SlideoutProps {
+interface IProps {
   children: JSX.Element | string;
   show: boolean;
   setShow(value: boolean): void;
 }
 
-const Slideout = ({ children, show, setShow }: SlideoutProps) => {
+const Slideout = ({ children, show, setShow }: IProps) => {
   const ref = useRef(null);
 
   // Clicking outside the drawer will close it

--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -13,11 +13,11 @@ import { truncateString } from "@/utils/truncateString";
 
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
 
-type TProps = {
+interface IProps {
   family?: TMatchedFamily;
-};
+}
 
-export const FamilyMatchesDrawer = ({ family }: TProps) => {
+export const FamilyMatchesDrawer = ({ family }: IProps) => {
   const router = useRouter();
 
   if (!family) return null;

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -8,13 +8,14 @@ import PageLevel from "./PageLevel";
 type TState = {
   hasError: boolean;
 };
-type TProps = {
+
+interface IProps {
   children: React.ReactNode;
   level: "top" | "page";
-};
+}
 
-class ErrorBoundary extends React.Component<TProps, TState> {
-  constructor(props: TProps) {
+class ErrorBoundary extends React.Component<IProps, TState> {
+  constructor(props: IProps) {
     super(props);
 
     // Define a state variable to track whether is an error or not

--- a/src/components/error/PageLevel.tsx
+++ b/src/components/error/PageLevel.tsx
@@ -4,11 +4,11 @@ import { ExternalLink } from "@/components/ExternalLink";
 import { Button } from "@/components/atoms/button/Button";
 import { Heading } from "@/components/typography/Heading";
 
-type TProps = {
+interface IProps {
   resetError: () => void;
-};
+}
 
-const PageLevel = ({ resetError }: TProps) => {
+const PageLevel = ({ resetError }: IProps) => {
   return (
     <Layout title={"Application Error"}>
       <section>

--- a/src/components/error/TopLevel.tsx
+++ b/src/components/error/TopLevel.tsx
@@ -2,11 +2,11 @@ import { ExternalLink } from "@/components/ExternalLink";
 import { Button } from "@/components/atoms/button/Button";
 import { Heading } from "@/components/typography/Heading";
 
-type TProps = {
+interface IProps {
   resetError: () => void;
-};
+}
 
-const TopLevel = ({ resetError }: TProps) => {
+const TopLevel = ({ resetError }: IProps) => {
   return (
     <div className="max-w-screen-sm m-auto h-full flex flex-col justify-center p-4 gap-4">
       <Heading level={1}>Sorry, the app has encountered an error</Heading>

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -17,10 +17,10 @@ import { TConcept, TGeography, TThemeConfig } from "@/types";
 
 type TFilterChange = (type: string, value: string) => void;
 
-type TProps = {
+interface IProps {
   filterChange: TFilterChange;
   concepts?: TConcept[];
-};
+}
 
 const handleCountryRegion = (slug: string, dataSet: TGeography[]) => {
   return getCountryName(slug, dataSet);
@@ -154,7 +154,7 @@ const generatePills = (
   return pills;
 };
 
-export const AppliedFilters = ({ filterChange, concepts }: TProps) => {
+export const AppliedFilters = ({ filterChange, concepts }: IProps) => {
   const router = useRouter();
   const configQuery = useConfig();
   const { themeConfig } = useGetThemeConfig();

--- a/src/components/filters/DateRange.tsx
+++ b/src/components/filters/DateRange.tsx
@@ -10,15 +10,15 @@ import { Button } from "@/components/atoms/button/Button";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { currentYear } from "@/constants/timedate";
 
-type TProps = {
+interface IProps {
   type: string;
   handleChange(values: string[], reset?: boolean): void;
   defaultValues: string[];
   min: number;
   max: number;
-};
+}
 
-export const DateRange = ({ handleChange, defaultValues, min, max }: TProps) => {
+export const DateRange = ({ handleChange, defaultValues, min, max }: IProps) => {
   const router = useRouter();
   const [startYear, endYear] = defaultValues;
   const [showDateInput, setShowDateInput] = useState(false);

--- a/src/components/filters/DateRangeInput.tsx
+++ b/src/components/filters/DateRangeInput.tsx
@@ -1,14 +1,14 @@
 import { InputListContainer } from "./InputListContainer";
 
-type TProps = {
+interface IProps {
   label: string;
   name: string;
   value: string;
   handleSubmit(): void;
   handleChange(value: string): void;
-};
+}
 
-export const DateRangeInput = ({ label, name, value, handleSubmit, handleChange }: TProps) => {
+export const DateRangeInput = ({ label, name, value, handleSubmit, handleChange }: IProps) => {
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       handleSubmit();

--- a/src/components/filters/InputListContainer.tsx
+++ b/src/components/filters/InputListContainer.tsx
@@ -1,7 +1,7 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
-};
+}
 
-export const InputListContainer = ({ children }: TProps) => {
+export const InputListContainer = ({ children }: IProps) => {
   return <div className="flex flex-col gap-2">{children}</div>;
 };

--- a/src/components/filters/MultiList.tsx
+++ b/src/components/filters/MultiList.tsx
@@ -3,14 +3,14 @@ import FilterTag from "../labels/FilterTag";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { getCountryName } from "@/helpers/getCountryFields";
 
-type TProps = {
+interface IProps {
   list: string[];
   removeFilter: (type: string, value: string) => void;
   type: string;
   dataCy?: string;
-};
+}
 
-const MultiList = ({ list, removeFilter, type, dataCy }: TProps) => {
+const MultiList = ({ list, removeFilter, type, dataCy }: IProps) => {
   const configQuery = useConfig();
   const { data: { countries = [] } = {} } = configQuery;
 

--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -7,7 +7,7 @@ import { SearchSettingsItem } from "./SearchSettingsItem";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { sortOptions, sortOptionsBrowse } from "@/constants/sortOptions";
 
-type TProps = {
+interface IProps {
   extraClasses?: string;
   handlePassagesClick?: (passagesOption: string) => void;
   handleSearchChange?: (key: string, value: string) => void;
@@ -15,7 +15,7 @@ type TProps = {
   queryParams: ParsedUrlQuery;
   setShowOptions?: (value: boolean) => void;
   settingsButtonRef?: MutableRefObject<any>;
-};
+}
 
 const getCurrentSortChoice = (queryParams: ParsedUrlQuery, isBrowsing: boolean) => {
   const field = queryParams[QUERY_PARAMS.sort_field];
@@ -47,7 +47,7 @@ export const SearchSettings = ({
   queryParams,
   setShowOptions,
   settingsButtonRef,
-}: TProps) => {
+}: IProps) => {
   const searchOptionsRef = useRef(null);
   const [options, setOptions] = useState(sortOptions);
 

--- a/src/components/filters/SearchSettingsItem.tsx
+++ b/src/components/filters/SearchSettingsItem.tsx
@@ -1,12 +1,12 @@
 import { LuCheck } from "react-icons/lu";
 
-type TProps = {
+interface IProps {
   children: React.ReactNode;
   isActive?: boolean;
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
-};
+}
 
-export const SearchSettingsItem = ({ children, isActive, onClick, ...props }: TProps) => (
+export const SearchSettingsItem = ({ children, isActive, onClick, ...props }: IProps) => (
   <a
     className={`flex gap-1 text-white items-center hover:text-white hover:opacity-100 ${isActive ? "" : "opacity-70"}`}
     onClick={onClick}

--- a/src/components/filters/SearchSettingsList.tsx
+++ b/src/components/filters/SearchSettingsList.tsx
@@ -1,8 +1,8 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
-};
+}
 
-export const SearchSettingsList = ({ children, ...props }: TProps) => (
+export const SearchSettingsList = ({ children, ...props }: IProps) => (
   <div className="flex flex-col gap-2" {...props}>
     {children}
   </div>

--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { InputLearnMoreLink } from "./InputLearnMoreLink";
 
-type TProps = {
+interface IProps {
   label?: string;
   checked: boolean;
   name?: string;
@@ -8,13 +8,13 @@ type TProps = {
   learnMoreUrl?: string;
   learnMoreExternal?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
+}
 
-const CheckBox = ({ checked, onChange, name }: TProps) => {
+const CheckBox = ({ checked, onChange, name }: IProps) => {
   return <input type="checkbox" checked={checked || false} onChange={onChange} className="w-[24px] h-[24px]" name={name} />;
 };
 
-export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal }: TProps) => {
+export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal }: IProps) => {
   return (
     <>
       <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""}`}>

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -1,7 +1,7 @@
-type TProps = {
+interface IProps {
   message: string;
-};
+}
 
-export const FormError = ({ message }: TProps) => {
+export const FormError = ({ message }: IProps) => {
   return <div className="error text-red-600">{message}</div>;
 };

--- a/src/components/forms/InputLearnMoreLink.tsx
+++ b/src/components/forms/InputLearnMoreLink.tsx
@@ -1,10 +1,10 @@
-type TProps = {
+interface IProps {
   additionalInfo?: string;
   learnMoreUrl?: string;
   learnMoreExternal?: boolean;
-};
+}
 
-export const InputLearnMoreLink = ({ additionalInfo, learnMoreUrl, learnMoreExternal }: TProps) => {
+export const InputLearnMoreLink = ({ additionalInfo, learnMoreUrl, learnMoreExternal }: IProps) => {
   if (!additionalInfo) return null;
 
   return (

--- a/src/components/forms/Radio.tsx
+++ b/src/components/forms/Radio.tsx
@@ -1,6 +1,6 @@
 import { InputLearnMoreLink } from "./InputLearnMoreLink";
 
-type TProps = {
+interface IProps {
   label?: string;
   checked: boolean;
   name?: string;
@@ -9,13 +9,13 @@ type TProps = {
   learnMoreExternal?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
-};
+}
 
-const Radio = ({ checked, onChange, onClick, name }: TProps) => {
+const Radio = ({ checked, onChange, onClick, name }: IProps) => {
   return <input type="radio" checked={checked || false} onChange={onChange} onClick={onClick ?? onClick} className="w-[24px] h-[24px]" name={name} />;
 };
 
-export const InputRadio = ({ label, checked, onChange, onClick, name, additionalInfo, learnMoreUrl, learnMoreExternal }: TProps) => {
+export const InputRadio = ({ label, checked, onChange, onClick, name, additionalInfo, learnMoreUrl, learnMoreExternal }: IProps) => {
   return (
     <>
       <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""}`}>

--- a/src/components/forms/SearchDropdown.tsx
+++ b/src/components/forms/SearchDropdown.tsx
@@ -5,14 +5,14 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { Icon } from "@/components/atoms/icon/Icon";
 import { systemGeoCodes } from "@/constants/systemGeos";
 
-type TProps = {
+interface IProps {
   show: boolean;
   term: string;
   handleSearchClick: (term: string, filter?: string, filterValue?: string) => void;
   largeSpacing?: boolean;
-};
+}
 
-export const SearchDropdown = ({ show = false, term, handleSearchClick, largeSpacing }: TProps) => {
+export const SearchDropdown = ({ show = false, term, handleSearchClick, largeSpacing }: IProps) => {
   const router = useRouter();
   const configQuery = useConfig();
   const geographies = configQuery.data?.countries || [];

--- a/src/components/forms/SearchForm.tsx
+++ b/src/components/forms/SearchForm.tsx
@@ -4,15 +4,15 @@ import { SearchDropdown } from "./SearchDropdown";
 import { TextInput } from "./TextInput";
 import { Icon } from "@/components/atoms/icon/Icon";
 
-type TProps = {
+interface IProps {
   input?: string;
   placeholder: string;
   size?: "small" | "large" | "default";
   handleSearchInput(term: string): void;
   handleSuggestion?(term: string, filter?: string, filterValue?: string): void;
-};
+}
 
-const SearchForm = ({ input, placeholder, size = "large", handleSearchInput, handleSuggestion }: TProps) => {
+const SearchForm = ({ input, placeholder, size = "large", handleSearchInput, handleSuggestion }: IProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
   const formRef = useRef(null);

--- a/src/components/forms/TextInput.tsx
+++ b/src/components/forms/TextInput.tsx
@@ -1,4 +1,4 @@
-type TProps = {
+interface IProps {
   value?: string;
   type?: string;
   className?: string;
@@ -8,7 +8,7 @@ type TProps = {
   size?: "small" | "large" | "default";
   name?: string;
   onChange?: (value: string) => void;
-};
+}
 
 const iconClasses = (side: "left" | "right", children?: React.ReactNode) => {
   if (children) {
@@ -31,7 +31,7 @@ export const TextInput = ({
   side = "left",
   name,
   ...props
-}: TProps) => {
+}: IProps) => {
   const handleChange = (e: React.FormEvent<HTMLInputElement>): void => {
     if (onChange) {
       onChange(e.currentTarget.value);

--- a/src/components/forms/TypeAhead.tsx
+++ b/src/components/forms/TypeAhead.tsx
@@ -6,16 +6,16 @@ import { TextInput } from "./TextInput";
 import { sortData } from "@/utils/sorting";
 import { Icon } from "@/components/atoms/icon/Icon";
 
-type TProps = {
+interface IProps {
   list: Object[];
   selectedList: string[];
   keyField: string;
   keyFieldDisplay?: string;
   filterType: string;
   handleFilterChange(filterType: string, value: string): void;
-};
+}
 
-export const TypeAhead = ({ list, selectedList, keyField, keyFieldDisplay, filterType, handleFilterChange }: TProps) => {
+export const TypeAhead = ({ list, selectedList, keyField, keyFieldDisplay, filterType, handleFilterChange }: IProps) => {
   const [input, setInput] = useState("");
   const [suggestList, setSuggestList] = useState<Object[]>([]);
 

--- a/src/components/labels/FilterTag.tsx
+++ b/src/components/labels/FilterTag.tsx
@@ -1,8 +1,9 @@
-interface FilterTagProps {
+interface IProps {
   onClick(): void;
   item: string;
 }
-const FilterTag = ({ onClick, item }) => {
+
+const FilterTag = ({ onClick, item }: IProps) => {
   return (
     <div className="rounded bg-cpr-dark text-white flex items-center py-1 px-2">
       <div className="text-xs">{item}</div>

--- a/src/components/labels/Label.tsx
+++ b/src/components/labels/Label.tsx
@@ -1,9 +1,9 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
   extraClasses?: string;
-};
+}
 
-export const Label = ({ children, extraClasses = "" }: TProps) => {
+export const Label = ({ children, extraClasses = "" }: IProps) => {
   return (
     <>
       <span className="bg-blue-600 text-white text-xs font-medium px-1.5 py-0.5 rounded-sm">{children}</span>

--- a/src/components/layouts/LandingPage.tsx
+++ b/src/components/layouts/LandingPage.tsx
@@ -9,7 +9,7 @@ import { getCanonicalUrl } from "@/utils/getCanonicalUrl";
 
 import { TTheme, TThemeConfig } from "@/types";
 
-type TProps = {
+interface IProps {
   title?: string;
   theme?: TTheme;
   description?: string;
@@ -17,9 +17,9 @@ type TProps = {
   metadataKey?: string;
   text?: string;
   children?: ReactNode;
-};
+}
 
-const Layout = ({ children, title, theme, description, themeConfig, metadataKey, text }: TProps) => {
+const Layout = ({ children, title, theme, description, themeConfig, metadataKey, text }: IProps) => {
   const router = useRouter();
 
   return (

--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -14,7 +14,7 @@ import dynamic from "next/dynamic";
 
 const Wrapper = dynamic<{ children: ReactNode }>(() => import(`/themes/${process.env.THEME}/layouts/main`));
 
-type TProps = {
+interface IProps {
   title?: string;
   theme?: TTheme;
   description?: string;
@@ -22,9 +22,9 @@ type TProps = {
   metadataKey?: string;
   text?: string;
   children?: ReactNode;
-};
+}
 
-const Layout: FC<TProps> = ({ children, title, theme, description, themeConfig, metadataKey, text }) => {
+const Layout: FC<IProps> = ({ children, title, theme, description, themeConfig, metadataKey, text }) => {
   const router = useRouter();
   const contextTheme = useContext(ThemeContext);
 

--- a/src/components/map/GeographySelect.tsx
+++ b/src/components/map/GeographySelect.tsx
@@ -3,7 +3,7 @@ import SuggestList from "@/components/filters/SuggestList";
 import { sortData } from "@/utils/sorting";
 import { Icon } from "@/components/atoms/icon/Icon";
 
-interface ByTextInputProps {
+interface IProps {
   title: string;
   list: { [key: string]: {} };
   keyField: string;
@@ -12,7 +12,7 @@ interface ByTextInputProps {
   handleFilterChange(filterType: string, value: string): void;
 }
 
-const GeographySelect = ({ title, list, keyField, keyFieldDisplay, filterType, handleFilterChange }: ByTextInputProps) => {
+const GeographySelect = ({ title, list, keyField, keyFieldDisplay, filterType, handleFilterChange }: IProps) => {
   const [input, setInput] = useState("");
   const [suggestList, setSuggestList] = useState([]);
 
@@ -75,4 +75,5 @@ const GeographySelect = ({ title, list, keyField, keyFieldDisplay, filterType, h
     </div>
   );
 };
+
 export default GeographySelect;

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -1,10 +1,10 @@
-type TLegendProps = {
+interface IProps {
   max: number;
   showLitigation: boolean;
   showMcf: boolean;
-};
+}
 
-export const Legend = ({ max, showLitigation, showMcf }: TLegendProps) => {
+export const Legend = ({ max, showLitigation, showMcf }: IProps) => {
   const scale = [1, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), max];
 
   return (

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -132,11 +132,11 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
   );
 };
 
-type TMapChartProps = {
+interface IProps {
   showLitigation?: boolean;
-};
+}
 
-export default function MapChart({ showLitigation = false }: TMapChartProps) {
+export default function MapChart({ showLitigation = false }: IProps) {
   const configQuery = useConfig();
   const geographiesQuery = useGeographies();
   const { data: { countries: configCountries = [] } = {} } = configQuery;

--- a/src/components/map/ZoomControls.tsx
+++ b/src/components/map/ZoomControls.tsx
@@ -1,13 +1,13 @@
-type TProps = {
+interface IProps {
   mapZoom: number;
   minZoom: number;
   maxZoom: number;
   handleZoomIn: () => void;
   handleZoomOut: () => void;
   handleReset: () => void;
-};
+}
 
-export const ZoomControls = ({ mapZoom, minZoom, maxZoom, handleZoomIn, handleZoomOut, handleReset }: TProps) => {
+export const ZoomControls = ({ mapZoom, minZoom, maxZoom, handleZoomIn, handleZoomOut, handleReset }: IProps) => {
   return (
     <div className="absolute bottom-0 right-0 p-4 flex gap-2">
       <button className="text-xs bg-white text-gray-500 rounded-full border border-gray-300 h-[40px] px-4" onClick={handleReset}>

--- a/src/components/menus/DropdownMenuItem.tsx
+++ b/src/components/menus/DropdownMenuItem.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from "@/components/ExternalLink";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { useRouter } from "next/router";
 
-interface DropdownMenuItemProps {
+interface IProps {
   first?: boolean;
   title: string;
   href: string;
@@ -11,7 +11,7 @@ interface DropdownMenuItemProps {
   cy?: string;
   setShowMenu?(value: boolean): void;
 }
-const DropdownMenuItem = ({ first = false, title, href, target = "", external = false, cy, setShowMenu }: DropdownMenuItemProps) => {
+const DropdownMenuItem = ({ first = false, title, href, target = "", external = false, cy, setShowMenu }: IProps) => {
   const { pathname } = useRouter();
 
   const linkClass = (pageUrl: string) => {

--- a/src/components/menus/DropdownMenuWrapper.tsx
+++ b/src/components/menus/DropdownMenuWrapper.tsx
@@ -1,10 +1,10 @@
 import React, { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-const DropdownMenuWrapper: FC<TProps> = ({ children }) => {
+const DropdownMenuWrapper: FC<IProps> = ({ children }) => {
   return (
     <div data-cy="dropdown-menu" className="rounded shadow-xl py-2 w-[200px] bg-gray-100">
       {children}

--- a/src/components/menus/MainMenu.tsx
+++ b/src/components/menus/MainMenu.tsx
@@ -4,11 +4,11 @@ import { Icon } from "@/components/atoms/icon/Icon";
 import DropdownMenuItem from "./DropdownMenuItem";
 import DropdownMenuWrapper from "./DropdownMenuWrapper";
 
-type TProps = {
+interface IProps {
   iconClass?: string;
-};
+}
 
-const MainMenu = ({ iconClass = "text-white" }: TProps) => {
+const MainMenu = ({ iconClass = "text-white" }: IProps) => {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef(null);
   useOutsideAlerter(menuRef, () => setShowMenu(false));

--- a/src/components/modals/DownloadCsv.tsx
+++ b/src/components/modals/DownloadCsv.tsx
@@ -4,13 +4,13 @@ import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Heading } from "@/components/typography/Heading";
 import Popup from "./Popup";
 
-type TProps = {
+interface IProps {
   active: boolean;
   onCancelClick: () => void;
   onConfirmClick: () => void;
-};
+}
 
-export const DownloadCsvPopup = ({ active, onCancelClick, onConfirmClick }: TProps) => {
+export const DownloadCsvPopup = ({ active, onCancelClick, onConfirmClick }: IProps) => {
   return (
     <Popup active={active} onCloseClick={onCancelClick}>
       <div className="flex flex-col items-center">

--- a/src/components/molecules/conceptLink/ConceptLink.stories.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: { layout: "centered" },
   argTypes: {},
 } satisfies Meta<typeof ConceptLink>;
-type Story = StoryObj<typeof ConceptLink>;
+type TStory = StoryObj<typeof ConceptLink>;
 
 export default meta;
 
@@ -47,13 +47,13 @@ const concepts: Partial<TConcept>[] = [
   },
 ];
 
-export const Single: Story = {
+export const Single: TStory = {
   args: {
     concept: concepts[0] as TConcept,
   },
 };
 
-export const Multiple: Story = {
+export const Multiple: TStory = {
   argTypes: {
     concept: { control: false },
   },

--- a/src/components/molecules/conceptLink/ConceptLink.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.tsx
@@ -4,12 +4,12 @@ import { joinTailwindClasses } from "@/utils/tailwind";
 import { startCase } from "lodash";
 import { useState } from "react";
 
-interface ConceptLinkProps {
+interface IProps {
   concept: TConcept;
   triggerClasses?: string;
 }
 
-export const ConceptLink = ({ concept, triggerClasses = "" }: ConceptLinkProps) => {
+export const ConceptLink = ({ concept, triggerClasses = "" }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const allTriggerClasses = joinTailwindClasses(

--- a/src/components/molecules/info/Info.stories.tsx
+++ b/src/components/molecules/info/Info.stories.tsx
@@ -7,11 +7,11 @@ const meta = {
   parameters: { layout: "centered" },
   argTypes: {},
 } satisfies Meta<typeof Info>;
-type Story = StoryObj<typeof Info>;
+type TStory = StoryObj<typeof Info>;
 
 export default meta;
 
-export const Filters: Story = {
+export const Filters: TStory = {
   args: {
     title: "About",
     description: "Narrow down your results using the filter below. You can also combine these with a search term.",
@@ -22,7 +22,7 @@ export const Filters: Story = {
   },
 };
 
-export const Minimal: Story = {
+export const Minimal: TStory = {
   args: {
     description: "Here is some more info!",
   },

--- a/src/components/molecules/info/Info.tsx
+++ b/src/components/molecules/info/Info.tsx
@@ -3,14 +3,14 @@ import { joinTailwindClasses } from "@/utils/tailwind";
 import { useState } from "react";
 import { LuInfo } from "react-icons/lu";
 
-type TInfoProps = {
+interface IProps {
   className?: string;
   title?: string;
   description: string;
   link?: TPopoverLink;
-};
+}
 
-export const Info = ({ className, description, link, title }: TInfoProps) => {
+export const Info = ({ className, description, link, title }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const infoClasses = joinTailwindClasses("cursor-help", isOpen ? "text-text-brand" : "text-text-secondary", className);

--- a/src/components/molecules/navSearch/NavSearch.stories.tsx
+++ b/src/components/molecules/navSearch/NavSearch.stories.tsx
@@ -5,11 +5,11 @@ const meta = {
   title: "Molecules/NavSearch",
   component: NavSearch,
 } satisfies Meta<typeof NavSearch>;
-type Story = StoryObj<typeof NavSearch>;
+type TStory = StoryObj<typeof NavSearch>;
 
 export default meta;
 
-export const SearchPage: Story = {
+export const SearchPage: TStory = {
   parameters: {
     nextjs: {
       router: {
@@ -23,7 +23,7 @@ export const SearchPage: Story = {
   },
 };
 
-export const GeographyPage: Story = {
+export const GeographyPage: TStory = {
   parameters: {
     nextjs: {
       router: {
@@ -38,7 +38,7 @@ export const GeographyPage: Story = {
   },
 };
 
-export const FamilyPage: Story = {
+export const FamilyPage: TStory = {
   parameters: {
     nextjs: {
       router: {
@@ -53,7 +53,7 @@ export const FamilyPage: Story = {
   },
 };
 
-export const DocumentPage: Story = {
+export const DocumentPage: TStory = {
   parameters: {
     nextjs: {
       router: {

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -1,18 +1,18 @@
 import { useEffect, useRef, useState } from "react";
 import { LuChevronsUpDown } from "react-icons/lu";
 
-interface NavSearchDropdownProps {
+interface IProps {
   contextualSearchName: string;
   isEverything: boolean;
   setIsEverything: (newValue: boolean) => void;
 }
 
-type DropdownOption = {
+type TDropdownOption = {
   name: string;
   newIsEverythingValue: boolean;
 };
 
-export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEverything }: NavSearchDropdownProps) => {
+export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEverything }: IProps) => {
   const ref = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -38,7 +38,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
   }, [ref]);
 
   // Show the other option below the currently selected one
-  const dropdownOptions: DropdownOption[] = [
+  const dropdownOptions: TDropdownOption[] = [
     {
       name: "Everything",
       newIsEverythingValue: true,

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -2,7 +2,7 @@ import { Url } from "next/dist/shared/lib/router/router";
 import Link from "next/link";
 import { MouseEventHandler } from "react";
 
-interface NavSearchSuggestionProps {
+interface IProps {
   children: React.ReactNode;
   hint?: React.ReactNode;
   href: Url;
@@ -10,7 +10,7 @@ interface NavSearchSuggestionProps {
   onClick?: MouseEventHandler<HTMLAnchorElement>;
 }
 
-export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick }: NavSearchSuggestionProps) => (
+export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick }: IProps) => (
   <Link href={href} className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-surface-ui transition duration-200 group" onClick={onClick}>
     <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-brand transition duration-200" : ""}`}>{Icon}</div>
     <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>

--- a/src/components/nav/SubNav.tsx
+++ b/src/components/nav/SubNav.tsx
@@ -1,11 +1,11 @@
 import { SiteWidth } from "@/components/panels/SiteWidth";
 
-type TProps = {
+interface IProps {
   extraClasses?: string;
   children?: React.ReactNode;
-};
+}
 
-export const SubNav = ({ extraClasses = "", children, ...props }: TProps) => {
+export const SubNav = ({ extraClasses = "", children, ...props }: IProps) => {
   return (
     <div className={`border-b border-gray-200 py-4 ${extraClasses}`} {...props}>
       <SiteWidth extraClasses="md:flex justify-between items-center">{children}</SiteWidth>

--- a/src/components/nav/TabbedNav.tsx
+++ b/src/components/nav/TabbedNav.tsx
@@ -11,14 +11,14 @@ type TTabItems = {
   count?: number;
 };
 
-type TTabbedNavProps = {
+interface IProps {
   handleTabClick(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, index: number, value: string): void;
   items: TTabItems[];
   activeIndex: number;
   showBorder?: boolean;
-};
+}
 
-const TabbedNav = ({ handleTabClick, items, activeIndex = 0, showBorder = true }: TTabbedNavProps) => {
+const TabbedNav = ({ handleTabClick, items, activeIndex = 0, showBorder = true }: IProps) => {
   const [activeTab, setActiveTab] = useState(activeIndex);
 
   const helpText = (index: number) => {

--- a/src/components/nav/TabbedNavItem.tsx
+++ b/src/components/nav/TabbedNavItem.tsx
@@ -4,7 +4,7 @@ import { getCategoryTooltip } from "@/helpers/getCategoryTooltip";
 
 import { TDocumentCategory } from "@/types";
 
-interface TabbedNavItemProps {
+interface IProps {
   title: TDocumentCategory;
   count?: number;
   index: number;
@@ -16,7 +16,7 @@ const tabCount = (count: number, active: boolean) => {
   return <span className={`py-1 px-2 rounded-2xl text-xs bg-gray-100 ${active && "text-blue-600 bg-blue-100"}`}>{count}</span>;
 };
 
-const TabbedNavItem = ({ title, count, index, activeTab, onClick }: TabbedNavItemProps) => {
+const TabbedNavItem = ({ title, count, index, activeTab, onClick }: IProps) => {
   const tooltipId = `${index}-tooltip`;
   const tooltipText = getCategoryTooltip(title);
   const isActive = activeTab === index;

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -13,13 +13,13 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TConcept } from "@/types";
 import { LinkWithQuery } from "../LinkWithQuery";
 
-type TProps = {
+interface IProps {
   concepts: TConcept[];
   containerClasses?: string;
   showSearch?: boolean;
   startingSort?: TSort;
   title: React.ReactNode;
-};
+}
 
 const SORT_OPTIONS = ["A-Z", "Grouped"] as const;
 
@@ -68,7 +68,7 @@ const onConceptChange = (router: NextRouter, concept: TConcept) => {
   router.push({ query: query }, undefined, { shallow: true });
 };
 
-export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = "Grouped", showSearch = true, title }: TProps) => {
+export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = "Grouped", showSearch = true, title }: IProps) => {
   const router = useRouter();
   const ref = useRef(null);
   const [search, setSearch] = useState("");

--- a/src/components/organisms/navBar/NavBar.stories.tsx
+++ b/src/components/organisms/navBar/NavBar.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     menu: { control: false },
   },
 } satisfies Meta<typeof NavBar>;
-type Story = StoryObj<typeof NavBar>;
+type TStory = StoryObj<typeof NavBar>;
 
 export default meta;
 
@@ -27,7 +27,7 @@ const CPRArgs = {
   showSearch: true,
 };
 
-export const SearchPage: Story = {
+export const SearchPage: TStory = {
   args: CPRArgs,
   parameters: {
     nextjs: {
@@ -42,7 +42,7 @@ export const SearchPage: Story = {
   },
 };
 
-export const GeographyPage: Story = {
+export const GeographyPage: TStory = {
   args: CPRArgs,
   parameters: {
     nextjs: {
@@ -58,7 +58,7 @@ export const GeographyPage: Story = {
   },
 };
 
-export const FamilyPage: Story = {
+export const FamilyPage: TStory = {
   args: CPRArgs,
   parameters: {
     nextjs: {
@@ -88,12 +88,12 @@ const documentPageParameters = {
   },
 };
 
-export const DocumentPage: Story = {
+export const DocumentPage: TStory = {
   args: CPRArgs,
   parameters: documentPageParameters,
 };
 
-export const CCLW: Story = {
+export const CCLW: TStory = {
   args: {
     headerClasses: "bg-cclw-dark",
     logo: CCLWLogo,
@@ -105,7 +105,7 @@ export const CCLW: Story = {
   parameters: documentPageParameters,
 };
 
-export const MCF: Story = {
+export const MCF: TStory = {
   args: {
     headerClasses: "bg-surface-light min-h-20 border-b border-gray-200 border-solid",
     logo: MCFLogo,

--- a/src/components/organisms/navBar/NavBar.tsx
+++ b/src/components/organisms/navBar/NavBar.tsx
@@ -1,6 +1,6 @@
 import { NavSearch } from "@/components/molecules/navSearch/NavSearch";
 
-interface NavBarProps {
+interface IProps {
   headerClasses?: string;
   logo: React.ReactNode;
   menu: React.ReactNode;
@@ -8,7 +8,7 @@ interface NavBarProps {
   showSearch?: boolean;
 }
 
-export const NavBar = ({ headerClasses = "", logo, menu, showLogo = true, showSearch = true }: NavBarProps) => {
+export const NavBar = ({ headerClasses = "", logo, menu, showLogo = true, showSearch = true }: IProps) => {
   return (
     <header data-cy="header" className={`w-full h-[128px] sm:h-[72px] sticky top-0 z-60 ${headerClasses}`}>
       <div

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/atoms/button/Button";
 
 import { getCurrentPage } from "@/utils/getCurrentPage";
 
-interface PaginationProps {
+interface IProps {
   onChange(ct: string, offSet: number): void;
   offset?: string | number;
   maxNeighbourDistance?: number;
@@ -36,14 +36,7 @@ const calcCurrentPage = (offset: string | number = 0, continuationTokens: string
   return getCurrentPage(offSet, RESULTS_PER_PAGE, PAGES_PER_CONTINUATION_TOKEN, cts, activeContinuationToken);
 };
 
-const Pagination = ({
-  onChange,
-  offset,
-  totalHits = 0,
-  continuationToken = null,
-  continuationTokens = "[]",
-  activeContinuationToken,
-}: PaginationProps) => {
+const Pagination = ({ onChange, offset, totalHits = 0, continuationToken = null, continuationTokens = "[]", activeContinuationToken }: IProps) => {
   const parsedTokens: string[] = JSON.parse(continuationTokens);
   // empty string to the beginning of the array accounts for the first set of pages that do not require a token
   parsedTokens.splice(0, 0, "");

--- a/src/components/panels/FullWidth.tsx
+++ b/src/components/panels/FullWidth.tsx
@@ -1,10 +1,10 @@
-type TProps = {
+interface IProps {
   extraClasses?: string;
   children?: React.ReactNode;
   [x: string]: any;
-};
+}
 
-export function FullWidth({ extraClasses = "", children, ...props }: TProps) {
+export function FullWidth({ extraClasses = "", children, ...props }: IProps) {
   return (
     <div className={`px-5 ${extraClasses}`} {...props}>
       {children}

--- a/src/components/panels/MultiCol.tsx
+++ b/src/components/panels/MultiCol.tsx
@@ -1,9 +1,9 @@
-type TProps = {
+interface IProps {
   extraClasses?: string;
   children?: React.ReactNode;
-};
+}
 
-export function MultiCol({ extraClasses = "", children, ...props }: TProps & React.HTMLProps<HTMLDivElement>) {
+export function MultiCol({ extraClasses = "", children, ...props }: IProps & React.HTMLProps<HTMLDivElement>) {
   return (
     <div className={`max-w-maxSiteWidth mx-auto flex items-stretch ${extraClasses}`} {...props}>
       {children}

--- a/src/components/panels/SideCol.tsx
+++ b/src/components/panels/SideCol.tsx
@@ -1,8 +1,8 @@
-type TProps = {
+interface IProps {
   extraClasses?: string;
-};
+}
 
-export function SideCol({ extraClasses = "", children, ...props }: TProps & React.HTMLAttributes<HTMLDivElement>) {
+export function SideCol({ extraClasses = "", children, ...props }: IProps & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div className={`md:block md:w-maxSidebar md:grow-0 md:shrink-0 ${extraClasses}`} {...props}>
       {children}

--- a/src/components/panels/SingleCol.tsx
+++ b/src/components/panels/SingleCol.tsx
@@ -1,9 +1,9 @@
-type TProps = {
+interface IProps {
   extraClasses?: string;
   children?: React.ReactNode;
-};
+}
 
-export function SingleCol({ extraClasses = "", children, ...props }: TProps) {
+export function SingleCol({ extraClasses = "", children, ...props }: IProps) {
   return (
     <div className={`max-w-maxContent basis-maxContent mx-auto ${extraClasses}`} {...props}>
       {children}

--- a/src/components/panels/SiteWidth.tsx
+++ b/src/components/panels/SiteWidth.tsx
@@ -1,10 +1,10 @@
-type TProps = {
+interface IProps {
   extraClasses?: string;
   children?: React.ReactNode;
   [x: string]: any;
-};
+}
 
-export function SiteWidth({ extraClasses = "", children, ...props }: TProps) {
+export function SiteWidth({ extraClasses = "", children, ...props }: IProps) {
   return (
     <div className={`max-w-maxSiteWidth w-full px-5 mx-auto ${extraClasses}`} {...props}>
       {children}

--- a/src/components/popover/ConceptsPopover.tsx
+++ b/src/components/popover/ConceptsPopover.tsx
@@ -4,12 +4,12 @@ import { Heading } from "@/components/typography/Heading";
 import { getConceptStoreLink } from "@/utils/getConceptStoreLink";
 import { Popover } from "./Popover";
 
-type TProps = {
+interface IProps {
   concept?: TConcept;
   onClose: () => void;
-};
+}
 
-export const ConceptsPopover = ({ concept, onClose }: TProps) => {
+export const ConceptsPopover = ({ concept, onClose }: IProps) => {
   return (
     <Popover>
       <>

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -1,8 +1,10 @@
 import { ReactNode } from "react";
 
-type TProps = { children?: ReactNode };
+interface IProps {
+  children?: ReactNode;
+}
 
-export const Popover = ({ children }: TProps) => {
+export const Popover = ({ children }: IProps) => {
   return (
     <div className="w-64 p-4 bg-white rounded-lg shadow-md border border-gray-200 flex items-start">
       <div className="space-y-6 w-full">{children}</div>

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -4,13 +4,14 @@ import { Button } from "@/components/atoms/button/Button";
 import { FamilyListItem } from "@/components/document/FamilyListItem";
 import { Icon } from "@/components/atoms/icon/Icon";
 import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
-interface ISearchResultProps {
+
+interface IProps {
   family: TMatchedFamily;
   active: boolean;
   onClick?: () => void;
 }
 
-const SearchResult = ({ family, active, onClick }: ISearchResultProps) => {
+const SearchResult = ({ family, active, onClick }: IProps) => {
   const { family_documents, total_passage_hits, family_slug } = family;
 
   const matchesNumber = total_passage_hits >= MAX_RESULTS ? `${MAX_RESULTS}+` : `${total_passage_hits}`;

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -3,12 +3,12 @@ import SearchResult from "./SearchResult";
 
 import { TMatchedFamily } from "@/types";
 
-type TProps = {
+interface IProps {
   category?: string;
   families: TMatchedFamily[];
   activeFamilyIndex?: number | boolean;
   onClick?: (index: number) => void;
-};
+}
 
 const renderEmptyMessage = (category: string) => {
   if (category !== "UNFCCC") {
@@ -22,7 +22,7 @@ const renderEmptyMessage = (category: string) => {
   );
 };
 
-const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: TProps) => {
+const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: IProps) => {
   if (category && category.toLowerCase() === "litigation") {
     return (
       <>

--- a/src/components/svg/Logo.tsx
+++ b/src/components/svg/Logo.tsx
@@ -1,8 +1,8 @@
-interface LogoProps {
+interface IProps {
   fixed?: boolean;
 }
 
-const Logo = ({ fixed = false }: LogoProps) => {
+const Logo = ({ fixed = false }: IProps) => {
   return (
     <svg
       data-cy="header-logo"

--- a/src/components/svg/LogoMono.tsx
+++ b/src/components/svg/LogoMono.tsx
@@ -1,8 +1,8 @@
-interface LogoProps {
+interface IProps {
   fixed?: boolean;
 }
 
-const LogoMono = ({ fixed = false }: LogoProps) => {
+const LogoMono = ({ fixed = false }: IProps) => {
   return (
     <svg
       data-cy="header-logo"

--- a/src/components/timeline/Event.tsx
+++ b/src/components/timeline/Event.tsx
@@ -1,13 +1,13 @@
 import { TEvent } from "@/types";
 import { convertDate } from "@/utils/timedate";
 
-interface EventProps {
+interface IProps {
   event: TEvent;
   last: boolean;
   index: number;
 }
 
-export const Event = ({ event, last, index }: EventProps) => {
+export const Event = ({ event, last, index }: IProps) => {
   const { title, date } = event;
   const [year, _, month] = convertDate(date);
 

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,10 +1,10 @@
 import { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-export const Timeline: FC<TProps> = ({ children }) => {
+export const Timeline: FC<IProps> = ({ children }) => {
   return (
     <div className="mt-4">
       <div className="flex place-content-center bg-gray-50 rounded border border-gray-200 drop-shadow-lg p-4">

--- a/src/components/tooltip/SearchLimitTooltip.tsx
+++ b/src/components/tooltip/SearchLimitTooltip.tsx
@@ -2,12 +2,12 @@ import Tooltip from ".";
 
 import { MAX_RESULTS } from "@/constants/paging";
 
-type TProps = {
+interface IProps {
   colour?: string;
   textOverride?: string;
-};
+}
 
-export const SearchLimitTooltip = ({ colour, textOverride }: TProps) => {
+export const SearchLimitTooltip = ({ colour, textOverride }: IProps) => {
   return (
     <Tooltip
       id="search-results-number"

--- a/src/components/tooltip/TooltipSSR.tsx
+++ b/src/components/tooltip/TooltipSSR.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import { Tooltip } from "react-tooltip";
 
-type TProps = {
+interface IProps {
   id: string;
   place?: "top" | "right" | "bottom" | "left";
   tooltip?: string | React.ReactNode;
   interactableContent?: boolean;
-};
+}
 
-export const ToolTipSSR = ({ id, place, tooltip, interactableContent }: TProps) => {
+export const ToolTipSSR = ({ id, place, tooltip, interactableContent }: IProps) => {
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,6 +1,6 @@
 import { ToolTipSSR } from "./TooltipSSR";
 
-interface TooltipProps {
+interface IProps {
   id: string;
   tooltip: string | React.ReactNode;
   icon?: "?" | "!" | "i";
@@ -9,7 +9,7 @@ interface TooltipProps {
   colour?: string;
 }
 
-const Tooltip = ({ id, tooltip, icon = "?", place, interactableContent, colour }: TooltipProps) => {
+const Tooltip = ({ id, tooltip, icon = "?", place, interactableContent, colour }: IProps) => {
   let colourCss = "";
   switch (colour) {
     case "grey":

--- a/src/components/typography/Heading.tsx
+++ b/src/components/typography/Heading.tsx
@@ -1,11 +1,11 @@
 type THeadingLevels = 1 | 2 | 3 | 4 | 5;
 
-type TProps = {
+interface IProps {
   level?: THeadingLevels;
   extraClasses?: string;
   children: React.ReactNode;
   [x: string]: any;
-};
+}
 
 // Dev note: because we have dynamic content that we may not have control over, please update the style.css with the corresponding html heading tags
 export const coreClasses = "text-textDark font-medium";
@@ -15,7 +15,7 @@ export const h3Classes = "text-xl mb-5";
 export const h4Classes = "text-lg mb-5";
 export const h5Classes = "text-l mb-5";
 
-export const Heading = ({ level, extraClasses = "", children, ...props }: TProps) => {
+export const Heading = ({ level, extraClasses = "", children, ...props }: IProps) => {
   switch (level) {
     case 1:
       return (

--- a/src/components/typography/Quote.tsx
+++ b/src/components/typography/Quote.tsx
@@ -1,8 +1,8 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
-};
+}
 
-export const Quote = ({ children }: TProps) => {
+export const Quote = ({ children }: IProps) => {
   return (
     <div className="pl-4 border-l-2 border-blue-600">
       <p className="text-sm text-neutral-600">{children}</p>

--- a/src/components/typography/Text.tsx
+++ b/src/components/typography/Text.tsx
@@ -1,7 +1,7 @@
-type TProps = {
+interface IProps {
   children: React.ReactNode;
-};
+}
 
-export const Text = ({ children }: TProps) => {
+export const Text = ({ children }: IProps) => {
   return <p>{children}</p>;
 };

--- a/src/components/utility/VerticalSpacing.tsx
+++ b/src/components/utility/VerticalSpacing.tsx
@@ -1,9 +1,9 @@
-type spacingSize = "base" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "xxxl" | "minimumtargetsize";
+type SpacingSize = "base" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "xxxl" | "minimumtargetsize";
 
-type Tprops = {
-  size: spacingSize;
+interface IProps {
+  size: SpacingSize;
   children?: React.ReactNode;
-};
+}
 
 const padding = {
   base: 1, //"4px",
@@ -18,6 +18,6 @@ const padding = {
   minimumtargetsize: "[44px]",
 };
 
-export const VerticalSpacing = ({ size, children = null }: Tprops) => {
+export const VerticalSpacing = ({ size, children = null }: IProps) => {
   return <div className={`p-${padding[size]}`}>{children}</div>;
 };

--- a/src/context/EnvConfig.ts
+++ b/src/context/EnvConfig.ts
@@ -24,14 +24,14 @@ export const publicRuntimeEnvConfig = [
   "HOSTNAME",
 ] as const;
 
-export type PublicEnvConfig = Record<(typeof publicRuntimeEnvConfig)[number], string>;
+export type TPublicEnvConfig = Record<(typeof publicRuntimeEnvConfig)[number], string>;
 
 /**
  * This method is specifically made to be used with `getServerSideProps`
  * where `pageProps.envConfig` is then read in `_app.tsx` and passed to `EnvConfigContext.Provider`
  */
-export function withEnvConfig<PageProps>(pageProps: PageProps): PageProps & { envConfig: PublicEnvConfig } {
-  const config = {} as PublicEnvConfig;
+export function withEnvConfig<PageProps>(pageProps: PageProps): PageProps & { envConfig: TPublicEnvConfig } {
+  const config = {} as TPublicEnvConfig;
 
   for (const key of publicRuntimeEnvConfig) {
     config[key] = process.env[key];
@@ -43,9 +43,9 @@ export function withEnvConfig<PageProps>(pageProps: PageProps): PageProps & { en
   };
 }
 
-export const EnvConfigContext = createContext<PublicEnvConfig>(undefined);
+export const EnvConfigContext = createContext<TPublicEnvConfig>(undefined);
 
-export function useEnvConfig(): PublicEnvConfig {
+export function useEnvConfig(): TPublicEnvConfig {
   const envConfig = useContext(EnvConfigContext);
 
   if (typeof envConfig === "undefined") {

--- a/src/context/PostHogProvider.tsx
+++ b/src/context/PostHogProvider.tsx
@@ -10,10 +10,10 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react";
 import { Suspense, useEffect } from "react";
 
-type Props = {
+interface IProps {
   children: React.ReactNode;
   consent?: boolean;
-};
+}
 
 function PostHogPageView() {
   const pathname = usePathname();
@@ -47,7 +47,7 @@ export function SuspendedPostHogPageView() {
   );
 }
 
-export function PostHogProvider({ children, consent }: Props) {
+export function PostHogProvider({ children, consent }: IProps) {
   /**
    * The sessionStorage is read by tag manager to not re-init posthog
    * We don't use something like posthog.__loaded as posthog isn't available on the window

--- a/src/context/SlideOutContext.ts
+++ b/src/context/SlideOutContext.ts
@@ -2,9 +2,9 @@ import { createContext } from "react";
 
 export type TSlideOutContent = "concepts" | "";
 
-type TProps = {
+interface IProps {
   currentSlideOut: TSlideOutContent;
   setCurrentSlideOut: (value: TSlideOutContent) => void;
-};
+}
 
-export const SlideOutContext = createContext<TProps>(null);
+export const SlideOutContext = createContext<IProps>(null);

--- a/src/helpers/getCorpusInfo.tsx
+++ b/src/helpers/getCorpusInfo.tsx
@@ -1,11 +1,11 @@
 import { TCorpusTypeDictionary } from "@/types";
 
-type TProps = {
+interface IProps {
   corpus_types: TCorpusTypeDictionary;
   corpus_id: string;
-};
+}
 
-export const getCorpusInfo = ({ corpus_types, corpus_id }: TProps) => {
+export const getCorpusInfo = ({ corpus_types, corpus_id }: IProps) => {
   const corpora = Object.values(corpus_types).flatMap((corpus_type) => corpus_type.corpora);
   const selectedCorpus = corpora.find((corpus) => corpus.corpus_import_id === corpus_id);
   const defaultCorpus = {

--- a/src/helpers/getCountriesFromRegions.ts
+++ b/src/helpers/getCountriesFromRegions.ts
@@ -1,12 +1,12 @@
 import { TGeography } from "@/types";
 
-type TProps = {
+interface IProps {
   selectedRegions: string[];
   regions: TGeography[];
   countries: TGeography[];
-};
+}
 
-export const getCountriesFromRegions = ({ regions, countries, selectedRegions }: TProps) => {
+export const getCountriesFromRegions = ({ regions, countries, selectedRegions }: IProps) => {
   const selectedRegionsGeo = regions.filter((item) => selectedRegions.includes(item.slug));
 
   let newList = countries;

--- a/src/helpers/mapFamilyMetadata.ts
+++ b/src/helpers/mapFamilyMetadata.ts
@@ -4,17 +4,17 @@ import { getSubCategoryName } from "@/helpers/getCategoryName";
 import { getSumUSD } from "@/helpers/getSumUSD";
 import { TCorpusTypeSubCategory } from "@/types";
 
-interface Metadata {
+interface IMetadata {
   [key: string]: string[] | TCorpusTypeSubCategory | string;
 }
 
-type ResultItem = {
+type TResultItem = {
   label: string;
   value: string[] | string;
 };
 
-export const mapFamilyMetadata = (metadata: Metadata) => {
-  const result: ResultItem[] = [];
+export const mapFamilyMetadata = (metadata: IMetadata) => {
+  const result: TResultItem[] = [];
 
   for (const [key, values] of Object.entries(metadata)) {
     const mapping = metadataLabelMappings[key];

--- a/src/hooks/useUpdateCountries.ts
+++ b/src/hooks/useUpdateCountries.ts
@@ -1,16 +1,16 @@
 import { useMutation, useQueryClient } from "react-query";
 import { TGeography } from "@/types";
 
-type TMutationProps = {
+interface IProps {
   regionName: string;
   regions: TGeography[];
   countries: TGeography[];
-};
+}
 
 export default function useUpdateCountries() {
   const queryClient = useQueryClient();
 
-  return useMutation(async (value: TMutationProps) => {
+  return useMutation(async (value: IProps) => {
     const { regionName, regions, countries } = value;
     const region = regions.find((item) => item.slug === regionName);
     let newList = countries;

--- a/src/pages/[page].tsx
+++ b/src/pages/[page].tsx
@@ -15,13 +15,13 @@ type TPage = {
   contentPath: string;
 };
 
-type TProps = {
+interface IProps {
   page?: TPage & {
     notFound?: boolean;
   };
-};
+}
 
-export default function Page({ page }: TProps) {
+export default function Page({ page }: IProps) {
   // TODO: fix this properly
   // Next is throwing a NEXT_REDIRECT error under the hood when attemping to navigate to a missing page at root, e.g. /missing-page
   if (!page || page.notFound) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,12 +19,12 @@ const favicon = `/images/favicon/${process.env.THEME}.png`;
 
 const queryClient = new QueryClient();
 
-type TProps = AppProps & {
+interface IProps extends AppProps {
   theme?: string;
   adobeApiKey?: string;
-};
+}
 
-function MyApp({ Component, pageProps, theme, adobeApiKey }: TProps) {
+function MyApp({ Component, pageProps, theme, adobeApiKey }: IProps) {
   const [siteTheme, setSiteTheme] = useState(null);
   const [adobeKey, setAdobeKey] = useState(null);
 

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -50,7 +50,7 @@ import { MultiCol } from "@/components/panels/MultiCol";
 import { ConceptsPanel } from "@/components/concepts/ConceptsPanel";
 import { withEnvConfig } from "@/context/EnvConfig";
 
-type TProps = {
+interface IProps {
   page: TFamilyPage;
   targets: TTarget[];
   countries: TGeography[];
@@ -58,7 +58,7 @@ type TProps = {
   theme: TTheme;
   featureFlags: Record<string, string | boolean>;
   vespaFamilyData?: TSearchResponse;
-};
+}
 
 /*
   # DEV NOTES
@@ -75,7 +75,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   theme,
   featureFlags,
   vespaFamilyData,
-}: TProps) => {
+}: IProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const startingNumberOfTargetsToDisplay = 5;

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -29,13 +29,13 @@ import { ConceptsDocumentViewer } from "@/components/documents/ConceptsDocumentV
 import { getMatchedPassagesFromSearch } from "@/utils/getMatchedPassagesFromFamiy";
 import { withEnvConfig } from "@/context/EnvConfig";
 
-type TProps = {
+interface IProps {
   document: TDocumentPage;
   family: TFamilyPage;
   theme: TTheme;
   vespaFamilyData?: TSearchResponse;
   vespaDocumentData?: TSearchResponse;
-};
+}
 
 const passageClasses = (canPreview: boolean) => {
   if (canPreview) {
@@ -73,7 +73,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   theme,
   vespaFamilyData,
   vespaDocumentData,
-}: TProps) => {
+}: IProps) => {
   const [canPreview, setCanPreview] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [passageIndex, setPassageIndex] = useState(null);

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -37,13 +37,13 @@ import { TGeographyStats, TGeographySummary, TThemeConfig } from "@/types";
 import { TTarget, TEvent, TGeography, TTheme } from "@/types";
 import { withEnvConfig } from "@/context/EnvConfig";
 
-type TProps = {
+interface IProps {
   geography: TGeographyStats;
   summary: TGeographySummary;
   targets: TTarget[];
   theme: TTheme;
   themeConfig: TThemeConfig;
-};
+}
 
 // Mapping of category index to category name in search
 const categoryByIndex = {
@@ -58,7 +58,7 @@ const categoryByIndex = {
 
 const MAX_NUMBER_OF_FAMILIES = 3;
 
-const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ geography, summary, targets, theme, themeConfig }: TProps) => {
+const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ geography, summary, targets, theme, themeConfig }: IProps) => {
   const router = useRouter();
   const startingNumberOfTargetsToDisplay = 5;
   const [numberOfTargetsToDisplay, setNumberOfTargetsToDisplay] = useState(startingNumberOfTargetsToDisplay);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,7 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 
 import { triggerNewSearch } from "@/utils/triggerNewSearch";
 import dynamic from "next/dynamic";
-import { TProps as HomepageProps } from "@/cpr/pages/homepage";
+import { IProps as HomepageProps } from "@/cpr/pages/homepage";
 
 const Homepage = dynamic<HomepageProps>(() => import(`/themes/${process.env.THEME}/pages/homepage`));
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -43,19 +43,19 @@ import { TConcept, TTheme, TThemeConfig } from "@/types";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { Info } from "@/components/molecules/info/Info";
 
-type TProps = {
+interface IProps {
   theme: TTheme;
   themeConfig: TThemeConfig;
   featureFlags: Record<string, string | boolean>;
   conceptsData?: TConcept[];
-};
+}
 
 const SETTINGS_ANIMATION_VARIANTS = {
   hidden: { opacity: 0, transition: { duration: 0.1 } },
   visible: { opacity: 1, transition: { duration: 0 } },
 };
 
-const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme, themeConfig, featureFlags, conceptsData }: TProps) => {
+const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme, themeConfig, featureFlags, conceptsData }: IProps) => {
   const router = useRouter();
   const [showFilters, setShowFilters] = useState(false);
   const [showCSVDownloadPopup, setShowCSVDownloadPopup] = useState(false);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -312,12 +312,12 @@ export type TCorpusType = {
   corpora: TCorpusWithStats[];
 };
 
-export interface TDictionary<T> {
+export interface IDictionary<T> {
   [Key: string]: T;
 }
 
-export type TOrganisationDictionary = TDictionary<TOrganisation>;
-export type TCorpusTypeDictionary = TDictionary<TCorpusType>;
+export type TOrganisationDictionary = IDictionary<TOrganisation>;
+export type TCorpusTypeDictionary = IDictionary<TCorpusType>;
 
 export type TConcept = {
   alternative_labels: string[];

--- a/src/utils/checkCorpusAccess.ts
+++ b/src/utils/checkCorpusAccess.ts
@@ -10,7 +10,7 @@ import { jwtDecode } from "jwt-decode";
  * @property {string} sub - The 'theme' of the custom app that requested the token.
  * @property {string} aud - The URL of the server that the token is intended for.
  */
-type DecodedToken = {
+type TDecodedToken = {
   allowed_corpora_ids: string[];
   exp: number;
   iat: number;
@@ -21,7 +21,7 @@ type DecodedToken = {
 
 export const hasMcfAccess = (token: string): boolean => {
   try {
-    const decoded = jwtDecode<DecodedToken>(token);
+    const decoded = jwtDecode<TDecodedToken>(token);
     return decoded.allowed_corpora_ids.some((id) => id.startsWith("MCF"));
   } catch (error) {
     return false;

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -49,23 +49,23 @@ export const fetchAndProcessConcepts = async (conceptIds: string[]) => {
   return { rootConcepts: rootConceptsResults, concepts: conceptsResults };
 };
 
-interface Concept {
+interface IConcept {
   name: string;
   count: number;
   wikibaseId: string;
 }
 
-interface ConceptMap {
-  [subconcept: string]: Concept;
+interface IConceptMap {
+  [subconcept: string]: IConcept;
 }
 
-interface RootConceptsMapped {
-  [rootConcept: string]: ConceptMap;
+interface IRootConceptsMapped {
+  [rootConcept: string]: IConceptMap;
 }
 
-export const processConcepts = (concepts: (TConcept & { count: number })[]): RootConceptsMapped => {
-  const conceptMap: RootConceptsMapped = {};
-  let otherConcepts: ConceptMap = {};
+export const processConcepts = (concepts: (TConcept & { count: number })[]): IRootConceptsMapped => {
+  const conceptMap: IRootConceptsMapped = {};
+  let otherConcepts: IConceptMap = {};
 
   concepts.forEach((concept) => {
     let isRootOrSubconcept = false;

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -1,4 +1,4 @@
-export type SortFuncType = (data: any, prop: any) => any;
+export type TSortFuncType = (data: any, prop: any) => any;
 
 export const sortData = (data, prop) => {
   var myData = data.sort((a, b) => {

--- a/themes/ccc/components/AccordianItem.tsx
+++ b/themes/ccc/components/AccordianItem.tsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 
-type TProps = {
+interface IProps {
   id?: string;
   title: string;
   children: JSX.Element;
   startOpen?: boolean;
   className?: string;
   headContent?: JSX.Element;
-};
+}
 
-export const AccordianItem = ({ id, title, children, startOpen = false, className, headContent }: TProps) => {
+export const AccordianItem = ({ id, title, children, startOpen = false, className, headContent }: IProps) => {
   const { asPath } = useRouter();
   const [open, setOpen] = useState(startOpen);
 

--- a/themes/ccc/components/Analytics.tsx
+++ b/themes/ccc/components/Analytics.tsx
@@ -1,12 +1,12 @@
 import Script from "next/script";
 
-type TProps = {
+interface IProps {
   enableAnalytics: boolean;
-};
+}
 
 const CCLW_GA_ID = "UA-153841121-2";
 
-const Analytics = ({ enableAnalytics }: TProps) => {
+const Analytics = ({ enableAnalytics }: IProps) => {
   return (
     <>
       {enableAnalytics && (

--- a/themes/ccc/components/Card.tsx
+++ b/themes/ccc/components/Card.tsx
@@ -1,6 +1,13 @@
-type TProps = { heading: string; type?: string; img?: string; imgAlt?: string; extraClasses?: string; children: React.ReactNode };
+interface IProps {
+  children: React.ReactNode;
+  extraClasses?: string;
+  heading: string;
+  img?: string;
+  imgAlt?: string;
+  type?: string;
+}
 
-export const Card = ({ heading, type, img, extraClasses, children }: TProps) => {
+export const Card = ({ heading, type, img, extraClasses, children }: IProps) => {
   return (
     <div className={`h-full ${extraClasses}`}>
       <div className="block relative border border-gray-300 rounded-xl h-full shadow p-4">

--- a/themes/ccc/components/Feature.tsx
+++ b/themes/ccc/components/Feature.tsx
@@ -5,15 +5,15 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 
 import { Heading } from "@/components/typography/Heading";
 
-type TProps = {
+interface IProps {
   heading?: string;
   contentSide?: "left" | "right";
   image?: string;
   imageAlt?: string;
   children?: ReactNode;
-};
+}
 
-export const Feature = ({ heading, contentSide = "left", image, imageAlt, children }: TProps) => {
+export const Feature = ({ heading, contentSide = "left", image, imageAlt, children }: IProps) => {
   return (
     <div className="bg-cclw-dark text-white py-12">
       <SiteWidth extraClasses="md:flex gap-8">

--- a/themes/ccc/components/Hero.tsx
+++ b/themes/ccc/components/Hero.tsx
@@ -3,12 +3,12 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { Heading } from "@/components/typography/Heading";
 import LandingSearchForm from "./LandingSearchForm";
 
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-export const Hero = ({ handleSearchInput, searchInput }: TProps) => {
+export const Hero = ({ handleSearchInput, searchInput }: IProps) => {
   return (
     <div className="pb-[33vh] text-white">
       <SiteWidth>

--- a/themes/ccc/components/LandingSearchForm.tsx
+++ b/themes/ccc/components/LandingSearchForm.tsx
@@ -14,13 +14,13 @@ const EXAMPLE_SEARCHES = [
   { id: 4, term: "Coastal zones" },
 ];
 
-interface SearchFormProps {
+interface IProps {
   placeholder?: string;
   handleSearchInput(term: string, filter?: string, filterValue?: string): void;
   input?: string;
 }
 
-const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
+const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
   const formRef = useRef(null);

--- a/themes/ccc/layouts/main.tsx
+++ b/themes/ccc/layouts/main.tsx
@@ -2,11 +2,11 @@ import { Footer } from "@/ccc/components/Footer";
 import Header from "@/ccc/components/Header";
 import { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-const Main: FC<TProps> = ({ children }) => (
+const Main: FC<IProps> = ({ children }) => (
   <>
     <Header />
     <main id="main" className="flex flex-col flex-1">

--- a/themes/ccc/pages/faq.tsx
+++ b/themes/ccc/pages/faq.tsx
@@ -15,11 +15,11 @@ import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-type TProps = {
+interface IProps {
   featureFlags: Record<string, string | boolean>;
-};
+}
 
-const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: IProps) => {
   return (
     <Layout
       title="FAQ"

--- a/themes/ccc/pages/homepage.tsx
+++ b/themes/ccc/pages/homepage.tsx
@@ -3,12 +3,12 @@ import { Hero } from "@/ccc/components/Hero";
 import { APP_NAME, PAGE_DESCRIPTION } from "@/ccc/constants/pageMetadata";
 import Layout from "@/components/layouts/LandingPage";
 
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
+const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
   return (
     <Layout title="Climate Case Chart" theme={APP_NAME} description={PAGE_DESCRIPTION}>
       <main id="main" className="h-screen flex flex-col bg-[rebeccapurple]">

--- a/themes/cclw/components/AccordianItem.tsx
+++ b/themes/cclw/components/AccordianItem.tsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 
-type TProps = {
+interface IProps {
   id?: string;
   title: string;
   children: JSX.Element;
   startOpen?: boolean;
   className?: string;
   headContent?: JSX.Element;
-};
+}
 
-export const AccordianItem = ({ id, title, children, startOpen = false, className, headContent }: TProps) => {
+export const AccordianItem = ({ id, title, children, startOpen = false, className, headContent }: IProps) => {
   const { asPath } = useRouter();
   const [open, setOpen] = useState(startOpen);
 

--- a/themes/cclw/components/Analytics.tsx
+++ b/themes/cclw/components/Analytics.tsx
@@ -1,12 +1,12 @@
 import Script from "next/script";
 
-type TProps = {
+interface IProps {
   enableAnalytics: boolean;
-};
+}
 
 const CCLW_GA_ID = "UA-153841121-2";
 
-const Analytics = ({ enableAnalytics }: TProps) => {
+const Analytics = ({ enableAnalytics }: IProps) => {
   return (
     <>
       {enableAnalytics && (

--- a/themes/cclw/components/Card.tsx
+++ b/themes/cclw/components/Card.tsx
@@ -1,6 +1,13 @@
-type TProps = { heading: string; type?: string; img?: string; imgAlt?: string; extraClasses?: string; children: React.ReactNode };
+interface IProps {
+  children: React.ReactNode;
+  extraClasses?: string;
+  heading: string;
+  img?: string;
+  imgAlt?: string;
+  type?: string;
+}
 
-export const Card = ({ heading, type, img, extraClasses, children }: TProps) => {
+export const Card = ({ heading, type, img, extraClasses, children }: IProps) => {
   return (
     <div className={`h-full ${extraClasses}`}>
       <div className="block relative border border-gray-300 rounded-xl h-full shadow p-4">

--- a/themes/cclw/components/Feature.tsx
+++ b/themes/cclw/components/Feature.tsx
@@ -5,15 +5,15 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 
 import { Heading } from "@/components/typography/Heading";
 
-type TProps = {
+interface IProps {
   heading?: string;
   contentSide?: "left" | "right";
   image?: string;
   imageAlt?: string;
   children?: ReactNode;
-};
+}
 
-export const Feature = ({ heading, contentSide = "left", image, imageAlt, children }: TProps) => {
+export const Feature = ({ heading, contentSide = "left", image, imageAlt, children }: IProps) => {
   return (
     <div className="bg-cclw-dark text-white py-12">
       <SiteWidth extraClasses="md:flex gap-8">

--- a/themes/cclw/components/Hero.tsx
+++ b/themes/cclw/components/Hero.tsx
@@ -11,12 +11,12 @@ const Instructions = dynamic(() => import("./Instructions"), {
   ssr: false,
 });
 
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-export const Hero = ({ handleSearchInput, searchInput }: TProps) => {
+export const Hero = ({ handleSearchInput, searchInput }: IProps) => {
   return (
     <div className="pb-6 text-white pt-[28px] sm:pt-[48px] md:pt-[80px] lg:pt-[100px] xl:pt-[140px]">
       <SiteWidth>

--- a/themes/cclw/components/LandingSearchForm.tsx
+++ b/themes/cclw/components/LandingSearchForm.tsx
@@ -14,13 +14,13 @@ const EXAMPLE_SEARCHES = [
   { id: 4, term: "Coastal zones" },
 ];
 
-interface SearchFormProps {
+interface IProps {
   placeholder?: string;
   handleSearchInput(term: string, filter?: string, filterValue?: string): void;
   input?: string;
 }
 
-const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
+const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
   const formRef = useRef(null);

--- a/themes/cclw/layouts/main.tsx
+++ b/themes/cclw/layouts/main.tsx
@@ -2,11 +2,11 @@ import Footer from "@/cclw/components/Footer";
 import Header from "@/cclw/components/Header";
 import { FC, ReactNode } from "react";
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-const Main: FC<TProps> = ({ children }) => (
+const Main: FC<IProps> = ({ children }) => (
   <>
     <Header />
     <main id="main" className="flex flex-col flex-1">

--- a/themes/cclw/pages/faq.tsx
+++ b/themes/cclw/pages/faq.tsx
@@ -15,11 +15,11 @@ import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-type TProps = {
+interface IProps {
   featureFlags: Record<string, string | boolean>;
-};
+}
 
-const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: IProps) => {
   return (
     <Layout
       title="FAQ"

--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -23,12 +23,12 @@ import { Heading } from "@/components/typography/Heading";
 //   ssr: false,
 // });
 
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
+const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
   return (
     <Layout title="Law and Policy Search" theme={APP_NAME} description={PAGE_DESCRIPTION}>
       <main id="main" className="flex flex-col flex-1">

--- a/themes/cpr/components/LandingSearchForm.tsx
+++ b/themes/cpr/components/LandingSearchForm.tsx
@@ -3,13 +3,13 @@ import { Icon } from "@/components/atoms/icon/Icon";
 import { SearchDropdown } from "@/components/forms/SearchDropdown";
 import { Button } from "@/components/atoms/button/Button";
 
-interface SearchFormProps {
+interface IProps {
   placeholder?: string;
   handleSearchInput(term: string, filter?: string, filterValue?: string): void;
   input?: string;
 }
 
-const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
+const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
   const [showAnimation, setShowAnimation] = useState(true);

--- a/themes/cpr/components/oep/ColumnAndImage.tsx
+++ b/themes/cpr/components/oep/ColumnAndImage.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from "react";
 
-type TColumnAndImageProp = {
+interface IProps {
   children: ReactNode;
   extraClasses?: string;
-};
+}
 
-export const ColumnAndImage = ({ children, extraClasses = "" }: TColumnAndImageProp) => (
+export const ColumnAndImage = ({ children, extraClasses = "" }: IProps) => (
   <div className={`flex flex-col max-w-[775px] lg:max-w-[440px] ${extraClasses}`}>{children}</div>
 );

--- a/themes/cpr/components/oep/EqualColumns.tsx
+++ b/themes/cpr/components/oep/EqualColumns.tsx
@@ -1,15 +1,15 @@
 import { ReactNode } from "react";
 
-type TEqualColumnProps = {
+interface IProps {
   children: ReactNode;
   extraClasses?: string;
   reverseColumn?: boolean; // Reverses the column order below md breakpoint
-};
+}
 
-export const EqualColumns = ({ children, extraClasses = "", reverseColumn = false }: TEqualColumnProps) => {
+export const EqualColumns = ({ children, extraClasses = "", reverseColumn = false }: IProps) => {
   const columnDirection = reverseColumn ? "flex-col-reverse" : "flex-col";
 
   return <div className={`flex ${columnDirection} md:flex-row md:items-center ${extraClasses}`}>{children}</div>;
 };
 
-export const EqualColumn = ({ children, extraClasses = "" }: TEqualColumnProps) => <div className={`flex-1 h-auto ${extraClasses}`}>{children}</div>;
+export const EqualColumn = ({ children, extraClasses = "" }: IProps) => <div className={`flex-1 h-auto ${extraClasses}`}>{children}</div>;

--- a/themes/cpr/components/oep/Narrow.tsx
+++ b/themes/cpr/components/oep/Narrow.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
 
-type TNarrowProps = {
+interface IProps {
   children: ReactNode;
   extraClasses?: string;
-};
+}
 
-export const Narrow = ({ children, extraClasses = "" }: TNarrowProps) => <div className={`max-w-[775px] ${extraClasses}`}>{children}</div>;
+export const Narrow = ({ children, extraClasses = "" }: IProps) => <div className={`max-w-[775px] ${extraClasses}`}>{children}</div>;

--- a/themes/cpr/components/oep/Section.tsx
+++ b/themes/cpr/components/oep/Section.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from "react";
 
-type TSectionProps = {
+interface IProps {
   children: ReactNode;
   containerClasses?: string;
   sectionClasses?: string;
-};
+}
 
-export const Section = ({ children, containerClasses = "", sectionClasses = "" }: TSectionProps) => (
+export const Section = ({ children, containerClasses = "", sectionClasses = "" }: IProps) => (
   <section className={sectionClasses}>
     <div className={`max-w-[1000px] w-full px-5 lg:px-0 mx-auto text-textDark ${containerClasses}`}>{children}</div>
   </section>

--- a/themes/cpr/layouts/main.tsx
+++ b/themes/cpr/layouts/main.tsx
@@ -11,11 +11,11 @@ export const CPRLogo = (
   </LinkWithQuery>
 );
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-const Main: FC<TProps> = ({ children }) => (
+const Main: FC<IProps> = ({ children }) => (
   <>
     <NavBar headerClasses="banner" logo={CPRLogo} menu={<MainMenu />} />
     <main className="flex flex-col flex-1">{children}</main>

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -9,11 +9,11 @@ import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { FAQS, PLATFORM_FAQS } from "@/cpr/constants/faqs";
 import { getFeatureFlags } from "@/utils/featureFlags";
 
-type TProps = {
+interface IProps {
   featureFlags: Record<string, string | boolean>;
-};
+}
 
-const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: IProps) => {
   return (
     <Layout
       title="FAQ"

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -26,14 +26,14 @@ import LandingSearchForm from "@/cpr/components/LandingSearchForm";
  * GOTCHA: we export this to be used in the src/pages/index.tsx file.
  * It's a generic passed to `dynamic` so we can't rely on generic type checking.
  */
-export type TProps = {
+export interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   handleSearchChange: (type: string, value: any) => void;
   searchInput: string;
   exactMatch: boolean;
-};
+}
 
-const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exactMatch }: TProps) => {
+const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exactMatch }: IProps) => {
   const handleLinkClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     const term = e.currentTarget.textContent;

--- a/themes/mcf/components/AboutTheFunds.tsx
+++ b/themes/mcf/components/AboutTheFunds.tsx
@@ -4,12 +4,12 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { Heading } from "@/components/typography/Heading";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 
-type FundDescription = {
+type TFundDescription = {
   name: string;
   description: string;
 };
 
-const fundDescriptions: FundDescription[] = [
+const fundDescriptions: TFundDescription[] = [
   {
     name: "Adaptation Fund",
     description: "(AF) finances projects and programmes that help vulnerable communities in developing countries adapt to climate change.",

--- a/themes/mcf/components/Analytics.tsx
+++ b/themes/mcf/components/Analytics.tsx
@@ -1,12 +1,12 @@
 import Script from "next/script";
 
-type TProps = {
+interface IProps {
   enableAnalytics: boolean;
-};
+}
 
 const MCF_GA_ID = "G-4SHFJ172GL";
 
-const Analytics = ({ enableAnalytics }: TProps) => {
+const Analytics = ({ enableAnalytics }: IProps) => {
   return (
     <>
       {enableAnalytics && (

--- a/themes/mcf/components/Hero.tsx
+++ b/themes/mcf/components/Hero.tsx
@@ -5,14 +5,12 @@ import { SiteWidth } from "@/components/panels/SiteWidth";
 import { VerticalSpacing } from "@/components/utility/VerticalSpacing";
 import { MultilateralClimateFundLogos } from "./HeroComponents/MultilateralClimateFundsLogos";
 
-const Instructions = () => <p>Loading document stats...</p>;
-
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-const Hero = ({ handleSearchInput, searchInput }: TProps) => (
+const Hero = ({ handleSearchInput, searchInput }: IProps) => (
   <div className="pb-6 pt-[28px] sm:pt-[48px] md:pt-[80px] lg:pt-[100px] xl:pt-[140px]">
     <SiteWidth extraClasses="!max-w-[1024px]">
       <div className="mx-auto text-center">

--- a/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
+++ b/themes/mcf/components/HeroComponents/MultilateralClimateFundsLogos.tsx
@@ -1,12 +1,12 @@
 import { ExternalLink } from "@/components/ExternalLink";
 
-interface FundData {
+interface IFundData {
   imgSrc: string;
   name: string;
   url: string;
 }
 
-const fundInformation: FundData[] = [
+const fundInformation: IFundData[] = [
   {
     imgSrc: "/images/mcf/AF.png",
     name: "Adaptation Fund",

--- a/themes/mcf/components/LandingSearchForm.tsx
+++ b/themes/mcf/components/LandingSearchForm.tsx
@@ -13,13 +13,13 @@ const EXAMPLE_SEARCHES = [
   { id: 3, filterValue: "Philippines", filterType: QUERY_PARAMS.country },
 ];
 
-interface SearchFormProps {
+interface IProps {
   placeholder?: string;
   handleSearchInput(term: string, filter?: string, filterValue?: string): void;
   input?: string;
 }
 
-const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
+const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
   const formRef = useRef(null);

--- a/themes/mcf/layouts/main.tsx
+++ b/themes/mcf/layouts/main.tsx
@@ -1,11 +1,11 @@
 import React, { FC, ReactNode } from "react";
 import { Header, Footer } from "@/mcf/components";
 
-type TProps = {
+interface IProps {
   children?: ReactNode;
-};
+}
 
-const Main: FC<TProps> = ({ children }) => (
+const Main: FC<IProps> = ({ children }) => (
   <>
     <Header />
     <main id="main" className="flex flex-col flex-1">

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -9,11 +9,11 @@ import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
 import { FAQS, PLATFORM_FAQS } from "@/mcf/constants/faqs";
 import { getFeatureFlags } from "@/utils/featureFlags";
 
-type TProps = {
+interface IProps {
   featureFlags: Record<string, string | boolean>;
-};
+}
 
-const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: TProps) => {
+const FAQ: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags = {} }: IProps) => {
   return (
     <Layout
       title="FAQ"

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -13,12 +13,12 @@ import {
 } from "@/mcf/components";
 import { PAGE_DESCRIPTION, APP_NAME } from "@/mcf/constants/pageMetadata";
 
-type TProps = {
+interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
-};
+}
 
-const LandingPage = ({ handleSearchInput, searchInput }: TProps) => {
+const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
   return (
     <Layout title="Climate Fund Search" theme={APP_NAME} description={PAGE_DESCRIPTION}>
       <main id="main" className="flex flex-col flex-1">


### PR DESCRIPTION
# What's changed

- All TypeScript types and interface names are prefixed with `T` and `I` respectively.
- React component argument objects are always interfaces where possible.
- Main React component exports in a file have an argument type called `Props`, therefore `IProps` or rarely `TProps`.

This is a very noisy PR without any functionality change.

This PR _doesn't_ enforce naming via linting as it would require importing an entire ESLint package for the sake of one rule ([typescript-eslint's naming-convention](https://typescript-eslint.io/rules/naming-convention/)). If we have the appetite for this, please challenge me during the review.

## Why?

- Making our preferred naming conventions stick.
- Strongly hinting to other contributors what the standard is by example.