### PR TITLE
fixL: remove posthog person_profiles

### DIFF
--- a/src/context/PostHogProvider.tsx
+++ b/src/context/PostHogProvider.tsx
@@ -65,7 +65,6 @@ export function PostHogProvider({ children, consent }: IProps) {
       capture_pageview: false,
       capture_pageleave: true,
       persistence: "memory",
-      person_profiles: "always",
     });
     window.sessionStorage.setItem("posthogLoaded", "true");
 


### PR DESCRIPTION
# What's changed

- removes the use of [posthog's `person_profiles`](https://posthog.com/docs/data/anonymous-vs-identified-events)

[There's more context here](https://linear.app/climate-policy-radar/issue/ANA-9/why-have-posthogs-landing-page-numbers-changed).

Fixes https://linear.app/climate-policy-radar/issue/ANA-10/reverse-change-httpsgithubcomclimatepolicyradarnavigator

## Why?

**TL;DR;**
- We are seeing some strange data happening when that change was made. @juliesaigusaCPR 
- We can't think of a reason why this change made this strangeness happen, but this should rule it in / out depending on if we see it return to normal
- If it does return to normal we will get hold of posthog to try debug the issue


