### PR TITLE
Use correct AWS env's ECR repo

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,11 +39,11 @@ jobs:
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
 
-      - name: Build, tag, and push to ECR with 'production' tag
+      - name: Build, tag, and push to ECR with 'latest' tag
         id: build-image
         env:
           ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-          IMAGE_TAG: production
+          IMAGE_TAG: latest
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ inputs.theme }}
           THEME: ${{ inputs.theme }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,7 +31,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-          IMAGE_TAG: staging
+          IMAGE_TAG: latest
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}
           THEME: ${{ matrix.theme }}

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -167,10 +167,23 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
+      - name: Build, tag, and push image to Amazon ECR (staging)
+        id: build-image-staging
         env:
-          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY_STAGING }}
+          IMAGE_TAG: ${{ github.sha }}
+          AWS_REGION: eu-west-1
+          ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}
+          THEME: ${{ matrix.theme }}
+        run: |
+          docker build --build-arg THEME=${THEME} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Amazon ECR (production)
+        id: build-image-prod
+        env:
+          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY_PROD }}
           IMAGE_TAG: ${{ github.sha }}
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}


### PR DESCRIPTION
# What's changed

Auto deploys do not work when the image is stored in a different AWS environment's ECR repo. i.e., we could have prod auto deploys because all our images were stored in the prod ECR, but we couldn't have staging auto deploys.

I've updated the infra so that we make ECR repos in both AWS environments, and push the GIT SHA tagged image to both repos.

This lets us enable auto deploys on staging and prod, using the `latest` tag.