### PR TITLE
Revert CCLW KG switch on

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,7 +9,7 @@ on:
       - main
   # b. Allow deployment from the actions tab - this allows feature branch deployment
   workflow_dispatch: {}
-  # c. Label a PR with "deploy:staging" will deply to staging
+  # c. Label a PR with "deploy:staging" will deploy to staging
   pull_request:
     types: [labeled]
 

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -162,7 +162,7 @@ const config: TThemeConfig = {
   ],
   documentCategories: ["All", "Laws", "Policies", "UNFCCC", "Litigation"],
   features: {
-    knowledgeGraph: true,
+    knowledgeGraph: false,
     searchFamilySummary: true,
   },
 };


### PR DESCRIPTION


## Why?

CCLW Knowledge Graph switch on is delayed until this issue is looked into more. :warning: Don’t deploy to CCLW prod as it has the change to the config merged into main at the moment (revert it if not deploying today): https://linear.app/climate-policy-radar/issue/APP-777/classifiers-not-showing-on-some-familiies


