### PR TITLE
Control search descriptions

### DIFF
--- a/src/components/drawer/FamilyMatchesDrawer.tsx
+++ b/src/components/drawer/FamilyMatchesDrawer.tsx
@@ -1,13 +1,18 @@
 import { File } from "lucide-react";
 import { useRouter } from "next/router";
+import { useContext } from "react";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import PassageMatches from "@/components/PassageMatches";
 import { Button } from "@/components/atoms/button/Button";
 import { FamilyMeta } from "@/components/document/FamilyMeta";
 import { Heading } from "@/components/typography/Heading";
+import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
+import { ThemeContext } from "@/context/ThemeContext";
 import { TMatchedFamily } from "@/types";
 import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
+import { isSearchFamilySummaryEnabled } from "@/utils/features";
+import { truncateString } from "@/utils/truncateString";
 
 interface IProps {
   family?: TMatchedFamily;
@@ -15,6 +20,7 @@ interface IProps {
 
 export const FamilyMatchesDrawer = ({ family }: IProps) => {
   const router = useRouter();
+  const { themeConfig } = useContext(ThemeContext);
 
   if (!family) return null;
   const { family_geographies, family_name, family_category, family_date, family_documents, corpus_type_name } = family;
@@ -41,13 +47,27 @@ export const FamilyMatchesDrawer = ({ family }: IProps) => {
   return (
     <>
       <div className="h-full flex flex-col">
-        <div className="p-5 pb-0 pr-12">
+        <div className="p-5 pb-0 pr-12 mb-10">
           <div className="flex flex-wrap text-sm gap-1 mb-2 items-center middot-between">
             <FamilyMeta category={family_category} corpus_type_name={corpus_type_name} geographies={family_geographies} date={family_date} />
           </div>
-          <Heading level={3} extraClasses="!mb-10">
+          <Heading level={3} extraClasses="!mb-0">
             {family_name}
           </Heading>
+          {isSearchFamilySummaryEnabled(themeConfig) && (
+            <div className="mt-5">
+              <Heading level={4}>Summary</Heading>
+              <div
+                className="text-content mb-2"
+                dangerouslySetInnerHTML={{
+                  __html: truncateString(family.family_description, MAX_FAMILY_SUMMARY_LENGTH_BRIEF),
+                }}
+              />
+              <LinkWithQuery href={`/document/${family.family_slug}`} className="text-sm alt">
+                View full summary and timeline
+              </LinkWithQuery>
+            </div>
+          )}
         </div>
         <div className="p-5 pt-0 flex-grow flex flex-col">
           <div className="mb-4">

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -1,8 +1,11 @@
 import { TextSearch } from "lucide-react";
+import { useContext } from "react";
 
 import { FamilyListItem } from "@/components/document/FamilyListItem";
 import { MAX_RESULTS } from "@/constants/paging";
+import { ThemeContext } from "@/context/ThemeContext";
 import { TMatchedFamily } from "@/types";
+import { isSearchFamilySummaryEnabled } from "@/utils/features";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
 interface IProps {
@@ -12,6 +15,7 @@ interface IProps {
 }
 
 const SearchResult = ({ family, active, onClick }: IProps) => {
+  const { themeConfig } = useContext(ThemeContext);
   const { family_documents, total_passage_hits, family_slug } = family;
 
   const hasFamilyDocuments = family_documents.length > 0;
@@ -25,7 +29,7 @@ const SearchResult = ({ family, active, onClick }: IProps) => {
   );
 
   return (
-    <FamilyListItem family={family} showSummary={false} titleClasses={titleClasses}>
+    <FamilyListItem family={family} showSummary={isSearchFamilySummaryEnabled(themeConfig)} titleClasses={titleClasses}>
       {hasFamilyDocuments && (
         <>
           <div>

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -2,6 +2,6 @@ export const featureFlagKeys = ["concepts-v1", "corporate-reports", "litigation"
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
 
-export const configFeatureKeys = ["knowledgeGraph"] as const;
+export const configFeatureKeys = ["knowledgeGraph", "searchFamilySummary"] as const;
 export type TConfigFeature = (typeof configFeatureKeys)[number];
 export type TConfigFeatures = Record<TConfigFeature, boolean>;

--- a/src/utils/buildSearchQuery.test.ts
+++ b/src/utils/buildSearchQuery.test.ts
@@ -26,7 +26,7 @@ describe("buildSearchQuery: ", () => {
       links: [],
       metadata: [],
       documentCategories: [],
-      features: { knowledgeGraph: true },
+      features: { knowledgeGraph: true, searchFamilySummary: true },
     };
 
     const searchQueryWithNoCategory = buildSearchQuery({}, themeConfig);
@@ -48,7 +48,7 @@ describe("buildSearchQuery: ", () => {
       links: [],
       metadata: [],
       documentCategories: [],
-      features: { knowledgeGraph: true },
+      features: { knowledgeGraph: true, searchFamilySummary: true },
     };
 
     const searchQuery = buildSearchQuery({}, themeConfig);

--- a/src/utils/buildSearchQueryMetadata.test.ts
+++ b/src/utils/buildSearchQueryMetadata.test.ts
@@ -19,6 +19,7 @@ const testThemeConfig: TThemeConfig = {
   metadata: [],
   features: {
     knowledgeGraph: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/src/utils/canDisplayFilter.test.ts
+++ b/src/utils/canDisplayFilter.test.ts
@@ -52,6 +52,7 @@ const testThemeConfig: TThemeConfig = {
   metadata: [],
   features: {
     knowledgeGraph: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -34,3 +34,8 @@ export const isUNFCCCFiltersEnabled = (featureFlags: TFeatureFlags) =>
   isFeatureEnabled({
     featureFlag: featureFlags["unfccc-filters"],
   });
+
+export const isSearchFamilySummaryEnabled = (themeConfig: TThemeConfig) =>
+  isFeatureEnabled({
+    configFeature: themeConfig.features.searchFamilySummary,
+  });

--- a/tests/unit/components/blocks/FilterOptions.test.tsx
+++ b/tests/unit/components/blocks/FilterOptions.test.tsx
@@ -23,6 +23,7 @@ describe("FilterOptions", () => {
       documentCategories: [],
       features: {
         knowledgeGraph: false,
+        searchFamilySummary: true,
       },
     };
 

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -70,6 +70,7 @@ const config: TThemeConfig = {
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"],
   features: {
     knowledgeGraph: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -163,6 +163,7 @@ const config: TThemeConfig = {
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation"],
   features: {
     knowledgeGraph: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -351,6 +351,7 @@ const config: TThemeConfig = {
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation", "MCF", "Reports"],
   features: {
     knowledgeGraph: true,
+    searchFamilySummary: false,
   },
 };
 

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -134,6 +134,7 @@ const config: TThemeConfig = {
   documentCategories: ["All"],
   features: {
     knowledgeGraph: false,
+    searchFamilySummary: true,
   },
 };
 


### PR DESCRIPTION
# What's changed
- Adding a new feature to the config file to control whether to display the family summary in the search results. This will also control whether to show the summary in the drawer

## Why?
- We want to be able to control this option on an app-by-app basis. LSE and MCFs want to see the summary in the search results,

## Screenshots?
