### PR TITLE
Add new faq to topics

### DIFF
--- a/src/constants/conceptsFaqs.tsx
+++ b/src/constants/conceptsFaqs.tsx
@@ -43,6 +43,29 @@ export const CONCEPTS_FAQS: TFAQ[] = [
     ),
   },
   {
+    title: "What happens if I select multiple topics or add a text search?",
+    content: (
+      <>
+        <p>
+          When you select more than one topic or combine a topic with a text search, the tool looks for <i>individual passages</i> (short sections of
+          text) that include <b>all</b> selected topics and/or keywords together.
+        </p>
+
+        <p>Because few passages contain many topics at once, selecting more topics can reduce the number of results — sometimes to zero.</p>
+
+        <p>
+          <b>Example:</b> If you choose “target” and “energy sector,” you’ll only see passages where <i>both</i> appear together, not all documents
+          that mention each topic separately.
+        </p>
+
+        <p>
+          We’re working on improving this feature to support broader searches across entire documents and give you more control over how topics and
+          keywords are combined.
+        </p>
+      </>
+    ),
+  },
+  {
     title: "Which topics are currently available?",
     content: (
       <>


### PR DESCRIPTION
# What's changed
- add a new question to the Topics FAQs as per this [Notion page](https://www.notion.so/climatepolicyradar/New-FAQ-to-add-to-topics-FAQs-in-App-20f9109609a480b98e8bc58f6cdaf108)

## Why?
- to explain what happens if a user selects multiple topics or adds a text search

## Screenshots?

![Screenshot 2025-06-16 at 11 23 21](https://github.com/user-attachments/assets/494bf78a-6280-42a7-b781-0d4385a433dd)
