### PR TITLE
App 635 document page double search

### DIFF
--- a/src/components/EmbeddedPDF.tsx
+++ b/src/components/EmbeddedPDF.tsx
@@ -15,7 +15,6 @@ interface IProps {
 }
 
 const EmbeddedPDF = ({ document, documentPassageMatches = [], passageIndex = null, startingPassageIndex = 0 }: IProps) => {
-  const isLoading = useState(true);
   const containerRef = useRef(null);
   const adobeKey = useContext(AdobeContext);
 

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -11,11 +11,10 @@ import { EmptyDocument } from "@/components/documents/EmptyDocument";
 import { EmptyPassages } from "@/components/documents/EmptyPassages";
 import { UnavailableConcepts } from "@/components/documents/UnavailableConcepts";
 import { SearchSettings } from "@/components/filters/SearchSettings";
-import { MAX_PASSAGES, MAX_RESULTS } from "@/constants/paging";
+import { MAX_RESULTS } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { useEffectOnce } from "@/hooks/useEffectOnce";
-import useSearch from "@/hooks/useSearch";
-import { TConcept, TDocumentPage, TPassage, TSearchResponse } from "@/types";
+import { TConcept, TDocumentPage, TLoadingStatus, TMatchedFamily, TPassage, TSearchResponse } from "@/types";
 import { getPassageResultsContext } from "@/utils/getPassageResultsContext";
 import { fetchAndProcessConcepts } from "@/utils/processConcepts";
 
@@ -39,6 +38,8 @@ interface IProps {
   vespaDocumentData: TSearchResponse;
   document: TDocumentPage;
   familySlug: string;
+  searchStatus: TLoadingStatus;
+  searchResultFamilies: TMatchedFamily[];
   // Callback props for state changes
   onExactMatchChange?: (isExact: boolean) => void;
 }
@@ -50,10 +51,6 @@ const passageClasses = (canPreview: boolean) => {
   return "xl:w-2/3";
 };
 
-const renderPassageCount = (count: number): string => {
-  return count > MAX_PASSAGES ? `top ${MAX_PASSAGES} matches` : count + ` match${count > 1 ? "es" : ""}`;
-};
-
 export const ConceptsDocumentViewer = ({
   initialQueryTerm = "",
   initialExactMatch = false,
@@ -63,6 +60,8 @@ export const ConceptsDocumentViewer = ({
   familySlug,
   vespaFamilyData,
   vespaDocumentData,
+  searchStatus,
+  searchResultFamilies,
   onExactMatchChange,
 }: IProps) => {
   const router = useRouter();
@@ -80,6 +79,7 @@ export const ConceptsDocumentViewer = ({
 
   const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
 
+  // Load concept data
   useEffectOnce(() => {
     // Extract unique concept IDs directly from vespaFamilyData
     const conceptIds = new Set<string>();
@@ -137,69 +137,42 @@ export const ConceptsDocumentViewer = ({
     [initialConceptFilters, familyConcepts]
   );
 
-  // Check if any initial concept filters are not in the document concepts (e.g., the concept appears in the family or other documents
-  // but not this one)
+  // Check if any initial concept filters are not in the document concepts
+  // (e.g., the concept appears in the family or other documents but not this one)
   const unavailableConcepts = initialConceptFilters
     ? initialConceptFilters.filter((filter) => !documentConcepts?.some((concept) => concept.preferred_label === filter))
     : [];
 
-  // Prepare search.
-  const searchQueryParams = useMemo(
-    () => ({
-      [QUERY_PARAMS.query_string]: initialQueryTerm,
-      [QUERY_PARAMS.exact_match]: state.isExactSearch ? "true" : "false",
-      [QUERY_PARAMS.concept_name]: initialConceptFilters
-        ? Array.isArray(initialConceptFilters)
-          ? initialConceptFilters
-          : [initialConceptFilters]
-        : undefined,
-    }),
-    [initialQueryTerm, state.isExactSearch, initialConceptFilters]
-  );
-
-  const { status, families, searchQuery } = useSearch(
-    searchQueryParams,
-    null,
-    document.import_id,
-    !!(initialQueryTerm || initialConceptFilters),
-    MAX_PASSAGES
-  );
-
   // Calculate passage matches.
   useEffect(() => {
-    const matches = families.flatMap((family) =>
+    const matches = searchResultFamilies.flatMap((family) =>
       family.family_documents.filter((cacheDoc) => cacheDoc.document_slug === document.slug).flatMap((cacheDoc) => cacheDoc.document_passage_matches)
     );
 
     const totalMatches =
-      families.find((family) => family.family_documents.some((cacheDoc) => cacheDoc.document_slug === document.slug))?.total_passage_hits || 0;
+      searchResultFamilies.find((family) => family.family_documents.some((cacheDoc) => cacheDoc.document_slug === document.slug))
+        ?.total_passage_hits || 0;
 
     setState({
       passageMatches: matches,
       totalNoOfMatches: totalMatches,
     });
-  }, [families, document.slug]);
+  }, [searchResultFamilies, document.slug]);
 
-  const handlePassageClick = useCallback(
-    (index: number) => {
-      if (!canPreview) return;
-      setState({ passageIndex: index });
-    },
-    [canPreview]
-  );
+  const handlePassageClick = (index: number) => {
+    if (!canPreview) return;
+    setState({ passageIndex: index });
+  };
 
-  const handleSemanticSearchChange = useCallback(
-    (_: string, isExact: string) => {
-      const exactBool = isExact === "true";
-      setState({
-        isExactSearch: exactBool,
-        passageIndex: 0,
-      });
-      setShowSearchOptions(false);
-      onExactMatchChange?.(exactBool);
-    },
-    [onExactMatchChange]
-  );
+  const handleSemanticSearchChange = (_: string, isExact: string) => {
+    const exactBool = isExact === "true";
+    setState({
+      isExactSearch: exactBool,
+      passageIndex: 0,
+    });
+    setShowSearchOptions(false);
+    onExactMatchChange?.(exactBool);
+  };
 
   const handleToggleConcepts = () => {
     setShowConcepts((current) => !current);
@@ -219,7 +192,7 @@ export const ConceptsDocumentViewer = ({
     selectedTopics: selectedConcepts,
   });
 
-  const isLoading = status !== "success";
+  const isLoading = searchStatus !== "success";
   const hasConcepts = documentConcepts.length > 0;
   const hasSelectedConcepts = selectedConcepts.length > 0;
   const hasPassages = state.totalNoOfMatches > 0;
@@ -297,7 +270,7 @@ export const ConceptsDocumentViewer = ({
                   }}
                 >
                   <SearchSettings
-                    queryParams={searchQueryParams}
+                    queryParams={router.query}
                     handleSearchChange={handleSemanticSearchChange}
                     handlePassagesClick={handlePassagesOrderChange}
                     setShowOptions={setShowSearchOptions}

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -83,7 +83,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   const passagesByPosition = router.query[QUERY_PARAMS.passages_by_position] === "true";
   const startingPassage = Number(router.query.passage) || 0;
 
-  // TODO: Remove this once we have hard launched concepts in product.
+  // Note: only runs a fresh start if either a query string or concept data is provided
   const { status, families, searchQuery } = useSearch(
     router.query,
     null,
@@ -138,7 +138,6 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   };
 
   // Handlers to update router
-
   const handleExactMatchChange = useCallback(
     (isExact: boolean) => {
       const queryObj = { ...router.query };
@@ -159,6 +158,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     [router, document.slug]
   );
 
+  // Update passages based on search results
   useEffect(() => {
     const [passageMatches, totalNoOfMatches] = getMatchedPassagesFromSearch(families, document);
 
@@ -309,6 +309,8 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
             vespaDocumentData={vespaDocumentData}
             familySlug={family.slug}
             document={document}
+            searchStatus={status}
+            searchResultFamilies={families}
             onExactMatchChange={handleExactMatchChange}
           />
         )}


### PR DESCRIPTION
# What's changed
Prevent double calls to the `/searches` endpoint by:
- Moving search out of the `ConceptsDocumentViewer` and instead pass in from the document page where the existing search was taking place

- Removed a couple of instances of `useCallback` inspired by Kent (https://kentcdodds.com/blog/usememo-and-usecallback). I don't believe we need to preserve the identity of this function in between renders

## Why?
- I believe this was leading to race conditions which was displaying oddities to the user (showing a loader when the API call had finished, etc)
- Reduced duplication between document page and component

## Screenshots?
