### PR TITLE
APP-592: Poor alignment on non-pdf document viewers

### DIFF
--- a/src/components/documents/EmptyDocument.tsx
+++ b/src/components/documents/EmptyDocument.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from "@/components/ExternalLink";
 import { Icon } from "@/components/atoms/icon/Icon";
 
 export const EmptyDocument = () => (
-  <div className="ml-4 text-center text-gray-600">
+  <div className="ml-4 mt-4 text-center text-gray-600">
     <div className="mb-2 flex justify-center">
       <Icon name="bookOpen" />
     </div>

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -200,7 +200,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
               <div id="document-container" className="flex flex-col md:flex-row md:h-[80vh]">
                 <div
                   id="document-preview"
-                  className={`pt-4 flex-1 h-[400px] basis-[400px] md:block md:h-full ${totalNoOfMatches ? "md:border-r md:border-r-gray-200" : ""}`}
+                  className={`flex-1 h-[400px] basis-[400px] md:block md:h-full ${totalNoOfMatches ? "md:border-r md:border-r-gray-200" : ""}`}
                 >
                   {canPreview && (
                     <EmbeddedPDF


### PR DESCRIPTION
# What's changed

- Moved top padding on PDF panel (no concepts) to `EmptyDocument` component for consistency.

## Why?

Satisfies [APP-592](https://linear.app/climate-policy-radar/issue/APP-592/poor-alignment-on-non-pdf-document-viewers).

## Screenshots?

Concepts feature flag off:
<img width="1515" alt="Screenshot 2025-05-14 at 11 20 36" src="https://github.com/user-attachments/assets/db0799f7-391f-4563-93f9-ac616f1292c4" />

Concepts feature flag on (no concepts to display):
<img width="1518" alt="Screenshot 2025-05-14 at 11 23 22" src="https://github.com/user-attachments/assets/68a95e88-52a5-4fc8-8ef5-d2a238aa1096" />