### PR TITLE
APP-634: Menu icon on CCLW app is barely distinguishable

### DIFF
--- a/themes/cclw/components/Header.tsx
+++ b/themes/cclw/components/Header.tsx
@@ -1,9 +1,9 @@
 import Image from "next/image";
 import { useRouter } from "next/router";
 
+import { Menu } from "@/cclw/components/Menu";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { NavBar } from "@/components/organisms/navBar/NavBar";
-import { Menu } from "@/mcf/components/Menu";
 
 export const CCLWLogo = (
   <LinkWithQuery href={`/`} cypress="cclw-logo">


### PR DESCRIPTION
# What's changed

- The CCLW theme `Header` now correctly imports the CCLW `Menu`, not the MCF one.
  - Issue introduced by me during the search in navbar work.
  - Fortunately the CCLW and MCF menus are near identical - the only consequence was that the link to the "Framework laws" page was missing, and some of the menu items were in the wrong order.
- Also checked for other instances of themed imports on the wrong theme and found none.

## Why?

- Satisfies [APP-634](https://linear.app/climate-policy-radar/issue/APP-634/menu-icon-on-cclw-app-is-barely-distinguishable), a bug fix.

## Screenshots?

<img width="1407" alt="Screenshot 2025-06-03 at 10 33 48" src="https://github.com/user-attachments/assets/413e5af6-59a3-4f3a-ab97-5c4b994339c2" />