### PR TITLE
Add UNFCCC filters to cclw config

### DIFF
--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -68,6 +68,69 @@ const config: TThemeConfig = {
       corporaKey: "Laws and Policies",
       quickSearch: "true",
     },
+    {
+      label: "Author Type",
+      corporaKey: "Intl. agreements",
+      taxonomyKey: "author_type",
+      apiMetaDataKey: "family.author.type",
+      type: "radio",
+      category: ["UNFCCC.corpus.i00000001.n0000"],
+    },
+    {
+      label: "Type of submission",
+      corporaKey: "Intl. agreements",
+      taxonomyKey: "_document.type",
+      apiMetaDataKey: "document.type",
+      type: "radio",
+      category: ["UNFCCC.corpus.i00000001.n0000"],
+      options: [
+        {
+          label: "Nationally Determined Contribution (NDC)",
+          slug: "Nationally Determined Contribution",
+          value: "Nationally Determined Contribution",
+        },
+        {
+          label: "National Adaptation Plan (NAP)",
+          slug: "National Adaptation Plan",
+          value: "National Adaptation Plan",
+        },
+        {
+          label: "Biennial Transparency Report (BTR)",
+          slug: "Biennial Transparency Report",
+          value: "Biennial Transparency Report",
+        },
+        {
+          label: "Long-Term Low-Emission Development Strategy (LT-LEDS)",
+          slug: "Long-Term Low-Emission Development Strategy",
+          value: "Long-Term Low-Emission Development Strategy",
+        },
+        {
+          label: "Biennial Update Report (BUR)",
+          slug: "Biennial Update Report",
+          value: "Biennial Update Report",
+        },
+        {
+          label: "Biennial Report (BR)",
+          slug: "Biennial Report",
+          value: "Biennial Report",
+        },
+        {
+          label: "National Communication (NC)",
+          slug: "National Communication",
+          value: "National Communication",
+        },
+        {
+          label: "National Inventory Report (NIR)",
+          slug: "National Inventory Report",
+          value: "National Inventory Report",
+        },
+        {
+          label: "Adaptation Communication (AC)",
+          slug: "Adaptation Communication",
+          value: "Adaptation Communication",
+        },
+      ],
+    },
   ],
   labelVariations: [],
   links: [


### PR DESCRIPTION
# What's changed
- Adding the UNFCCC filters to the cclw theme

## Why?
- So that the climate laws app gets access to the new UNFCCC filters

## Screenshots?
