### PR TITLE
feat: add GITHU_SHA as version from api/health endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,8 @@ THEME=cpr
 ADOBE_API_KEY=dca9187b65294374a6367824df902fdf
 HOSTNAME=http://localhost:3000
 
+# @related: GITHUB_SHA_ENV_VAR
+GITHUB_SHA=local
+
 # to run playwright tests in watch mode
 # PWTEST_WATCH=1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,7 +52,8 @@ jobs:
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ inputs.theme }}
           THEME: ${{ inputs.theme }}
+        # @related: GITHUB_SHA_ENV_VAR
         run: |
-          docker build --build-arg THEME=${THEME} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --build-arg THEME=${THEME} --build-arg GITHUB_SHA=$(git rev-parse HEAD) -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+  pull_request:
+    types: [labeled]
 
 permissions:
   id-token: write
@@ -14,7 +16,7 @@ permissions:
 
 jobs:
   deploy-staging:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'deploy:staging' }}
     strategy:
       matrix:
         theme: [cpr, cclw, mcf, ccc]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,12 +1,15 @@
 name: Deploy to staging
 on:
+  # a. Auto deploy once the merge-to-main action is completed successfully
   workflow_run:
     workflows: [Merge to main]
     types:
       - completed
     branches:
       - main
+  # b. Allow deployment from the actions tab - this allows feature branch deployment
   workflow_dispatch: {}
+  # c. Label a PR with "deploy:staging" will deply to staging
   pull_request:
     types: [labeled]
 
@@ -16,7 +19,11 @@ permissions:
 
 jobs:
   deploy-staging:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'deploy:staging' }}
+    # relating to a, b, c in the `on` section
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'deploy:staging'
     strategy:
       matrix:
         theme: [cpr, cclw, mcf, ccc]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   deploy-staging:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         theme: [cpr, cclw, mcf, ccc]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,7 +42,8 @@ jobs:
           AWS_REGION: eu-west-1
           ECR_REPOSITORY: navigator-frontend-${{ matrix.theme }}
           THEME: ${{ matrix.theme }}
+        # @related: GITHUB_SHA_ENV_VAR
         run: |
-          docker build --build-arg THEME=${THEME} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --build-arg THEME=${THEME} --build-arg GITHUB_SHA=$(git rev-parse HEAD) -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
+# trunk-ignore-all(trivy/DS026)
+# trunk-ignore-all(checkov/CKV_DOCKER_2)
 FROM node:22.12.0-alpine3.21
 
 ARG THEME
 ENV THEME=$THEME
+
+# @related: GITHUB_SHA_ENV_VAR
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA}
 
 # Make sure the latest npm is installed for speed and fixes.
 RUN npm i npm@latest -g

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({
+    /** @related: GITHUB_SHA_ENV_VAR */
+    version: process.env.GITHUB_SHA || "unknown",
+  });
+}


### PR DESCRIPTION
# What's changed
- adds `version` to `/api/health` endpoint

## ✨ BONUS FEATURES!
- Tested [manual deploying of feature branches](https://github.com/climatepolicyradar/navigator-frontend/pull/542) to `staging`
- You can also tag / retag a PR with `deploy:staging` which will kick off a deploy straight from your PR

Based on https://github.com/climatepolicyradar/navigator-backend/pull/516

## Why?
This will allow us to track what's deployed vs what's available to be deployed

## Screenshots?
![Screenshot 2025-06-03 at 16 46 32](https://github.com/user-attachments/assets/cb05707d-74b3-4bf0-815b-5c4c12e3fa5b)


