### PR TITLE
APP-521: Quick win text changes to make to product

### DIFF
--- a/src/components/footer/FooterLinks.tsx
+++ b/src/components/footer/FooterLinks.tsx
@@ -5,8 +5,17 @@ const FooterLinks = () => {
   return (
     <nav>
       <div data-cy="footer-nav" className="flex flex-col gap-2 md:flex-row justify-center md:gap-8 md:gap-16">
-        <ExternalLink url="https://github.com/climatepolicyradar/methodology" className="text-white underline hover:text-blue-500">
+        <ExternalLink
+          url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md"
+          className="text-white underline hover:text-blue-500"
+        >
           Methodology
+        </ExternalLink>
+        <ExternalLink
+          url="https://github.com/climatepolicyradar/methodology/blob/main/Climate%20Policy%20Radar%20Codebook.xlsx"
+          className="text-white underline hover:text-blue-500"
+        >
+          Codebook
         </ExternalLink>
         <LinkWithQuery href="/terms-of-use" className="text-white underline hover:text-blue-500">
           Terms &amp; conditions

--- a/src/components/menus/MainMenu.tsx
+++ b/src/components/menus/MainMenu.tsx
@@ -30,7 +30,7 @@ const MainMenu = ({ iconClass = "text-white" }: IProps) => {
             <DropdownMenuItem external={true} href="https://climatepolicyradar.org" title="About us" first={true} setShowMenu={setShowMenu} />
             <DropdownMenuItem
               external={true}
-              href="https://github.com/climatepolicyradar/methodology"
+              href="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md"
               title="Methodology"
               setShowMenu={setShowMenu}
             />

--- a/src/constants/platformFaqs.tsx
+++ b/src/constants/platformFaqs.tsx
@@ -146,7 +146,7 @@ export const PLATFORM_FAQS: TFAQ[] = [
     ),
   },
   {
-    title: "What map and boundaries are used?",
+    title: "What geographical map and boundaries are used?",
     content: (
       <>
         <p>

--- a/themes/ccc/pages/methodology.tsx
+++ b/themes/ccc/pages/methodology.tsx
@@ -42,7 +42,10 @@ const Methodology = () => {
                 offered alongside national level climate change laws and policies to help users in gaining a comprehensive understanding of national
                 level climate action. For details of the documents included, please visit our <LinkWithQuery href="/faq">FAQs</LinkWithQuery>. To
                 understand more about how new document types may be added in future, visit the{" "}
-                <ExternalLink url="https://github.com/climatepolicyradar/methodology">Climate Policy Radar methodology page</ExternalLink>.
+                <ExternalLink url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md">
+                  Climate Policy Radar methodology page
+                </ExternalLink>
+                .
               </p>
               <p>
                 Classifications described below have been assigned manually. LSE, Climate Policy Radar, and our partners are currently working to

--- a/themes/cclw/constants/faqs.tsx
+++ b/themes/cclw/constants/faqs.tsx
@@ -482,7 +482,7 @@ export const FAQS: TFAQ[] = [
     ),
   },
   {
-    title: "What map and boundaries are used?",
+    title: "What geographical map and boundaries are used?",
     content: (
       <p>
         This map was made with the{" "}

--- a/themes/cclw/pages/methodology.tsx
+++ b/themes/cclw/pages/methodology.tsx
@@ -42,7 +42,10 @@ const Methodology = () => {
                 offered alongside national level climate change laws and policies to help users in gaining a comprehensive understanding of national
                 level climate action. For details of the documents included, please visit our <LinkWithQuery href="/faq">FAQs</LinkWithQuery>. To
                 understand more about how new document types may be added in future, visit the{" "}
-                <ExternalLink url="https://github.com/climatepolicyradar/methodology">Climate Policy Radar methodology page</ExternalLink>.
+                <ExternalLink url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md">
+                  Climate Policy Radar methodology page
+                </ExternalLink>
+                .
               </p>
               <p>
                 Classifications described below have been assigned manually. LSE, Climate Policy Radar, and our partners are currently working to

--- a/themes/cpr/components/LandingSearchForm.tsx
+++ b/themes/cpr/components/LandingSearchForm.tsx
@@ -49,7 +49,7 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) =>
     };
   }, [formRef]);
 
-  const displayPlaceholder = placeholder ?? "Search the full text of 5000+ laws and policies";
+  const displayPlaceholder = placeholder ?? "Search the full text of over 12,000 climate documents";
 
   return (
     <form

--- a/themes/cpr/components/MethodologyLink.tsx
+++ b/themes/cpr/components/MethodologyLink.tsx
@@ -1,5 +1,7 @@
 import { ExternalLink } from "@/components/ExternalLink";
 
-const MethodologyLink = () => <ExternalLink url="https://github.com/climatepolicyradar/methodology">our methodology page</ExternalLink>;
+const MethodologyLink = () => (
+  <ExternalLink url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md">our methodology page</ExternalLink>
+);
 
 export default MethodologyLink;

--- a/themes/cpr/components/Summary.tsx
+++ b/themes/cpr/components/Summary.tsx
@@ -14,7 +14,7 @@ const Summary = () => {
           </p>
         </div>
         <ExternalLink
-          url="https://github.com/climatepolicyradar/methodology"
+          url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md"
           className="mt-4 md:mt-0 block w-full text-center bg-blue-500 text-white md:grow-0 p-2 rounded-xl md:w-48 transition duration-300 hover:text-white"
         >
           <div className="flex justify-center">

--- a/themes/cpr/components/oep/Footer.tsx
+++ b/themes/cpr/components/oep/Footer.tsx
@@ -21,7 +21,10 @@ export const Footer = () => {
         </p>
         <ul className="md:flex gap-9">
           <li className="mb-4 md:mb-0">
-            <ExternalLink url="https://github.com/climatepolicyradar/methodology" className="text-textNormal underline opacity-60 hover:opacity-100">
+            <ExternalLink
+              url="https://github.com/climatepolicyradar/methodology/blob/main/METHODOLOGY.md"
+              className="text-textNormal underline opacity-60 hover:opacity-100"
+            >
               Methodology
             </ExternalLink>
           </li>

--- a/themes/cpr/constants/faqs.tsx
+++ b/themes/cpr/constants/faqs.tsx
@@ -13,9 +13,9 @@ export const FAQS: TFAQ[] = [
     content: (
       <>
         <p>
-          Climate Policy Radar builds responsible AI tools for climate action. A UK-based not-for-profit, our data and tools help governments,
-          researchers, international organisations, civil society, and the private sector create effective climate policies and deploy climate
-          finance.
+          Climate Policy Radar builds responsible AI tools for climate action. A UK-based not-for-profit, our data and tools support governments,
+          researchers, international organisations, civil society, and the private sector in their decision-making pertaining to climate policy, law
+          and/or finance.
         </p>
       </>
     ),
@@ -62,7 +62,10 @@ export const PLATFORM_FAQS: TFAQ[] = [
           <li>Search for keywords and policy topics (like 'electric vehicles' or 'gender equality') across the full text of all documents</li>
           <li>View your search term (and related phrases) highlighted in search results</li>
           <li>Browse country profiles to find and compare their climate laws, policies and strategies</li>
-          <li>Access the raw data: you just need to fill out this form to request a copy of the entire dataset</li>
+          <li>
+            Access the raw data: you just need to fill out <ExternalLink url="https://form.jotform.com/250202141318339">this form</ExternalLink> to
+            request a copy of the entire dataset
+          </li>
         </ul>
       </>
     ),

--- a/themes/mcf/constants/platformFaqs.tsx
+++ b/themes/mcf/constants/platformFaqs.tsx
@@ -188,7 +188,7 @@ export const PLATFORM_FAQS: TFAQ[] = [
     ),
   },
   {
-    title: "What map and boundaries are used?",
+    title: "What geographical map and boundaries are used?",
     content: (
       <>
         <p>


### PR DESCRIPTION
# What's changed

- A bunch of specific "replace X with Y" style copy changes.
- Links to "methodology" that don't explicitly mention the codebook now go to that markdown page directly.
- Added a "Codebook" footer link.

## Why?

Satisfies [APP-521](https://linear.app/climate-policy-radar/issue/APP-521/quick-win-text-changes-to-make-to-product).

## Screenshots?
<img width="889" alt="Screenshot 2025-05-29 at 17 06 47" src="https://github.com/user-attachments/assets/8bde3b84-b98e-4d69-a969-16587121ae39" />