### PR TITLE
APP-708: Change the CTA for opening the drawer

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from "react";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { TFamily } from "@/types";
+import { joinTailwindClasses } from "@/utils/tailwind";
 import { truncateString } from "@/utils/truncateString";
 
 import { FamilyMeta } from "./FamilyMeta";
@@ -10,9 +11,10 @@ interface IProps {
   children?: ReactNode;
   family: TFamily;
   showSummary?: boolean;
+  titleClasses?: string;
 }
 
-export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = true }) => {
+export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = true, titleClasses = "hover:underline" }) => {
   const {
     corpus_type_name,
     family_slug,
@@ -24,6 +26,8 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
     family_metadata,
     family_source,
   } = family;
+
+  const allTitleClasses = joinTailwindClasses("result-title text-left font-medium text-lg duration-300 flex items-start", titleClasses);
 
   return (
     <div className="family-list-item relative">
@@ -37,12 +41,7 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
           {...(corpus_type_name === "Reports" ? { author: (family_metadata as { author: string[] }).author } : {})}
         />
       </div>
-      <LinkWithQuery
-        href={`/document/${family_slug}`}
-        className="result-title text-[#0041A3] text-left font-medium text-lg duration-300 flex items-start !no-underline hover:!underline"
-        passHref
-        data-cy="family-title"
-      >
+      <LinkWithQuery href={`/document/${family_slug}`} className={allTitleClasses} passHref data-cy="family-title">
         {family_name}
       </LinkWithQuery>
       {showSummary && (

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -1,9 +1,9 @@
-import { Button } from "@/components/atoms/button/Button";
-import { Icon } from "@/components/atoms/icon/Icon";
+import { TextSearch } from "lucide-react";
+
 import { FamilyListItem } from "@/components/document/FamilyListItem";
-import { ToolTipSSR } from "@/components/tooltip/TooltipSSR";
 import { MAX_RESULTS } from "@/constants/paging";
 import { TMatchedFamily } from "@/types";
+import { joinTailwindClasses } from "@/utils/tailwind";
 
 interface IProps {
   family: TMatchedFamily;
@@ -14,31 +14,36 @@ interface IProps {
 const SearchResult = ({ family, active, onClick }: IProps) => {
   const { family_documents, total_passage_hits, family_slug } = family;
 
+  const hasFamilyDocuments = family_documents.length > 0;
+
   const matchesNumber = total_passage_hits >= MAX_RESULTS ? `${MAX_RESULTS}+` : `${total_passage_hits}`;
-  const matchesText = `${matchesNumber} ${total_passage_hits === 1 ? "match" : "matches"} in documents`;
+  const matchesText = `View ${matchesNumber} text ${total_passage_hits === 1 ? "passage" : "passages"} matching your search`;
+
+  const titleClasses = joinTailwindClasses(
+    hasFamilyDocuments ? "text-text-primary" : "text-text-brand",
+    active ? "!underline" : "!no-underline hover:!underline"
+  );
 
   return (
-    <FamilyListItem family={family} showSummary={false}>
-      {family_documents.length > 0 && (
-        <div>
-          <div className="inline-block" data-tooltip-content="View passages in this document that match your search" data-tooltip-id={family_slug}>
-            <Button
-              color={active ? "brand" : "mono"}
-              content="both"
-              rounded
-              size="small"
-              variant={active ? "faded" : "outlined"}
-              onClick={onClick}
-              aria-label={matchesText}
-              data-analytics="search-result-matches-button"
-              data-slug={family_slug}
-            >
-              <Icon name="documentMagnify" width="16" height="16" />
-              {matchesText}
-            </Button>
-            <ToolTipSSR id={family_slug} place={"top"} />
+    <FamilyListItem family={family} showSummary={false} titleClasses={titleClasses}>
+      {hasFamilyDocuments && (
+        <>
+          <div>
+            <div className="inline-block">
+              <button
+                type="button"
+                onClick={onClick}
+                className="mt-1 text-text-brand"
+                aria-label={matchesText}
+                data-analytics="search-result-matches-button"
+                data-slug={family_slug}
+              >
+                <TextSearch size={16} className="inline mr-1.5" />
+                <span className="text-sm font-semibold underline">{matchesText}</span>
+              </button>
+            </div>
           </div>
-        </div>
+        </>
       )}
     </FamilyListItem>
   );

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -43,7 +43,6 @@ test("search", async ({ page }) => {
   await expect(firstSearchResult.locator('[data-cy="family-title"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="family-metadata-category"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="family-metadata-year"]')).toBeVisible();
-  await expect(firstSearchResult.locator('[data-cy="family-description"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="country-link"]')).toBeVisible();
 
   await searchResults.getByRole("link").first().click();

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -45,7 +45,8 @@ test("search", async ({ page }) => {
   await expect(firstSearchResult.locator('[data-cy="family-metadata-year"]')).toBeVisible();
   await expect(firstSearchResult.locator('[data-cy="country-link"]')).toBeVisible();
 
-  await searchResults.getByRole("link").first().click();
+  // Click first search result family title link
+  await firstSearchResult.locator('[data-cy="family-title"]').click();
 
   /** Document (AKA Family) page */
   await Promise.all([page.waitForURL("/document/*"), page.waitForResponse("**/searches")]);


### PR DESCRIPTION
# What's changed

- Replaced matches `Button` with `button` including Lucide icon.
- Removed now superfluous popover.
- `FamilyListItem` component provides a prop to style its title.
- Title is typically blue but is black when matches are shown.
- Active state now shows as an underline, making it easier to see which result the passages drawer refers to.

## Why?

[APP-708](https://linear.app/climate-policy-radar/issue/APP-708/change-the-cta-for-opening-the-drawer)

## Screenshots?

With no search criteria:
<img width="1699" alt="Screenshot 2025-06-11 at 16 55 14" src="https://github.com/user-attachments/assets/61ce8ac9-e0cd-48a3-bbd0-a2be22feca15" />

With search criteria:
<img width="1698" alt="Screenshot 2025-06-11 at 16 55 53" src="https://github.com/user-attachments/assets/b102ed23-6696-456a-a9ce-5855eb2e2128" />

Drawer open:
<img width="1137" alt="Screenshot 2025-06-11 at 16 58 10" src="https://github.com/user-attachments/assets/fbdfdbbe-f994-4dd8-8281-98b2aa421d73" />
