### PR TITLE
Remove env from release job 

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -137,11 +137,10 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-  # deploy
-  release-staging:
+
+  release:
     runs-on: ubuntu-latest
     needs: [code-quality, test, test-e2e]
-    environment: staging
     strategy:
       fail-fast: false
       matrix:
@@ -151,26 +150,28 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
+
       # build
       - run: |
           export THEME=${{ matrix.theme }}
           make build
+
       # release
       # most of this is taken from
       # https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service#creating-the-workflow
-      - name: Configure aws credentials
+      - name: Configure AWS credentials (staging)
         uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-frontend-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_STAGING }}:role/navigator-frontend-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
-      - name: Login to Amazon ECR
-        id: login-ecr
+      - name: Login to Amazon ECR (staging)
+        id: login-ecr-staging
         uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
       - name: Build, tag, and push image to Amazon ECR (staging)
         id: build-image-staging
         env:
-          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY_STAGING }}
           IMAGE_TAG: ${{ github.sha }}
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}
@@ -180,40 +181,20 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  release-production:
-    runs-on: ubuntu-latest
-    needs: [code-quality, test, test-e2e]
-    environment: production
-    strategy:
-      fail-fast: false
-      matrix:
-        theme: [cpr, cclw, mcf, ccc]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.12.0
-      # build
-      - run: |
-          export THEME=${{ matrix.theme }}
-          make build
-      # release
-      # most of this is taken from
-      # https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service#creating-the-workflow
-      - name: Configure aws credentials
+      - name: Configure aws credentials (production)
         uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-frontend-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/navigator-frontend-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
-      - name: Login to Amazon ECR
-        id: login-ecr
+      - name: Login to Amazon ECR (production)
+        id: login-ecr-prod
         uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
 
       - name: Build, tag, and push image to Amazon ECR (production)
         id: build-image-prod
         env:
-          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY_PROD }}
           IMAGE_TAG: ${{ github.sha }}
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}
@@ -222,7 +203,7 @@ jobs:
           docker build --build-arg THEME=${THEME} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-      # TODO: deploy
+
   storybook:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
# What's changed

Remove env from release job and do staging and prod ECR image pushes in same job

## Why?

Because otherwise by using the production environment, we accidentally end up gating the ECR image pushes to prod when we only want to gate code deploys to prod. This PR will be less noisy

## Screenshots?
