### PR TITLE
APP-587: Search results on mobile sort and no. of results needs attention

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -438,13 +438,23 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
               <SingleCol extraClasses="px-5 pt-5 relative">
                 <div>
                   <div className="">
-                    <div className="flex justify-between flex-wrap gap-2 items-start">
-                      <div className="md:hidden">
-                        <Button content="both" className="flex-nowrap" onClick={toggleFilters}>
-                          <span>{showFilters ? "Hide" : "Show"} filters</span>
-                        </Button>
+                    <div className="md:hidden mb-4">
+                      <Button content="both" className="flex-nowrap" onClick={toggleFilters}>
+                        <span>{showFilters ? "Hide" : "Show"} filters</span>
+                      </Button>
+                    </div>
+                    <div className="flex justify-between items-start">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm text-text-primary font-normal">
+                          Results <span className="text-text-secondary">{hits || 0}</span>
+                        </p>
+                        <Info
+                          title="Showing the top 500 results"
+                          description="We limit the number of matches you can see so you get the quickest, most accurate results."
+                          link={{ href: "/faq", text: "Learn more" }}
+                        />
                       </div>
-                      <div className="relative z-10 -top-0.5 md:order-1">
+                      <div className="relative z-10 -top-0.5">
                         <button
                           className={`px-1 py-0.5 -mt-0.5 rounded-md text-sm text-text-primary font-normal ${showOptions ? "bg-surface-ui" : ""}`}
                           onClick={() => setShowOptions(!showOptions)}
@@ -466,16 +476,6 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                             </motion.div>
                           )}
                         </AnimatePresence>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <p className="text-sm text-text-primary font-normal">
-                          Results <span className="text-text-secondary">{hits || 0}</span>
-                        </p>
-                        <Info
-                          title="Showing the top 500 results"
-                          description="We limit the number of matches you can see so you get the quickest, most accurate results."
-                          link={{ href: "/faq", text: "Learn more" }}
-                        />
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
# What's changed

- Search results count and search settings elements display on their own line on mobile viewports.

## Why?

Satisfies [APP-587](https://linear.app/climate-policy-radar/issue/APP-587/search-results-on-mobile-sort-and-no-of-results-needs-attention) - the wrapping of these elements with the "Show filters" button looked clumsy.

## Screenshots?

Samsung Galaxy S8+:
<img width="529" alt="Screenshot 2025-05-14 at 10 15 07" src="https://github.com/user-attachments/assets/de43c4bc-dfaa-4fbe-83a0-b70f5a029c1d" />

iPhone 12 Pro:
<img width="492" alt="Screenshot 2025-05-14 at 10 14 57" src="https://github.com/user-attachments/assets/9b79bb65-e44c-41f0-accd-07245b889219" />

Desktop:
<img width="1115" alt="Screenshot 2025-05-14 at 10 15 20" src="https://github.com/user-attachments/assets/ef4a6e92-6880-43ee-9149-0b20ca4b9af0" />