### PR TITLE
feat: remove corporate disclosures feature flag

### DIFF
--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -23,7 +23,7 @@ import { getCountriesFromRegions } from "@/helpers/getCountriesFromRegions";
 import useGetThemeConfig from "@/hooks/useThemeConfig";
 import { TConcept, TCorpusTypeDictionary, TFeatureFlags, TGeography, TSearchCriteria, TThemeConfigOption } from "@/types";
 import { canDisplayFilter } from "@/utils/canDisplayFilter";
-import { isCorporateReportsEnabled, isKnowledgeGraphEnabled } from "@/utils/features";
+import { isKnowledgeGraphEnabled } from "@/utils/features";
 import { getFilterLabel } from "@/utils/getFilterLabel";
 
 const isCategoryChecked = (selectedCatgeory: string | undefined, themeConfigCategory: TThemeConfigOption<any>) => {
@@ -120,20 +120,17 @@ const SearchFilters = ({
       {themeConfigStatus === "success" && themeConfig.categories && (
         <Accordian title={themeConfig.categories.label} data-cy="categories" key={themeConfig.categories.label} startOpen>
           <InputListContainer>
-            {themeConfig.categories?.options?.map(
-              (option) =>
-                ((option.slug === "corporate-disclosures" && isCorporateReportsEnabled(featureFlags)) || option.slug !== "corporate-disclosures") && (
-                  <InputRadio
-                    key={option.slug}
-                    label={option.label}
-                    checked={query && isCategoryChecked(query[QUERY_PARAMS.category] as string, option)}
-                    onChange={() => {
-                      handleDocumentCategoryClick(option.slug);
-                    }}
-                    name={`${themeConfig.categories.label}-${option.slug}`}
-                  />
-                )
-            )}
+            {themeConfig.categories?.options?.map((option) => (
+              <InputRadio
+                key={option.slug}
+                label={option.label}
+                checked={query && isCategoryChecked(query[QUERY_PARAMS.category] as string, option)}
+                onChange={() => {
+                  handleDocumentCategoryClick(option.slug);
+                }}
+                name={`${themeConfig.categories.label}-${option.slug}`}
+              />
+            ))}
           </InputListContainer>
         </Accordian>
       )}

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,4 +1,4 @@
-export const featureFlagKeys = ["concepts-v1", "corporate-reports", "litigation", "unfccc-filters"] as const;
+export const featureFlagKeys = ["concepts-v1", "litigation", "unfccc-filters"] as const;
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
 

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -14,11 +14,6 @@ export const isFeatureEnabled = ({ configFeature, featureFlag }: IArgs): boolean
 
 /* Specific feature shorthand functions */
 
-export const isCorporateReportsEnabled = (featureFlags: TFeatureFlags) =>
-  isFeatureEnabled({
-    featureFlag: featureFlags["corporate-reports"],
-  });
-
 export const isKnowledgeGraphEnabled = (featureFlags: TFeatureFlags, themeConfig: TThemeConfig) =>
   isFeatureEnabled({
     configFeature: themeConfig.features.knowledgeGraph,


### PR DESCRIPTION
# What's changed
- removes references to corporate-disclosers feature flag

## Why?
- we would like the the feautre to now be enabled!

## Screenshots?
<img width="1496" alt="Screenshot 2025-06-25 at 10 01 05" src="https://github.com/user-attachments/assets/570964ac-394a-4815-a43c-547a5301d525" />

