### PR TITLE
APP-621: Enable us to phase key features onto different custom apps in stages

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -20,8 +20,9 @@ import { currentYear, minYear } from "@/constants/timedate";
 import { SlideOutContext } from "@/context/SlideOutContext";
 import { getCountriesFromRegions } from "@/helpers/getCountriesFromRegions";
 import useGetThemeConfig from "@/hooks/useThemeConfig";
-import { TConcept, TCorpusTypeDictionary, TGeography, TSearchCriteria, TThemeConfigOption } from "@/types";
+import { TConcept, TCorpusTypeDictionary, TFeatureFlags, TGeography, TSearchCriteria, TThemeConfigOption } from "@/types";
 import { canDisplayFilter } from "@/utils/canDisplayFilter";
+import { isCorporateReportsEnabled, isUNFCCCFiltersEnabled } from "@/utils/features";
 import { getFilterLabel } from "@/utils/getFilterLabel";
 
 import { Info } from "../molecules/info/Info";
@@ -50,7 +51,7 @@ interface IProps {
   handleRegionChange(region: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
-  featureFlags: Record<string, string | boolean>;
+  featureFlags: TFeatureFlags;
 }
 
 const SearchFilters = ({
@@ -122,7 +123,7 @@ const SearchFilters = ({
           <InputListContainer>
             {themeConfig.categories?.options?.map(
               (option) =>
-                ((option.slug === "climate_policy_radar_reports" && featureFlags["corporate-reports"]) ||
+                ((option.slug === "climate_policy_radar_reports" && isCorporateReportsEnabled(featureFlags)) ||
                   option.slug !== "climate_policy_radar_reports") && (
                   <InputRadio
                     key={option.slug}
@@ -145,7 +146,7 @@ const SearchFilters = ({
           if (
             ["_document.type", "author_type"].includes(filter.taxonomyKey) &&
             filter.corporaKey === "Intl. agreements" &&
-            !featureFlags["unfccc-filters"]
+            !isUNFCCCFiltersEnabled(featureFlags)
           )
             return;
           // If the filter is not in the selected category, don't display it

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -1,0 +1,5 @@
+import { configFeatureKeys, featureFlagKeys, TConfigFeatures, TFeatureFlags } from "@/types";
+
+export const DEFAULT_FEATURE_FLAGS = Object.fromEntries(featureFlagKeys.map((key) => [key, false])) as TFeatureFlags;
+
+export const DEFAULT_CONFIG_FEATURES = Object.fromEntries(configFeatureKeys.map((key) => [key, false])) as TConfigFeatures;

--- a/src/context/ThemePageFeaturesContext.ts
+++ b/src/context/ThemePageFeaturesContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+
+import { DEFAULT_CONFIG_FEATURES, DEFAULT_FEATURE_FLAGS } from "@/constants/features";
+import { TFeatureFlags, TThemeConfig } from "@/types";
+
+type TThemePageFeatures = {
+  featureFlags: TFeatureFlags;
+  themeConfig: TThemeConfig;
+};
+
+export const ThemePageFeaturesContext = createContext<TThemePageFeatures>({
+  featureFlags: DEFAULT_FEATURE_FLAGS,
+  themeConfig: { features: DEFAULT_CONFIG_FEATURES } as TThemeConfig,
+});

--- a/src/pages/[page].tsx
+++ b/src/pages/[page].tsx
@@ -2,7 +2,14 @@
 import fs from "fs";
 
 import dynamic from "next/dynamic";
-import React from "react";
+import React, { useEffect, useState } from "react";
+
+import { DEFAULT_CONFIG_FEATURES, DEFAULT_FEATURE_FLAGS } from "@/constants/features";
+import { ThemePageFeaturesContext } from "@/context/ThemePageFeaturesContext";
+import { TFeatureFlags, TThemeConfig } from "@/types";
+import { getAllCookies } from "@/utils/cookies";
+import { getFeatureFlags } from "@/utils/featureFlags";
+import { readConfigFile } from "@/utils/readConfigFile";
 
 /*
 // This is a dynamic page to generate pages based on the routes.json file
@@ -23,6 +30,27 @@ interface IProps {
 }
 
 export default function Page({ page }: IProps) {
+  // const [configFeatures, setConfigFeatures] = useState<TConfigFeatures>(DEFAULT_CONFIG_FEATURES);
+  const [featureFlags, setFeatureFlags] = useState<TFeatureFlags>(DEFAULT_FEATURE_FLAGS);
+  const [themeConfig, setThemeConfig] = useState<TThemeConfig>({ features: DEFAULT_CONFIG_FEATURES } as TThemeConfig);
+
+  const loadFeatureFlags = async () => {
+    const allCookies = getAllCookies();
+    const retrievedFeatureFlags = await getFeatureFlags(allCookies);
+    setFeatureFlags(retrievedFeatureFlags);
+  };
+
+  const loadThemeConfig = async () => {
+    const theme = process.env.THEME;
+    const themeConfig = await readConfigFile(theme);
+    setThemeConfig(themeConfig);
+  };
+
+  useEffect(() => {
+    loadFeatureFlags();
+    loadThemeConfig();
+  }, []);
+
   // TODO: fix this properly
   // Next is throwing a NEXT_REDIRECT error under the hood when attemping to navigate to a missing page at root, e.g. /missing-page
   if (!page || page.notFound) {
@@ -34,7 +62,11 @@ export default function Page({ page }: IProps) {
     ssr: true,
   });
 
-  return <DynamicComponent />;
+  return (
+    <ThemePageFeaturesContext.Provider value={{ featureFlags, themeConfig }}>
+      <DynamicComponent />
+    </ThemePageFeaturesContext.Provider>
+  );
 }
 
 export async function getStaticPaths() {

--- a/src/pages/collection/[id].tsx
+++ b/src/pages/collection/[id].tsx
@@ -11,6 +11,7 @@ import { Heading } from "@/components/typography/Heading";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { TCollection, TTheme } from "@/types";
 import { getFeatureFlags } from "@/utils/featureFlags";
+import { isLitigationEnabled } from "@/utils/features";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
@@ -20,7 +21,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const id = context.params.id;
   const client = new ApiClient(process.env.BACKEND_API_URL);
 
-  if (!featureFlags["litigation"]) {
+  if (!isLitigationEnabled(featureFlags)) {
     return { notFound: true };
   }
 

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,0 +1,3 @@
+export const featureFlagKeys = ["concepts-v1", "corporate-reports", "litigation", "unfccc-filters"] as const;
+export type TFeatureFlag = (typeof featureFlagKeys)[number];
+export type TFeatureFlags = Record<TFeatureFlag, boolean>;

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,3 +1,7 @@
 export const featureFlagKeys = ["concepts-v1", "corporate-reports", "litigation", "unfccc-filters"] as const;
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
+
+export const configFeatureKeys = ["knowledgeGraph"] as const;
+export type TConfigFeature = (typeof configFeatureKeys)[number];
+export type TConfigFeatures = Record<TConfigFeature, boolean>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
-export * from "./types";
+export * from "./features";
 export * from "./themeConfig";
+export * from "./types";

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -1,3 +1,5 @@
+import { TConfigFeatures } from "./features";
+
 export type TDocumentCategory = "All" | "Laws" | "Policies" | "UNFCCC" | "Litigation" | "MCF" | "Reports";
 
 export type TLabelVariation = {
@@ -68,4 +70,5 @@ export type TThemeConfig = {
   links: TThemeLink[];
   metadata: TThemeMetadata[];
   documentCategories: TDocumentCategory[];
+  features: TConfigFeatures;
 };

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,16 +1,17 @@
-import { featureFlagKeys, TFeatureFlags } from "src/types/features";
+import { DEFAULT_FEATURE_FLAGS } from "@/constants/features";
+import { TFeatureFlags } from "@/types";
 
 import { deleteCookie, setCookie } from "./cookies";
 import getDomain from "./getDomain";
 
-export function setFeatureFlags(featureFlags: Partial<TFeatureFlags>) {
+export const setFeatureFlags = (featureFlags: Partial<TFeatureFlags>) => {
   if (Object.keys(featureFlags).length === 0) {
     deleteCookie(`feature_flags`, getDomain());
     return;
   } else {
     setCookie(`feature_flags`, JSON.stringify(featureFlags), getDomain());
   }
-}
+};
 
 export const getFeatureFlags = async (
   // This is a replica of `NextApiRequestCookies`
@@ -18,7 +19,7 @@ export const getFeatureFlags = async (
     [key: string]: string | string[];
   }>
 ): Promise<TFeatureFlags> => {
-  const featureFlags = Object.fromEntries(featureFlagKeys.map((flag) => [flag, false])) as TFeatureFlags;
+  const featureFlags = { ...DEFAULT_FEATURE_FLAGS };
 
   if (cookies.feature_flags) {
     try {

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,7 +1,9 @@
+import { featureFlagKeys, TFeatureFlags } from "src/types/features";
+
 import { deleteCookie, setCookie } from "./cookies";
 import getDomain from "./getDomain";
 
-export function setFeatureFlags(featureFlags: Partial<{ [key: string]: true }>) {
+export function setFeatureFlags(featureFlags: Partial<TFeatureFlags>) {
   if (Object.keys(featureFlags).length === 0) {
     deleteCookie(`feature_flags`, getDomain());
     return;
@@ -10,22 +12,27 @@ export function setFeatureFlags(featureFlags: Partial<{ [key: string]: true }>) 
   }
 }
 
-export async function getFeatureFlags(
+export const getFeatureFlags = async (
   // This is a replica of `NextApiRequestCookies`
   cookies: Partial<{
     [key: string]: string | string[];
   }>
-) {
-  let featureFlags: Partial<{ [key: string]: true }> = {};
+): Promise<TFeatureFlags> => {
+  const featureFlags = Object.fromEntries(featureFlagKeys.map((flag) => [flag, false])) as TFeatureFlags;
+
   if (cookies.feature_flags) {
     try {
       const featureFlagsCookie = Array.isArray(cookies.feature_flags) ? cookies.feature_flags[0] : cookies.feature_flags;
-      featureFlags = JSON.parse(featureFlagsCookie);
-    } catch (e) {
+      const featureFlagsObject = JSON.parse(featureFlagsCookie);
+
+      Object.keys(featureFlagsObject).forEach((key) => {
+        if (key in featureFlags) featureFlags[key] = featureFlagsObject[key] === true;
+      });
+    } catch (error) {
       /** it would be nice to alert to a beacon service, but we have none 😢 */
-      console.error(e); // eslint-disable-line no-console
+      console.error(error); // eslint-disable-line no-console
     }
   }
 
   return featureFlags;
-}
+};

--- a/src/utils/features.test.ts
+++ b/src/utils/features.test.ts
@@ -1,6 +1,10 @@
 import { isFeatureEnabled } from "./features";
 
 describe("isFeatureEnabled", () => {
+  it("returns true with no config feature or feature flag", () => {
+    expect(isFeatureEnabled({})).toBe(true);
+  });
+
   it("returns true with an enabled config feature", () => {
     expect(isFeatureEnabled({ configFeature: true })).toBe(true);
   });

--- a/src/utils/features.test.ts
+++ b/src/utils/features.test.ts
@@ -1,0 +1,23 @@
+import { isFeatureEnabled } from "./features";
+
+describe("isFeatureEnabled", () => {
+  it("returns true with an enabled config feature", () => {
+    expect(isFeatureEnabled({ configFeature: true })).toBe(true);
+  });
+
+  it("returns false with an disabled config feature", () => {
+    expect(isFeatureEnabled({ configFeature: false })).toBe(false);
+  });
+
+  it("returns false with an disabled config feature and an enabled feature flag", () => {
+    expect(isFeatureEnabled({ configFeature: false, featureFlag: true })).toBe(false);
+  });
+
+  it("returns true with an enabled config feature and an enabled feature flag", () => {
+    expect(isFeatureEnabled({ configFeature: true, featureFlag: true })).toBe(true);
+  });
+
+  it("returns false with an enabled config feature and a disabled feature flag", () => {
+    expect(isFeatureEnabled({ configFeature: true, featureFlag: false })).toBe(false);
+  });
+});

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -7,7 +7,7 @@ interface IArgs {
 
 // Determines if an app feature is on or off by combining app-level config and PostHog feature flags
 export const isFeatureEnabled = ({ configFeature, featureFlag }: IArgs): boolean => {
-  if (configFeature === undefined && featureFlag === undefined) return false; // Shouldn't be using this fn
+  if (configFeature === undefined && featureFlag === undefined) return true; // No feature control = on
   if (configFeature === false) return false; // Config feature off = always off
   if (configFeature === true && featureFlag === undefined) return true; // Config feature on = on
   return featureFlag === true; // Config feature on + feature flag = use feature flag

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,0 +1,37 @@
+import { TFeatureFlags, TThemeConfig } from "@/types";
+
+interface IArgs {
+  configFeature?: boolean;
+  featureFlag?: boolean;
+}
+
+// Determines if an app feature is on or off by combining app-level config and PostHog feature flags
+export const isFeatureEnabled = ({ configFeature, featureFlag }: IArgs): boolean => {
+  if (configFeature === undefined && featureFlag === undefined) return false; // Shouldn't be using this fn
+  if (configFeature === false) return false; // Config feature off = always off
+  if (configFeature === true && featureFlag === undefined) return true; // Config feature on = on
+  return featureFlag === true; // Config feature on + feature flag = use feature flag
+};
+
+/* Specific feature shorthand functions */
+
+export const isCorporateReportsEnabled = (featureFlags: TFeatureFlags) =>
+  isFeatureEnabled({
+    featureFlag: featureFlags["corporate-reports"],
+  });
+
+export const isKnowledgeGraphEnabled = (featureFlags: TFeatureFlags, themeConfig: TThemeConfig) =>
+  isFeatureEnabled({
+    configFeature: themeConfig.features.knowledgeGraph,
+    featureFlag: featureFlags["concepts-v1"],
+  });
+
+export const isLitigationEnabled = (featureFlags: TFeatureFlags) =>
+  isFeatureEnabled({
+    featureFlag: featureFlags["litigation"],
+  });
+
+export const isUNFCCCFiltersEnabled = (featureFlags: TFeatureFlags) =>
+  isFeatureEnabled({
+    featureFlag: featureFlags["unfccc-filters"],
+  });

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -68,6 +68,9 @@ const config: TThemeConfig = {
     },
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"],
+  features: {
+    knowledgeGraph: false,
+  },
 };
 
 export default config;

--- a/themes/ccc/pages/faq.tsx
+++ b/themes/ccc/pages/faq.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useEffect } from "react";
+import { useContext } from "react";
 
 import { FAQS, PLATFORM_FAQS } from "@/ccc/constants/faqs";
 import FaqSection from "@/components/FaqSection";
@@ -8,29 +7,14 @@ import Layout from "@/components/layouts/Main";
 import { SubNav } from "@/components/nav/SubNav";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
-import { getAllCookies } from "@/utils/cookies";
-import { getFeatureFlags } from "@/utils/featureFlags";
+import { ThemePageFeaturesContext } from "@/context/ThemePageFeaturesContext";
+import { isKnowledgeGraphEnabled } from "@/utils/features";
 
 const FAQ: React.FC = () => {
-  /*
-    The FAQs page is read in not by using Next.JS, but by our CPR specific page reading logic.
-    This means that we cannot fetch the feature flags directly by using the page context.
-    This function provides a means of working around this so we can conditionally display the
-    concept FAQs.
+  const { featureFlags, themeConfig } = useContext(ThemePageFeaturesContext);
 
-    TODO: Remove this once we have hard launched concepts in product.
-  */
-  const [featureFlags, setFeatureFlags] = useState({});
-  async function getFeatureFlag() {
-    const allCookies = getAllCookies();
-    const parsedFeatureFlags = await getFeatureFlags(allCookies);
-    setFeatureFlags(parsedFeatureFlags);
-  }
+  const knowledgeGraphEnabled = isKnowledgeGraphEnabled(featureFlags, themeConfig);
 
-  // TODO: Remove this once we have hard launched concepts in product.
-  useEffect(() => {
-    getFeatureFlag();
-  }, []);
   return (
     <Layout
       title="FAQ"
@@ -43,7 +27,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {knowledgeGraphEnabled && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
       <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -96,6 +96,9 @@ const config: TThemeConfig = {
     },
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation"],
+  features: {
+    knowledgeGraph: true,
+  },
 };
 
 export default config;

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -97,7 +97,7 @@ const config: TThemeConfig = {
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation"],
   features: {
-    knowledgeGraph: true,
+    knowledgeGraph: false,
   },
 };
 

--- a/themes/cclw/pages/faq.tsx
+++ b/themes/cclw/pages/faq.tsx
@@ -1,5 +1,4 @@
-import { Fragment, useState } from "react";
-import { useEffect } from "react";
+import { Fragment, useContext } from "react";
 
 import { AccordianItem } from "@/cclw/components/AccordianItem";
 import { FAQS } from "@/cclw/constants/faqs";
@@ -10,29 +9,13 @@ import { SingleCol } from "@/components/panels/SingleCol";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { Heading } from "@/components/typography/Heading";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
-import { getAllCookies } from "@/utils/cookies";
-import { getFeatureFlags } from "@/utils/featureFlags";
+import { ThemePageFeaturesContext } from "@/context/ThemePageFeaturesContext";
+import { isKnowledgeGraphEnabled } from "@/utils/features";
 
 const FAQ: React.FC = () => {
-  /*
-    The FAQs page is read in not by using Next.JS, but by our CPR specific page reading logic.
-    This means that we cannot fetch the feature flags directly by using the page context.
-    This function provides a means of working around this so we can conditionally display the
-    concept FAQs.
-  
-    TODO: Remove this once we have hard launched concepts in product.
-  */
-  const [featureFlags, setFeatureFlags] = useState({});
-  async function getFeatureFlag() {
-    const allCookies = getAllCookies();
-    const parsedFeatureFlags = await getFeatureFlags(allCookies);
-    setFeatureFlags(parsedFeatureFlags);
-  }
+  const { featureFlags, themeConfig } = useContext(ThemePageFeaturesContext);
 
-  // TODO: Remove this once we have hard launched concepts in product.
-  useEffect(() => {
-    getFeatureFlag();
-  }, []);
+  const knowledgeGraphEnabled = isKnowledgeGraphEnabled(featureFlags, themeConfig);
 
   return (
     <Layout
@@ -80,7 +63,7 @@ const FAQ: React.FC = () => {
             </div>
           </SingleCol>
 
-          {featureFlags["concepts-v1"] === true && (
+          {knowledgeGraphEnabled && (
             <SingleCol>
               <div className="text-content mb-12">
                 <Heading level={2}>Concepts FAQs</Heading>

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -347,6 +347,9 @@ const config: TThemeConfig = {
     },
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"],
+  features: {
+    knowledgeGraph: true,
+  },
 };
 
 export default config;

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -348,7 +348,7 @@ const config: TThemeConfig = {
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"],
   features: {
-    knowledgeGraph: true,
+    knowledgeGraph: false,
   },
 };
 

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
@@ -6,30 +6,14 @@ import Layout from "@/components/layouts/Main";
 import { SubNav } from "@/components/nav/SubNav";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
+import { ThemePageFeaturesContext } from "@/context/ThemePageFeaturesContext";
 import { FAQS, PLATFORM_FAQS } from "@/cpr/constants/faqs";
-import { getAllCookies } from "@/utils/cookies";
-import { getFeatureFlags } from "@/utils/featureFlags";
+import { isKnowledgeGraphEnabled } from "@/utils/features";
 
 const FAQ: React.FC = () => {
-  /*
-  The FAQs page is read in not by using Next.JS, but by our CPR specific page reading logic.
-  This means that we cannot fetch the feature flags directly by using the page context.
-  This function provides a means of working around this so we can conditionally display the
-  concept FAQs.
+  const { featureFlags, themeConfig } = useContext(ThemePageFeaturesContext);
 
-  TODO: Remove this once we have hard launched concepts in product.
-  */
-  const [featureFlags, setFeatureFlags] = useState({});
-  async function getFeatureFlag() {
-    const allCookies = getAllCookies();
-    const parsedFeatureFlags = await getFeatureFlags(allCookies);
-    setFeatureFlags(parsedFeatureFlags);
-  }
-
-  // TODO: Remove this once we have hard launched concepts in product.
-  useEffect(() => {
-    getFeatureFlag();
-  }, []);
+  const knowledgeGraphEnabled = isKnowledgeGraphEnabled(featureFlags, themeConfig);
 
   return (
     <Layout
@@ -43,7 +27,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {knowledgeGraphEnabled && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
     </Layout>

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -132,6 +132,9 @@ const config: TThemeConfig = {
     },
   ],
   documentCategories: ["All"],
+  features: {
+    knowledgeGraph: false,
+  },
 };
 
 export default config;

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useContext } from "react";
 
 import FaqSection from "@/components/FaqSection";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
@@ -6,30 +6,15 @@ import Layout from "@/components/layouts/Main";
 import { SubNav } from "@/components/nav/SubNav";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { CONCEPTS_FAQS } from "@/constants/conceptsFaqs";
+import { ThemePageFeaturesContext } from "@/context/ThemePageFeaturesContext";
 import { FAQS, PLATFORM_FAQS } from "@/mcf/constants/faqs";
-import { getAllCookies } from "@/utils/cookies";
-import { getFeatureFlags } from "@/utils/featureFlags";
+import { isKnowledgeGraphEnabled } from "@/utils/features";
 
 const FAQ: React.FC = () => {
-  /*
-    The FAQs page is read in not by using Next.JS, but by our CPR specific page reading logic.
-    This means that we cannot fetch the feature flags directly by using the page context.
-    This function provides a means of working around this so we can conditionally display the
-    concept FAQs.
-  
-    TODO: Remove this once we have hard launched concepts in product.
-  */
-  const [featureFlags, setFeatureFlags] = useState({});
-  async function getFeatureFlag() {
-    const allCookies = getAllCookies();
-    const parsedFeatureFlags = await getFeatureFlags(allCookies);
-    setFeatureFlags(parsedFeatureFlags);
-  }
+  const { featureFlags, themeConfig } = useContext(ThemePageFeaturesContext);
 
-  // TODO: Remove this once we have hard launched concepts in product.
-  useEffect(() => {
-    getFeatureFlag();
-  }, []);
+  const knowledgeGraphEnabled = isKnowledgeGraphEnabled(featureFlags, themeConfig);
+
   return (
     <Layout
       title="FAQ"
@@ -42,7 +27,7 @@ const FAQ: React.FC = () => {
         <SiteWidth>
           <FaqSection title="FAQs" faqs={FAQS} />
           <FaqSection title="Platform FAQs" faqs={PLATFORM_FAQS} />
-          {featureFlags["concepts-v1"] === true && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
+          {knowledgeGraphEnabled && <FaqSection title="Concepts FAQs" faqs={CONCEPTS_FAQS} />}
         </SiteWidth>
       </section>
       <script id="feature-flags" type="text/json" dangerouslySetInnerHTML={{ __html: JSON.stringify(featureFlags) }} />


### PR DESCRIPTION
# What's changed

This PR adds app-level features via app config so that each app can have different features. This is a separate mechanism to feature flags, but they can be combined together to provide more control.

### Config Features

- Updated `TThemeConfig` to include a `features` key of known feature keys and required booleans for each.
- `knowledgeGraph` is the first theme config feature and is enabled for both CPR and CCLW.

### Determining if a feature is enabled

- Added `isFeatureEnabled` function which considers the intersection of feature flags and theme config features to determine if a feature is active (see table below).
- All permutations are tested as this needs to be rock solid.
- Added shorthand functions for each feature we currently have, allowing you to call a syntactic sugar function with minimal arguments, e.g. `isLitigationEnabled(featureFlags)`.

This table represents how `isFeatureEnabled` determines its output. Note that either of its two arguments are optional, so it supports an app feature without a feature flag and vice versa.

- Horizontal axis: app config feature
- Vertical axis: feature flag

|| `true` | `false` | `undefined` |
|---|---|---|---|
| `true` | `true` | `true` | `true` |
| `false` | `true` | `false` | `false` |
| `undefined` | `true` | `false` | `false` |

What does this mean in practice?
- If a feature flag and app feature are both undefined, there's no need to use this function.
- If the app feature is `true`, the feature flag is ignored and the feature is on.
- If the app feature is `false` and there is no feature flag, the feature is off.
- Otherwise use the feature flag value.

### Putting it into practice

- All existing instances of direct feature flag comparison has been replaced by the new shorthand functions!
- Some `getServerSideProps` async calls for feature flags and theme config has been standardised in service of this.
- Extra tidy up around typings and state defaults.

### Dynamic theme pages

As the `concepts-v1` feature flag is already in use on dynamic theme pages, these also needed addressing:
- Added `ThemePageFeaturesContext` to roll up the theme config and feature flags.
- Applied `ThemePageFeaturesContext` around the dynamic page component.
- Replaced feature flag loading within each page with context use and shorthand feature functions.

## Why?

- Satisfies [APP-621](https://linear.app/climate-policy-radar/issue/APP-621/enable-us-to-phase-key-features-onto-different-custom-apps-in-stages).
- Feature branching should be bulletproof and a doddle for anyone to use or understand.