### PR TITLE
feat: send slack message on github deploy

### DIFF
--- a/.github/workflows/send-slack-message-on-deploy.yml
+++ b/.github/workflows/send-slack-message-on-deploy.yml
@@ -9,6 +9,7 @@ jobs:
   send-slack-message-staging-updates:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       # we can't use the github.event.deployment.environment directly in the environment property
       # so we need to switch on this case to get the secret.
       - id: webhook_url

--- a/.github/workflows/send-slack-message-on-deploy.yml
+++ b/.github/workflows/send-slack-message-on-deploy.yml
@@ -1,0 +1,33 @@
+name: Send slack message on deployment
+on: deployment
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  send-slack-message-staging-updates:
+    runs-on: ubuntu-latest
+    steps:
+      # we can't use the github.event.deployment.environment directly in the environment property
+      # so we need to switch on this case to get the secret.
+      - id: webhook_url
+        run: |
+          if [ "${{ github.event.deployment.environment }}" = "staging" ]; then
+            echo "webhook_url=${{ secrets.SLACK_WEBHOOK_URL_STAGING_UPDATES_CHANNEL }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.deployment.environment }}" = "production" ]; then
+            echo "webhook_url=${{ secrets.SLACK_WEBHOOK_URL_PRODUCTION_UPDATES_CHANNEL }}" >> $GITHUB_OUTPUT
+          fi
+      - id: pr_number
+        run: |
+          PR_NUMBER=$(gh pr list --search "$(git rev-parse HEAD)" --state all --json number -q '.[0].number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ steps.webhook_url.outputs.webhook_url }}
+          webhook-type: incoming-webhook
+          payload: |
+            🚀 Deploying ${{ github.repository }} to ${{ github.event.deployment.environment }}
+            • *PR*: https://github.com/${{ github.repository }}/pulls/${{ steps.pr_number.outputs.pr_number }}

--- a/.github/workflows/send-slack-message-on-deploy.yml
+++ b/.github/workflows/send-slack-message-on-deploy.yml
@@ -30,5 +30,4 @@ jobs:
           webhook: ${{ steps.webhook_url.outputs.webhook_url }}
           webhook-type: incoming-webhook
           payload: |
-            🚀 Deploying ${{ github.repository }} to ${{ github.event.deployment.environment }}
-            • *PR*: https://github.com/${{ github.repository }}/pulls/${{ steps.pr_number.outputs.pr_number }}
+            text: "🚀 Deploying ${{ github.repository }} to ${{ github.event.deployment.environment }}\n• *PR*: https://github.com/${{ github.repository }}/pull/${{ steps.pr_number.outputs.pr_number }}"


### PR DESCRIPTION
# What's changed
- sends a slack message to the `#{{env}}-updates` channel when a deploy happens

## Why?

To give us more context of what's being deployed

## notes

There were two options
1. code living in the deploy actions
1. code decoupled from the deploy actions and hooking into the GitHub deploy

I've opted for `2.` for
- the decoupling
- makes it quite an easy lift / shift to other repos or apps
- allows us to capture all deploys rather than tied to things like the `theme` deploys (great for microservices)

## screenshots
![Screenshot 2025-06-25 at 09 29 25](https://github.com/user-attachments/assets/3df2aeba-e095-4798-98cf-5fa694294cf8)


