### PR TITLE
feat: manual deploys to staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,6 +6,7 @@ on:
       - completed
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   id-token: write


### PR DESCRIPTION
# What's changed
- adds the ability to manually build and deploy to staging

I need to get this merged into `main` to allow the `workflow_dispatch` test.

## Why?
So that we can test on `staging` and potentially allow for auto-deploys to `production`

