### PR TITLE
APP-623: Rename Concepts to Topics

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -180,7 +180,7 @@ const SearchFilters = ({
             {...{ [SLIDE_OUT_DATA_KEY]: "concepts" }}
           >
             <div className="flex items-center gap-2 pointer-events-none">
-              <Heading>Concepts</Heading>
+              <Heading>Topics</Heading>
               <Label>Beta</Label>
             </div>
             <span

--- a/src/components/concepts/ConceptsHead.tsx
+++ b/src/components/concepts/ConceptsHead.tsx
@@ -9,13 +9,13 @@ export const ConceptsHead = () => {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <Heading level={2} className="text-base font-medium text-neutral-800">
-            Climate concepts
+            Climate topics
           </Heading>
           <Label>Beta</Label>
         </div>
         <Quote>
           <>
-            This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+            This feature automatically detects climate topics in documents. Accuracy is not 100%.{" "}
             <ExternalLink url="https://climatepolicyradar.org/concepts" className="text-gray-600 underline">
               Learn more
             </ExternalLink>

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -234,7 +234,7 @@ export const ConceptsDocumentViewer = ({
           <SideCol id="document-concepts" extraClasses="!w-full xl:!w-maxSidebar">
             <div className="p-4 xl:hidden">
               <Button content="both" onClick={handleToggleConcepts}>
-                <span>{showConcepts ? "Hide" : "Show"} concepts</span>
+                <span>{showConcepts ? "Hide" : "Show"} topics</span>
                 <div className={showConcepts ? "rotate-180" : ""}>
                   <Icon name="downChevron" />
                 </div>

--- a/src/components/documents/UnavailableConcepts.tsx
+++ b/src/components/documents/UnavailableConcepts.tsx
@@ -14,9 +14,9 @@ export const UnavailableConcepts = ({ unavailableConcepts, familySlug }: IProps)
         <Icon name="findInDoc" width="48" height="48" />
       </div>
     </div>
-    <p className="text-xl font-medium">Concept not in Document</p>
+    <p className="text-xl font-medium">Topic not in Document</p>
     <p>
-      Some concepts from your search are not be present in this document but might be present in{" "}
+      Some topics from your search are not be present in this document but might be present in{" "}
       <Link
         href={`/document/${familySlug}?${unavailableConcepts.map((concept) => `cfn=${concept}`).join("&")}`}
         className="text-blue-600  hover:underline"
@@ -26,7 +26,7 @@ export const UnavailableConcepts = ({ unavailableConcepts, familySlug }: IProps)
       .
     </p>
     <p>
-      The following {unavailableConcepts.length > 1 ? "concepts are" : "concept is"} not present in this document:
+      The following {unavailableConcepts.length > 1 ? "topics are" : "topic is"} not present in this document:
       <p className="font-medium">{unavailableConcepts.join(", ")}</p>
     </p>
   </div>

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -98,7 +98,7 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
       {/* SCROLL AREA */}
       <div className="flex-1 flex flex-col gap-5 overflow-y-auto scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker">
         <p className="text-sm">
-          This feature automatically detects climate concepts in documents. Accuracy is not 100%.{" "}
+          This feature automatically detects climate topics in documents. Accuracy is not 100%.{" "}
           <LinkWithQuery href="/faq" className="underline" target="_blank">
             Learn more
           </LinkWithQuery>
@@ -124,7 +124,7 @@ export const ConceptPicker = ({ concepts, containerClasses = "", startingSort = 
             />
           </div>
         </div>
-        {search !== "" && <p className="text-xs italic">The results below are also filtered using the concept's alternative labels</p>}
+        {search !== "" && <p className="text-xs italic">The results below are also filtered using the topic's alternative labels</p>}
         <div className={`flex flex-col text-sm border-t border-border-light ${sort === "A-Z" ? "gap-2 border-t-0" : ""}`}>
           {/* GROUPED SORT */}
           {sort === "Grouped" &&

--- a/src/constants/conceptsFaqs.tsx
+++ b/src/constants/conceptsFaqs.tsx
@@ -10,14 +10,14 @@ type TFAQ = {
 
 export const CONCEPTS_FAQS: TFAQ[] = [
   {
-    id: "concepts",
-    title: "Automatic detection of key concepts in documents",
+    id: "topics",
+    title: "Automatic detection of key topics in documents",
     headContent: <Label>Beta</Label>,
     content: (
       <>
         <p>
-          This new feature automatically identifies mentions of key concepts in documents, helping you quickly find where important topics like
-          economic sectors, targets, and climate finance instruments appear in our database.
+          This new feature automatically identifies mentions of key topics in documents, helping you quickly find where important topics like economic
+          sectors, targets, and climate finance instruments appear in our database.
         </p>
 
         <p>While this feature is more precise than our standard search, accuracy is not 100%.</p>
@@ -28,7 +28,7 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     title: "How should I use this feature?",
     content: (
       <>
-        <p>Automatically detected concepts help you:</p>
+        <p>Automatically detected topics help you:</p>
         <ul>
           <li>Quickly locate mentions of key topics in documents.</li>
           <li>Understand the primary focus of a document.</li>
@@ -36,14 +36,14 @@ export const CONCEPTS_FAQS: TFAQ[] = [
 
         <p>However, results are not 100% accurate. Be cautious when:</p>
         <ul>
-          <li>Counting how often a concept appears in a document.</li>
-          <li>Comparing documents based on concept frequency.</li>
+          <li>Counting how often a topic appears in a document.</li>
+          <li>Comparing documents based on topic frequency.</li>
         </ul>
       </>
     ),
   },
   {
-    title: "Which concepts are currently available?",
+    title: "Which topics are currently available?",
     content: (
       <>
         <p>Examples include:</p>
@@ -68,18 +68,18 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     ),
   },
   {
-    title: "How do we automatically detect climate concepts in documents?",
+    title: "How do we automatically detect climate topics in documents?",
     content: (
       <>
-        <p>Each detected concept is based on a combination of expert knowledge and automated models:</p>
+        <p>Each detected topic is based on a combination of expert knowledge and automated models:</p>
         <ul>
           <li>
-            <b>Expert-driven concept selection</b>: our policy specialists identify the most important concepts by looking at existing taxonomies and
-            consulting external experts. We maintain a catalogue of these concepts in{" "}
+            <b>Expert-driven topic selection</b>: our policy specialists identify the most important topics by looking at existing taxonomies and
+            consulting external experts. We maintain a catalogue of these topics in{" "}
             <ExternalLink url="https://climatepolicyradar.wikibase.cloud/wiki/Main_Page">our concept store</ExternalLink>.
           </li>
           <li>
-            <b>Automated detection</b>: our data scientists and software engineers build models to find these concepts in text, continuously refining
+            <b>Automated detection</b>: our data scientists and software engineers build models to find these topics in text, continuously refining
             them based on human feedback.
           </li>
           <li>
@@ -97,9 +97,9 @@ export const CONCEPTS_FAQS: TFAQ[] = [
 
         <ul>
           <li>
-            On average, if a classifier highlights a concept, it is correct in <b>9 out of 10 cases</b>.
+            On average, if a classifier highlights a topic, it is correct in <b>9 out of 10 cases</b>.
           </li>
-          <li>Accuracy varies by concept and document quality. For example, if text extraction fails, we cannot accurately detect concepts.</li>
+          <li>Accuracy varies by topic and document quality. For example, if text extraction fails, we cannot accurately detect topics.</li>
           <li>We are actively improving accuracy by refining our models and ensuring consistency across different document types and languages.</li>
         </ul>
       </>
@@ -150,7 +150,7 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     content: (
       <>
         <p>
-          If you believe a concept is missing or misclassified, <ExternalLink url="https://eu.jotform.com/250402253775352">contact us</ExternalLink>.
+          If you believe a topic is missing or misclassified, <ExternalLink url="https://eu.jotform.com/250402253775352">contact us</ExternalLink>.
           Your feedback helps us improve.
         </p>
       </>

--- a/src/constants/platformFaqs.tsx
+++ b/src/constants/platformFaqs.tsx
@@ -34,8 +34,8 @@ export const PLATFORM_FAQS: TFAQ[] = [
       <>
         <p>
           If you don't toggle (or click on) 'exact phrase only', our new search feature searches the database for similar and related terms to the
-          query you typed into the search bar. You will get a richer search experience. Often climate or policy concepts are described in different
-          ways by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
+          query you typed into the search bar. You will get a richer search experience. Often climate or policy topics are described in different ways
+          by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
           gasoline-powered cars, etc). This feature uses a technique called natural language processing, which trains computers to understand text and
           the meaning of words and phrases in context. Climate Policy Radar's team of policy experts is continually working to improve the performance
           and accuracy of the models.

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -400,7 +400,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
                         concepts={conceptsData}
                         title={
                           <div className="flex items-center gap-2">
-                            <div className="text-[15px] font-medium text-text-primary">Concepts</div>
+                            <div className="text-[15px] font-medium text-text-primary">Topics</div>
                             <Label>Beta</Label>
                           </div>
                         }

--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -26,7 +26,7 @@ export const fetchAndProcessConcepts = async (conceptIds: string[]) => {
       return {
         wikibase_id: conceptId,
         preferred_label: ROOT_LEVEL_CONCEPTS[conceptId] || "Other",
-        description: "Concept data unavailable",
+        description: "Topic data unavailable",
         subconcept_of: [],
       } as TConcept;
     }

--- a/themes/ccc/pages/faq.tsx
+++ b/themes/ccc/pages/faq.tsx
@@ -43,7 +43,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {featureFlags["concepts-v1"] === true && <FaqSection title="Topics FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
       <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -77,7 +77,7 @@ export const FAQS: TFAQ[] = [
             Find climate and climate-related laws, policies, strategies and action plans from every country and submissions to the UNFCCC relevant to
             country level action
           </li>
-          <li>Search for keywords and policy concepts (like ‘electric vehicles’ or ‘gender equality’) across the full text of all documents</li>
+          <li>Search for keywords and policy topics (like ‘electric vehicles’ or ‘gender equality’) across the full text of all documents</li>
           <li>View your search term (and related phrases) highlighted in search results</li>
           <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
           <li>

--- a/themes/cpr/constants/faqs.tsx
+++ b/themes/cpr/constants/faqs.tsx
@@ -59,7 +59,7 @@ export const PLATFORM_FAQS: TFAQ[] = [
             country level action
           </li>
           <li>Find data from 4 biggest Multilateral Climate Funds, including project summaries, implementation documents and project guidance</li>
-          <li>Search for keywords and policy concepts (like 'electric vehicles' or 'gender equality') across the full text of all documents</li>
+          <li>Search for keywords and policy topics (like 'electric vehicles' or 'gender equality') across the full text of all documents</li>
           <li>View your search term (and related phrases) highlighted in search results</li>
           <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
           <li>Access the raw data: you just need to fill out this form to request a copy of the entire dataset</li>

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -43,7 +43,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {featureFlags["concepts-v1"] && <FaqSection title="Topics FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
     </Layout>

--- a/themes/cpr/pages/oep.tsx
+++ b/themes/cpr/pages/oep.tsx
@@ -42,7 +42,7 @@ const OceanEnergyPathwayPage = () => {
               <p className="text-lg">
                 With this tool, you can find information on offshore wind from around the globe, including legislation, government policies,
                 strategies, industry reports, analyses and policy recommendations from researchers and civil society. You can search for keywords and
-                policy concepts across the full text of all documents, viewing your search term and related phrases highlighted in the search results.
+                policy topics across the full text of all documents, viewing your search term and related phrases highlighted in the search results.
               </p>
             </ColumnAndImage>
           </Section>

--- a/themes/mcf/constants/platformFaqs.tsx
+++ b/themes/mcf/constants/platformFaqs.tsx
@@ -65,8 +65,8 @@ export const PLATFORM_FAQS: TFAQ[] = [
       <>
         <p>
           If you don’t toggle (or click on) ‘exact phrase only’, our new search feature searches the database for similar and related terms to the
-          query you typed into the search bar. You will get a richer search experience. Often climate or policy concepts are described in different
-          ways by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
+          query you typed into the search bar. You will get a richer search experience. Often climate or policy topics are described in different ways
+          by the government actors and policymakers producing the documents (such as petrol cars, internal combustion engine vehicles,
           gasoline-powered cars, etc). This feature uses a technique called natural language processing, which trains computers to understand text and
           the meaning of words and phrases in context. Climate Policy Radar’s team of policy experts is continually working to improve the performance
           and accuracy of the models.

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -42,7 +42,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {featureFlags["concepts-v1"] === true && <FaqSection title="Topics FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
       <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />


### PR DESCRIPTION
# What's changed

- In copy, all instances of concept/concepts has been changed to topic/topics.
  - Does not include mentions of our concept store, as that appears to be what it is called when clicking through a URL to it.
- Makes no changes to component and variable names, comments, URL params, or the API endpoints which reference concepts in both URL and data structure. This is essentially tech debt - feel free to challenge me on changing all but the API stuff now.

## Why?

Confirmation from Rosi that we're using the word "topic" going forward.

## Screenshots?

Search page:
<img width="827" alt="Screenshot 2025-05-29 at 10 26 42" src="https://github.com/user-attachments/assets/68034c54-2dfd-401a-b416-2a48fe1c62b9" />

Family page:
<img width="488" alt="Screenshot 2025-05-29 at 10 26 20" src="https://github.com/user-attachments/assets/280e7469-adf5-49ed-ba5d-aa8014b8dce4" />

Document page:
<img width="326" alt="Screenshot 2025-05-29 at 10 24 56" src="https://github.com/user-attachments/assets/04819e29-3470-4229-9a45-69f4587bfa5d" />

FAQs:
<img width="876" alt="Screenshot 2025-05-29 at 10 25 07" src="https://github.com/user-attachments/assets/bcb13f5e-5857-4437-845d-65d5b3327803" />