### PR TITLE
Add two bits of business logic to force sort to be within a page

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -37,6 +37,16 @@ const getCurrentSemanticSearchChoice = (queryParams: ParsedUrlQuery) => {
 };
 
 const getCurrentPassagesOrderChoice = (queryParams: ParsedUrlQuery) => {
+  // TODO: remove this
+  // Setting the default sort order to "sort_within_page" for a specific search with conditions:
+  // - no search query
+  // - with concepts/classifiers
+  if (
+    !queryParams[QUERY_PARAMS.passages_by_position] &&
+    !queryParams[QUERY_PARAMS.query_string] &&
+    (queryParams[QUERY_PARAMS.concept_id] || queryParams[QUERY_PARAMS.concept_name])
+  )
+    return true;
   return queryParams[QUERY_PARAMS.passages_by_position] === "true";
 };
 

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -50,6 +50,20 @@ export default function buildSearchQuery(
     query.sort_within_page = routerQuery[QUERY_PARAMS.passages_by_position] === "true";
   }
 
+  // TODO: remove this
+  // Setting the default sort order to "sort_within_page" for a specific search with conditions:
+  // - no search query
+  // - within a document view
+  // - with concepts/classifiers
+  if (
+    !routerQuery[QUERY_PARAMS.passages_by_position] &&
+    !routerQuery[QUERY_PARAMS.query_string] &&
+    documentId &&
+    (routerQuery[QUERY_PARAMS.concept_id] || routerQuery[QUERY_PARAMS.concept_name])
+  ) {
+    query.sort_within_page = true;
+  }
+
   if (routerQuery[QUERY_PARAMS.offset]) {
     query.offset = Number(routerQuery[QUERY_PARAMS.offset]);
   }


### PR DESCRIPTION
# What's changed
Setting the default sort order to "sort_within_page" for a specific search with conditions:
- no search query
- within a document view
- with concepts/classifiers

⚠️ This is known and accepted business logic / technical debt

## Why?
See ticket but essentially product and users are unhappy with the default logic when only classifiers are being applied to search

## Screenshots?
