### PR TITLE
Fix author type key name in config and query builder

### DIFF
--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -227,12 +227,12 @@ export default function buildSearchQuery(
   }
   // ---- End of MCF specific ----
 
-  // ---- Reports specific ----
-  // These are the filters that are specific to the Reports corpus type
+  // ---- Reports & UNFCCC specific ----
+  // These are the filters that are specific to the Reports and UNFCCC corpus types - note: we pass in the corpusIds to check as there are multiple instances of the same filter
   if (routerQuery[QUERY_PARAMS.author_type]) {
-    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig);
+    query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.author_type], "author_type", themeConfig, corpusIds);
   }
-  // ---- End of Reports specific ----
+  // ---- End of Reports & UNFCCC specific specific ----
 
   // ---- UNFCCC specific ----
   // These are the filters that are specific to the UNFCCC corpus type

--- a/src/utils/buildSearchQueryMetadata.ts
+++ b/src/utils/buildSearchQueryMetadata.ts
@@ -4,14 +4,20 @@ export const buildSearchQueryMetadata = (
   metadata: TSearchCriteriaMeta[],
   metadataValue: string | string[],
   taxonomyKey: string,
-  themeConfig: TThemeConfig
+  themeConfig: TThemeConfig,
+  corpusIds?: string[]
 ) => {
   let metadataForApi: string[];
   let newMetadata: TSearchCriteriaMeta[] = [...metadata];
-  const configMetadata = themeConfig.filters.find((f) => f.taxonomyKey === taxonomyKey);
-  if (configMetadata) {
+  // Find the relevant filter option for the given taxonomy key
+  // If corpus IDs are passed in we need an additional check for the relevant corpus ID
+  // If no corpus IDs are passed, or the filter does not have a category defined we can use the filter
+  const filterOption = themeConfig.filters.find(
+    (f) => f.taxonomyKey === taxonomyKey && (corpusIds?.some((c) => f.category.includes(c)) || !f.category || !corpusIds)
+  );
+  if (filterOption) {
     // remove existing metadata filters from the metadata
-    newMetadata = newMetadata.filter((m) => m.name !== configMetadata.apiMetaDataKey);
+    newMetadata = newMetadata.filter((m) => m.name !== filterOption.apiMetaDataKey);
     if (Array.isArray(metadataValue)) {
       metadataForApi = metadataValue;
     } else {
@@ -20,7 +26,7 @@ export const buildSearchQueryMetadata = (
     metadataForApi.map((m) => {
       if (decodeURI(m).trim().length > 0) {
         newMetadata.push({
-          name: configMetadata.apiMetaDataKey,
+          name: filterOption.apiMetaDataKey,
           value: decodeURI(m),
         });
       }

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -72,7 +72,7 @@ const config: TThemeConfig = {
       label: "Author Type",
       corporaKey: "Intl. agreements",
       taxonomyKey: "author_type",
-      apiMetaDataKey: "family.author.type",
+      apiMetaDataKey: "family.author_type",
       type: "radio",
       category: ["UNFCCC.corpus.i00000001.n0000"],
     },

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -254,7 +254,7 @@ const config: TThemeConfig = {
       label: "Author Type",
       corporaKey: "Intl. agreements",
       taxonomyKey: "author_type",
-      apiMetaDataKey: "family.author.type",
+      apiMetaDataKey: "family.author_type",
       type: "radio",
       category: ["UNFCCC.corpus.i00000001.n0000"],
     },


### PR DESCRIPTION
# What's changed
- The author type was incorrectly named, it only worked on cpr because there was another author type field
- Now added additional checks when building the search query object to check against the selected corpus (optional param) to prevent this in future

## Why?

## Screenshots?
