### PR TITLE
APP-685: Iterate the Topics panel on the right hand side of the family page

### DIFF
--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -1,5 +1,5 @@
 import startCase from "lodash/startCase";
-import { ChevronUp } from "lucide-react";
+import { ChevronUp, TextSearch } from "lucide-react";
 import Link from "next/link";
 import { useContext, useState } from "react";
 
@@ -86,22 +86,25 @@ export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showC
 
   return (
     <div className="flex flex-col gap-4 pb-4 text-sm">
-      <div className="flex flex-col gap-4 pb-4 border-b border-border-light text-text-tertiary">
+      <div className="flex flex-col gap-4 pb-4 border-b border-border-light text-text-secondary">
         {knowledgeGraphIsNew && <NewFeatureCard newFeature={NEW_FEATURES[0]} />}
         <span className="text-base font-semibold text-text-primary">
-          In this document
+          <TextSearch size={20} className="inline mr-2 text-text-brand align-text-bottom" />
+          Find mentions of topics
           {!knowledgeGraphIsNew && <Badge className="ml-2">Beta</Badge>}
         </span>
         {!knowledgeGraphIsNew && (
           <p>
-            Find mentions of topics. Accuracy is not 100%.
-            <br />
-            <ExternalLink url="/faq#topics-faqs" className="underline">
+            Find where a topic precisely appears in the main document. Accuracy is not 100%.{" "}
+            <ExternalLink url="/faq#topics-faqs" className="underline inline-block">
               Learn more
             </ExternalLink>
           </p>
         )}
-        <p>Sorted by the most frequent mention.</p>
+      </div>
+      <div className="pt-1 pb-4">
+        <span className="block mb-1 text-[15px] text-text-primary font-semibold">Topics in the main document</span>
+        <p className="">Ordered by most frequently mentioned, grouped by category</p>
       </div>
 
       {rootConcepts.concat(otherRootConcept).map((rootConcept) => {

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -13,6 +13,7 @@ import { firstCase } from "@/utils/text";
 
 import { ExternalLink } from "../ExternalLink";
 import { Badge } from "../atoms/label/Badge";
+import { ConceptLink } from "../molecules/conceptLink/ConceptLink";
 import { Info } from "../molecules/info/Info";
 import { NewFeatureCard } from "../molecules/newFeatures/NewFeatureCard";
 import { Heading } from "../typography/Heading";
@@ -41,16 +42,7 @@ const ConceptsList = ({ concepts, onConceptClick }: IConceptListProps) => {
       {concepts.slice(0, showAll ? undefined : TOP_CONCEPTS_LENGTH).map((concept) => {
         return (
           <li key={concept.wikibase_id} className="">
-            <Link
-              className="inline text-text-primary capitalize underline underline-offset-2 decoration-dotted hover:underline"
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                onConceptClick?.(concept.preferred_label);
-              }}
-            >
-              {firstCase(concept.preferred_label)}
-            </Link>
+            <ConceptLink concept={concept} onClick={() => onConceptClick?.(concept.preferred_label)} />
           </li>
         );
       })}

--- a/src/components/concepts/ConceptsPanel.tsx
+++ b/src/components/concepts/ConceptsPanel.tsx
@@ -21,8 +21,6 @@ import { Heading } from "../typography/Heading";
 interface IProps {
   concepts: TConcept[];
   rootConcepts: TConcept[];
-  conceptCountsById: Record<string, number>;
-  showCounts?: boolean;
   onConceptClick?: (conceptLabel: string) => void;
 }
 
@@ -52,8 +50,8 @@ const ConceptsList = ({ concepts, onConceptClick }: IConceptListProps) => {
             <Button size="x-small" color="mono" variant="faded" onClick={() => setShowAll(!showAll)}>
               {showAll ? (
                 <>
-                  <ChevronUp />
-                  &nbsp; hide
+                  <ChevronUp size={14} className="mr-0.5" />
+                  hide
                 </>
               ) : (
                 `+${concepts.length - TOP_CONCEPTS_LENGTH} more`
@@ -66,7 +64,7 @@ const ConceptsList = ({ concepts, onConceptClick }: IConceptListProps) => {
   );
 };
 
-export const ConceptsPanel = ({ rootConcepts, concepts, conceptCountsById, showCounts = false, onConceptClick }: IProps) => {
+export const ConceptsPanel = ({ rootConcepts, concepts, onConceptClick }: IProps) => {
   const { previousNewFeature } = useContext(NewFeatureContext);
 
   const otherRootConcept: TConcept = {

--- a/src/components/molecules/conceptLink/ConceptLink.stories.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.stories.tsx
@@ -8,7 +8,9 @@ const meta = {
   title: "Molecules/ConceptLink",
   component: ConceptLink,
   parameters: { layout: "centered" },
-  argTypes: {},
+  argTypes: {
+    onClick: { control: false },
+  },
 } satisfies Meta<typeof ConceptLink>;
 type TStory = StoryObj<typeof ConceptLink>;
 
@@ -66,4 +68,12 @@ export const Multiple: TStory = {
       ))}
     </div>
   ),
+};
+
+export const WithOnClick: TStory = {
+  name: "With onClick",
+  args: {
+    concept: concepts[1] as TConcept,
+    onClick: (concept: TConcept) => alert(concept.preferred_label),
+  },
 };

--- a/src/components/molecules/conceptLink/ConceptLink.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.tsx
@@ -8,25 +8,35 @@ import { joinTailwindClasses } from "@/utils/tailwind";
 
 interface IProps {
   concept: TConcept;
+  onClick?: (concept: TConcept) => void;
   triggerClasses?: string;
 }
 
-export const ConceptLink = ({ concept, triggerClasses = "" }: IProps) => {
+export const ConceptLink = ({ concept, onClick, triggerClasses = "" }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const allTriggerClasses = joinTailwindClasses(
-    "inline capitalize underline underline-offset-2 decoration-dotted cursor-help",
+    "inline capitalize underline underline-offset-2 decoration-dotted",
     isOpen ? "decoration-text-primary" : "decoration-text-quaternary",
+    onClick ? "" : "cursor-help",
     triggerClasses
   );
 
   const title = startCase(concept.preferred_label);
 
+  const trigger = onClick ? (
+    <button className={allTriggerClasses} onClick={() => onClick(concept)}>
+      {title}
+    </button>
+  ) : (
+    <span className={allTriggerClasses}>{title}</span>
+  );
+
   return (
     <Popover
       openOnHover
       onOpenChange={setIsOpen}
-      trigger={<span className={allTriggerClasses}>{title}</span>}
+      trigger={trigger}
       title={title}
       description={concept.description}
       link={{

--- a/src/components/molecules/conceptLink/ConceptLink.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.tsx
@@ -1,10 +1,10 @@
-import startCase from "lodash/startCase";
 import { useState } from "react";
 
 import { Popover } from "@/components/atoms/popover/Popover";
 import { TConcept } from "@/types";
 import { getConceptStoreLink } from "@/utils/getConceptStoreLink";
 import { joinTailwindClasses } from "@/utils/tailwind";
+import { firstCase } from "@/utils/text";
 
 interface IProps {
   concept: TConcept;
@@ -22,7 +22,7 @@ export const ConceptLink = ({ concept, onClick, triggerClasses = "" }: IProps) =
     triggerClasses
   );
 
-  const title = startCase(concept.preferred_label);
+  const title = firstCase(concept.preferred_label);
 
   const trigger = onClick ? (
     <button className={allTriggerClasses} onClick={() => onClick(concept)}>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -436,12 +436,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
           </SingleCol>
           {concepts.length > 0 && (
             <div className="border-gray-200 grow-0 shrink-0 px-5 border-l pt-4 md:pt-8 basis-full md:basis-[320px] lg:basis-[380px] xl:basis-[460px]">
-              <ConceptsPanel
-                rootConcepts={rootConcepts}
-                concepts={concepts}
-                conceptCountsById={conceptCountsById}
-                onConceptClick={handleConceptClick}
-              ></ConceptsPanel>
+              <ConceptsPanel rootConcepts={rootConcepts} concepts={concepts} onConceptClick={handleConceptClick}></ConceptsPanel>
             </div>
           )}
         </MultiCol>

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -142,6 +142,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
 
   const [mainDocuments, otherDocuments] = getMainDocuments(page.documents);
   const mainDocumentImportIds = mainDocuments.map((document) => document.import_id);
+  const topMainDocument = mainDocumentImportIds[0];
 
   const getDocumentCategories = () => {
     // Some types are comma separated, so we need to split them
@@ -177,7 +178,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     (vespaFamilyData?.families ?? []).forEach((family) => {
       family.hits.forEach((hit) => {
         // Check the document id against the documents in the page
-        if (documentIsPublished(page.documents, hit.document_import_id) && mainDocumentImportIds.includes(hit.document_import_id)) {
+        if (documentIsPublished(page.documents, hit.document_import_id) && topMainDocument === hit.document_import_id) {
           Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
             const existingCount = uniqueConceptMap.get(conceptKey) || 0;
             uniqueConceptMap.set(conceptKey, existingCount + count);
@@ -189,7 +190,7 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     return Array.from(uniqueConceptMap.entries())
       .map(([conceptKey, count]) => ({ conceptKey, count }))
       .sort((a, b) => b.count - a.count);
-  }, [vespaFamilyData, page.documents, mainDocumentImportIds]);
+  }, [vespaFamilyData, page.documents, topMainDocument]);
 
   const conceptIds = conceptCounts.map(({ conceptKey }) => conceptKey.split(":")[0]);
 


### PR DESCRIPTION
# What's changed

- Updated panel header text and description. Added an icon.
- Topics listed are only pulled from the main documents.
- Fixed hide button sizing due to the oversized arrow icon.

## Why?

[APP-685](https://linear.app/climate-policy-radar/issue/APP-685/iterate-the-topics-panel-on-the-right-hand-side-of-the-family-page)

## Screenshots?

<img width="1449" alt="Screenshot 2025-06-12 at 15 29 53" src="https://github.com/user-attachments/assets/987e0b61-fa30-4d34-a6ac-f2e7274d4fe6" />
