### PR TITLE
Move search results across when topics is open

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -436,7 +436,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
             <div
               className={`flex-1 bg-white transition-all duration-150 ${
                 currentSlideOut
-                  ? "md:pointer-events-none md:select-none md:opacity-50" // if we want slide across: xl:pointer-events-auto xl:select-auto xl:opacity-100 xl:ml-[460px]
+                  ? "md:pointer-events-none md:select-none md:opacity-50 xl:pointer-events-auto xl:select-auto xl:opacity-100 xl:ml-[460px]"
                   : ""
               }`}
             >


### PR DESCRIPTION
# What's changed
- When the topics slideout is open, move the search results across and do not fade them or remove click events

## Why?
- Feedback on UX is that the search needs to be visible

## Screenshots?
https://github.com/user-attachments/assets/76214e8f-85a3-4da6-9fb7-0586ac35da8d

