### PR TITLE
Fix: Remove offset query param on new search

### DIFF
--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -87,6 +87,7 @@ export const NavSearch = () => {
   // The path to navigate to when submitting the search input
   const searchHref: Url = useMemo(() => {
     const newQuery = CleanRouterQuery({ ...router.query });
+    delete newQuery[QUERY_PARAMS.offset];
 
     if (searchText) {
       newQuery[QUERY_PARAMS.query_string] = searchText;


### PR DESCRIPTION
# What's changed

- Removes the `o` search offset URL parameter when submitting a new search through the `NavSearch` component.

## Why?

- Parity with the original functionality prior to the search in navbar piece of work.
- If the new search has less results than the offset number, no results are displayed despite there being more than 0 results.