### PR TITLE
APP-779 Component: Interactive table

### DIFF
--- a/src/components/atoms/menu/MenuItem.tsx
+++ b/src/components/atoms/menu/MenuItem.tsx
@@ -1,0 +1,21 @@
+import { Menu as BaseMenu } from "@base-ui-components/react";
+
+import { joinTailwindClasses } from "@/utils/tailwind";
+
+interface IProps extends BaseMenu.Item.Props {
+  className?: string;
+  color?: "brand" | "mono";
+  heading?: boolean;
+}
+
+export const MenuItem = ({ className, color = "mono", disabled, heading = false, ...props }: IProps) => {
+  const allClasses = joinTailwindClasses(
+    "px-2.5 py-2 rounded-md hover:outline-none focus-visible:outline-none leading-none select-none",
+    disabled ? "text-text-tertiary" : "hover:bg-surface-ui focus-visible:bg-surface-ui cursor-pointer",
+    !disabled && color === "brand" ? "text-text-brand" : "text-text-primary",
+    heading ? "text-xs font-semibold" : "text-sm",
+    className
+  );
+
+  return <BaseMenu.Item className={allClasses} disabled={disabled} {...props} />;
+};

--- a/src/components/atoms/menu/MenuPopup.tsx
+++ b/src/components/atoms/menu/MenuPopup.tsx
@@ -1,0 +1,16 @@
+import { Menu as BaseMenu } from "@base-ui-components/react";
+
+import { joinTailwindClasses } from "@/utils/tailwind";
+
+interface IProps extends BaseMenu.Popup.Props {
+  className?: string;
+}
+
+export const MenuPopup = ({ className, ...props }: IProps) => {
+  const allClasses = joinTailwindClasses(
+    "min-w-37.5 p-1 bg-surface-light border border-border-light rounded-lg shadow-xs focus-visible:outline-none",
+    className
+  );
+
+  return <BaseMenu.Popup className={allClasses} {...props} />;
+};

--- a/src/components/atoms/popover/Popover.tsx
+++ b/src/components/atoms/popover/Popover.tsx
@@ -50,7 +50,7 @@ export const Popover = ({ children, description, link, onOpenChange, openOnHover
         <BasePopover.Positioner positionMethod="fixed" sideOffset={8}>
           <BasePopover.Popup className={allPopupClasses}>
             <BasePopover.Arrow className="flex -top-2">
-              <BaseUIArrow fill="fill-surface-light" />
+              <BaseUIArrow fill="fill-surface-light" stroke="fill-border-light" />
             </BasePopover.Arrow>
             {children || (
               <>

--- a/src/components/atoms/tooltip/Tooltip.stories.tsx
+++ b/src/components/atoms/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { LucideInfo } from "lucide-react";
+
+import { Tooltip } from "./Tooltip";
+
+const meta = {
+  title: "Atoms/Tooltip",
+  component: Tooltip,
+  parameters: { layout: "centered" },
+  argTypes: {
+    children: { control: false },
+    content: { control: "text" },
+    side: { control: "select" },
+  },
+} satisfies Meta<typeof Tooltip>;
+type TStory = StoryObj<typeof Tooltip>;
+
+export default meta;
+
+const trigger = <LucideInfo size={16} className="text-text-tertiary" />;
+
+export const Basic: TStory = {
+  args: {
+    arrow: false,
+    children: trigger,
+    content: "Hello tooltip!",
+    popupClasses: "",
+    side: "top",
+  },
+};
+
+export const Complex: TStory = {
+  args: {
+    arrow: true,
+    children: trigger,
+    content: (
+      <div className="flex flex-col gap-1">
+        <p>
+          The annually published Global Climate Risk Index analyses to what extent countries have been affected by the impacts of weather-related loss
+          events (storms, floods, heat waves etc.).
+        </p>
+        <p>
+          This data is from the Global Risk Index 2021 published by{" "}
+          <a href="https://www.germanwatch.org/en/cri" className="underline">
+            German Watch
+          </a>
+          . Numbers marked with an asterisk (*) are from the Global Risk Index 2020, being the latest available data for that country. This data was
+          last updated on this site on 18 September 2023.
+        </p>
+        <p>
+          See the full report published by German Watch{" "}
+          <a href="https://www.germanwatch.org/en/19777" className="underline">
+            here
+          </a>
+          .
+        </p>
+      </div>
+    ),
+    popupClasses: "w-[350px] px-3 py-3 !text-sm text-wrap leading-normal font-normal",
+    side: "bottom",
+  },
+  argTypes: {
+    content: { control: false },
+  },
+};

--- a/src/components/atoms/tooltip/Tooltip.tsx
+++ b/src/components/atoms/tooltip/Tooltip.tsx
@@ -1,0 +1,42 @@
+import { Tooltip as BaseTooltip } from "@base-ui-components/react";
+import { ReactNode } from "react";
+
+import { BaseUIArrow } from "@/utils/baseUI";
+import { joinTailwindClasses } from "@/utils/tailwind";
+
+interface IProps {
+  arrow?: boolean;
+  children: ReactNode;
+  content: string | ReactNode;
+  popupClasses?: string;
+  side?: "top" | "bottom";
+}
+
+export const Tooltip = ({ arrow = false, children, content, popupClasses, side = "top" }: IProps) => {
+  const allPopupClasses = joinTailwindClasses(
+    "px-1.5 py-1 bg-surface-mono-dark text-xs text-text-light leading-none font-bold text-nowrap rounded-md",
+    popupClasses
+  );
+
+  const arrowClasses = joinTailwindClasses("flex", side === "top" ? "-bottom-2 rotate-180" : "-top-2");
+
+  return (
+    <BaseTooltip.Provider>
+      <BaseTooltip.Root>
+        <BaseTooltip.Trigger>{children}</BaseTooltip.Trigger>
+        <BaseTooltip.Portal>
+          <BaseTooltip.Positioner side={side} sideOffset={arrow ? 7 : 2}>
+            <BaseTooltip.Popup className={allPopupClasses}>
+              {arrow && (
+                <BaseTooltip.Arrow className={arrowClasses}>
+                  <BaseUIArrow fill="fill-surface-mono-dark" stroke="fill-surface-mono-dark" />
+                </BaseTooltip.Arrow>
+              )}
+              {content}
+            </BaseTooltip.Popup>
+          </BaseTooltip.Positioner>
+        </BaseTooltip.Portal>
+      </BaseTooltip.Root>
+    </BaseTooltip.Provider>
+  );
+};

--- a/src/components/atoms/tooltip/Tooltip.tsx
+++ b/src/components/atoms/tooltip/Tooltip.tsx
@@ -9,10 +9,11 @@ interface IProps {
   children: ReactNode;
   content: string | ReactNode;
   popupClasses?: string;
+  triggerClasses?: string;
   side?: "top" | "bottom";
 }
 
-export const Tooltip = ({ arrow = false, children, content, popupClasses, side = "top" }: IProps) => {
+export const Tooltip = ({ arrow = false, children, content, popupClasses, side = "top", triggerClasses }: IProps) => {
   const allPopupClasses = joinTailwindClasses(
     "px-1.5 py-1 bg-surface-mono-dark text-xs text-text-light leading-none font-bold text-nowrap rounded-md",
     popupClasses
@@ -23,7 +24,7 @@ export const Tooltip = ({ arrow = false, children, content, popupClasses, side =
   return (
     <BaseTooltip.Provider>
       <BaseTooltip.Root>
-        <BaseTooltip.Trigger>{children}</BaseTooltip.Trigger>
+        <BaseTooltip.Trigger className={triggerClasses}>{children}</BaseTooltip.Trigger>
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner side={side} sideOffset={arrow ? 7 : 2}>
             <BaseTooltip.Popup className={allPopupClasses}>

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -13,7 +13,7 @@ export default meta;
 
 /* Generic */
 
-type TWainwrightColumns = "height" | "link" | "region" | "wainwright";
+type TWainwrightColumns = "height" | "link" | "region" | "summited" | "wainwright";
 const linkToCell = (link: string): TInteractiveTableCell => ({
   display: (
     <a href={link} className="text-text-brand underline">
@@ -49,6 +49,11 @@ export const Generic: TStory<TWainwrightColumns> = {
         id: "link",
         name: "WalkLakes",
       },
+      {
+        id: "summited",
+        name: "Summited",
+        sortable: true,
+      },
     ],
     defaultSort: {
       column: "height",
@@ -62,6 +67,10 @@ export const Generic: TStory<TWainwrightColumns> = {
           region: "The Eastern Fells",
           height: 950,
           link: linkToCell("https://www.walklakes.co.uk/hill_2515.html"),
+          summited: {
+            display: "23/05/2025",
+            value: "2025-05-23T10:24:00.000Z",
+          },
         },
       },
       {
@@ -71,6 +80,7 @@ export const Generic: TStory<TWainwrightColumns> = {
           region: "The Southern Fells",
           height: 978,
           link: linkToCell("https://www.walklakes.co.uk/hill_2359.html"),
+          summited: null,
         },
       },
       {
@@ -80,6 +90,10 @@ export const Generic: TStory<TWainwrightColumns> = {
           region: "The Northern Fells",
           height: 931,
           link: linkToCell("https://www.walklakes.co.uk/hill_2319.html"),
+          summited: {
+            display: "20/04/2024",
+            value: "2024-04-20T10:32:00.000Z",
+          },
         },
       },
       {
@@ -89,6 +103,10 @@ export const Generic: TStory<TWainwrightColumns> = {
           region: "The Far Eastern Fells",
           height: 828,
           link: linkToCell("https://www.walklakes.co.uk/hill_2528.html"),
+          summited: {
+            display: "26/10/2024",
+            value: "2024-10-26T11:24:00.000Z",
+          },
         },
       },
     ],

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -1,0 +1,93 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import { InteractiveTable, TInteractiveTableCell } from "./InteractiveTable";
+
+const meta = {
+  title: "Organisms/InteractiveTable",
+  component: InteractiveTable,
+  argTypes: {},
+} satisfies Meta<typeof InteractiveTable>;
+type TStory<ColumnKey extends string> = StoryObj<typeof InteractiveTable<ColumnKey>>;
+
+export default meta;
+
+/* Generic */
+
+type TWainwrightColumns = "height" | "link" | "region" | "wainwright";
+const linkToCell = (link: string): TInteractiveTableCell => ({
+  display: (
+    <a href={link} className="text-text-brand underline">
+      View
+    </a>
+  ),
+  value: link,
+});
+
+export const Generic: TStory<TWainwrightColumns> = {
+  args: {
+    columns: [
+      {
+        id: "wainwright",
+        name: "Wainwright",
+        sortable: true,
+      },
+      {
+        id: "height",
+        name: "Height",
+        sortable: true,
+      },
+      {
+        id: "region",
+        name: "Region",
+      },
+      {
+        id: "link",
+        name: "WalkLakes",
+      },
+    ],
+    defaultSort: {
+      column: "height",
+      ascending: false,
+    },
+    rows: [
+      {
+        id: "helvellyn",
+        cells: {
+          wainwright: "Helvellyn",
+          region: "The Eastern Fells",
+          height: 950,
+          link: linkToCell("https://www.walklakes.co.uk/hill_2515.html"),
+        },
+      },
+      {
+        id: "scafell-pike",
+        cells: {
+          wainwright: "Scafell Pike",
+          region: "The Southern Fells",
+          height: 978,
+          link: linkToCell("https://www.walklakes.co.uk/hill_2359.html"),
+        },
+      },
+      {
+        id: "skiddaw",
+        cells: {
+          wainwright: "Skiddaw",
+          region: "The Northern Fells",
+          height: 931,
+          link: linkToCell("https://www.walklakes.co.uk/hill_2319.html"),
+        },
+      },
+      {
+        id: "high-street",
+        cells: {
+          wainwright: "High Street",
+          region: "The Far Eastern Fells",
+          height: 828,
+          link: linkToCell("https://www.walklakes.co.uk/hill_2528.html"),
+        },
+      },
+    ],
+  },
+};
+
+/* Entries */

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 
-import { InteractiveTable, TInteractiveTableCell } from "./InteractiveTable";
+import { InteractiveTable, IProps, TInteractiveTableCell } from "./InteractiveTable";
 
 const meta = {
   title: "Organisms/InteractiveTable",
@@ -30,6 +30,7 @@ export const Generic: TStory<TWainwrightColumns> = {
         id: "wainwright",
         name: "Wainwright",
         sortable: true,
+        fraction: 2,
       },
       {
         id: "height",
@@ -44,6 +45,7 @@ export const Generic: TStory<TWainwrightColumns> = {
             Which of Alfred Wainwright's books the Wainwright features in. The series of 7 books divides the Lakeland Fells by geographic region.
           </div>
         ),
+        fraction: 2,
       },
       {
         id: "link",
@@ -110,7 +112,22 @@ export const Generic: TStory<TWainwrightColumns> = {
         },
       },
     ],
+    tableClasses: "min-w-[650px]",
   },
 };
 
-/* Entries */
+/* Cell styling */
+
+export const CellStyling: TStory<TWainwrightColumns> = {
+  args: {
+    ...Generic.args,
+    columns: Generic.args.columns.map((column) => {
+      if (column.id !== "height") return column;
+      return { ...column, classes: "bg-amber-50" };
+    }),
+    rows: Generic.args.rows.map((row) => {
+      if (row.id !== "skiddaw") return row;
+      return { ...row, classes: "bg-green-50" };
+    }),
+  },
+};

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -39,6 +39,11 @@ export const Generic: TStory<TWainwrightColumns> = {
       {
         id: "region",
         name: "Region",
+        tooltip: (
+          <div className="w-[200px]">
+            Which of Alfred Wainwright's books the Wainwright features in. The series of 7 books divides the Lakeland Fells by geographic region.
+          </div>
+        ),
       },
       {
         id: "link",

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -1,6 +1,9 @@
 import orderBy from "lodash/orderBy";
-import { LucideArrowUpDown } from "lucide-react";
+import { LucideArrowUpDown, LucideInfo } from "lucide-react";
 import { ReactNode, useMemo, useState } from "react";
+
+import { Tooltip } from "@/components/atoms/tooltip/Tooltip";
+import { joinTailwindClasses } from "@/utils/tailwind";
 
 type TValue = string | number;
 
@@ -8,6 +11,7 @@ interface IInteractiveTableColumn<ColumnKey extends string> {
   id: ColumnKey;
   name: string;
   sortable?: boolean;
+  tooltip?: ReactNode;
 }
 
 export type TInteractiveTableCell =
@@ -61,22 +65,39 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
       {/* Heading */}
       <thead className="text-text-primary font-semibold">
         <tr className="border-b border-border-light">
-          {columns.map((column) => (
-            <td
-              key={`heading-${column.id}`}
-              className="px-2.5 py-1.5 border-l border-border-light first:border-l-0 cursor-default group hover:bg-surface-ui"
-            >
-              <div className="flex items-center">
-                <span className="block flex-1">{column.name}</span>
-                {/* Sort button */}
-                {column.sortable && (
-                  <button type="button" className="p-1 rounded-sm text-text-tertiary hover:bg-surface-heavy invisible group-hover:visible">
-                    <LucideArrowUpDown size={16} />
-                  </button>
-                )}
-              </div>
-            </td>
-          ))}
+          {columns.map((column) => {
+            const columnIsSorted = sortRules.column === column.id;
+            const buttonClasses = joinTailwindClasses(
+              "p-1 rounded-sm text-text-tertiary hover:bg-surface-heavy",
+              columnIsSorted ? "[&:not(:hover)]:text-text-brand" : "invisible group-hover:visible"
+            );
+
+            return (
+              <td
+                key={`heading-${column.id}`}
+                className="px-2.5 py-1.5 border-l border-border-light first:border-l-0 cursor-default group hover:bg-surface-ui"
+              >
+                <div className="flex items-center gap-1">
+                  <span className="block">{column.name}</span>
+                  {column.tooltip && (
+                    <Tooltip content={column.tooltip} popupClasses="text-wrap max-w-[250px]">
+                      <LucideInfo size={16} className="text-text-tertiary opacity-50 group-hover:opacity-100" />
+                    </Tooltip>
+                  )}
+                  {/* Sort button */}
+                  {column.sortable && (
+                    <div className="flex-1 text-right">
+                      <Tooltip content="Sort">
+                        <button type="button" className={buttonClasses}>
+                          <LucideArrowUpDown size={16} />
+                        </button>
+                      </Tooltip>
+                    </div>
+                  )}
+                </div>
+              </td>
+            );
+          })}
         </tr>
       </thead>
       {/* Rows */}

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -1,7 +1,10 @@
+import { Menu } from "@base-ui-components/react";
 import orderBy from "lodash/orderBy";
 import { LucideArrowUpDown, LucideInfo } from "lucide-react";
 import { ReactNode, useMemo, useState } from "react";
 
+import { MenuItem } from "@/components/atoms/menu/MenuItem";
+import { MenuPopup } from "@/components/atoms/menu/MenuPopup";
 import { Tooltip } from "@/components/atoms/tooltip/Tooltip";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
@@ -60,6 +63,9 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
     );
   }, [rows, sortRules]);
 
+  const onSort = (column: ColumnKey, ascending: boolean) => () => setSortRules({ column, ascending });
+  const onClearSort = () => setSortRules({ column: null, ascending: true });
+
   return (
     <table className="w-full text-sm text-text-secondary leading-tight">
       {/* Heading */}
@@ -67,9 +73,10 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
         <tr className="border-b border-border-light">
           {columns.map((column) => {
             const columnIsSorted = sortRules.column === column.id;
-            const buttonClasses = joinTailwindClasses(
-              "p-1 rounded-sm text-text-tertiary hover:bg-surface-heavy",
-              columnIsSorted ? "[&:not(:hover)]:text-text-brand" : "invisible group-hover:visible"
+
+            const sortButtonClasses = joinTailwindClasses(
+              "p-1 rounded-sm text-text-tertiary focus:bg-surface-heavy focus-visible:outline-none",
+              columnIsSorted ? "[&:not(:focus)]:text-text-brand" : "invisible group-hover:visible"
             );
 
             return (
@@ -84,14 +91,29 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
                       <LucideInfo size={16} className="text-text-tertiary opacity-50 group-hover:opacity-100" />
                     </Tooltip>
                   )}
-                  {/* Sort button */}
+                  {/* Sort button & menu */}
                   {column.sortable && (
                     <div className="flex-1 text-right">
-                      <Tooltip content="Sort">
-                        <button type="button" className={buttonClasses}>
+                      <Menu.Root>
+                        <Menu.Trigger className={sortButtonClasses}>
                           <LucideArrowUpDown size={16} />
-                        </button>
-                      </Tooltip>
+                        </Menu.Trigger>
+                        <Menu.Portal>
+                          <Menu.Backdrop />
+                          <Menu.Positioner align="start" sideOffset={2}>
+                            <MenuPopup>
+                              <MenuItem disabled heading>
+                                Sort
+                              </MenuItem>
+                              <MenuItem onClick={onSort(column.id, true)}>Ascending</MenuItem>
+                              <MenuItem onClick={onSort(column.id, false)}>Descending</MenuItem>
+                              <MenuItem color="brand" onClick={onClearSort}>
+                                Clear sort
+                              </MenuItem>
+                            </MenuPopup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.Root>
                     </div>
                   )}
                 </div>

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -1,0 +1,101 @@
+import orderBy from "lodash/orderBy";
+import { LucideArrowUpDown } from "lucide-react";
+import { ReactNode, useMemo, useState } from "react";
+
+type TValue = string | number;
+
+interface IInteractiveTableColumn<ColumnKey extends string> {
+  id: ColumnKey;
+  name: string;
+  sortable?: boolean;
+}
+
+export type TInteractiveTableCell =
+  | TValue
+  | {
+      display: ReactNode;
+      value: TValue;
+    };
+
+interface IInteractiveTableRow<ColumnKey extends string> {
+  id: string;
+  cells: Record<ColumnKey, TInteractiveTableCell>;
+}
+
+interface ISortRules<ColumnKey extends string> {
+  column: ColumnKey | null;
+  ascending: boolean;
+}
+
+interface IProps<ColumnKey extends string> {
+  columns: IInteractiveTableColumn<ColumnKey>[];
+  defaultSort?: ISortRules<ColumnKey>;
+  rows: IInteractiveTableRow<ColumnKey>[];
+}
+
+export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSort, rows }: IProps<ColumnKey>) => {
+  const [sortRules, setSortRules] = useState<ISortRules<ColumnKey>>(
+    defaultSort || {
+      column: null,
+      ascending: true,
+    }
+  );
+
+  const sortedRows = useMemo(() => {
+    if (sortRules.column === null) return rows;
+
+    return orderBy(
+      rows,
+      [
+        (row) => {
+          const cell = row.cells[sortRules.column];
+          return typeof cell === "object" ? cell.value : cell;
+        },
+      ],
+      [sortRules.ascending ? "asc" : "desc"]
+    );
+  }, [rows, sortRules]);
+
+  return (
+    <table className="w-full text-sm text-text-secondary leading-tight">
+      {/* Heading */}
+      <thead className="text-text-primary font-semibold">
+        <tr className="border-b border-border-light">
+          {columns.map((column) => (
+            <td
+              key={`heading-${column.id}`}
+              className="px-2.5 py-1.5 border-l border-border-light first:border-l-0 cursor-default group hover:bg-surface-ui"
+            >
+              <div className="flex items-center">
+                <span className="block flex-1">{column.name}</span>
+                {/* Sort button */}
+                {column.sortable && (
+                  <button type="button" className="p-1 rounded-sm text-text-tertiary hover:bg-surface-heavy invisible group-hover:visible">
+                    <LucideArrowUpDown size={16} />
+                  </button>
+                )}
+              </div>
+            </td>
+          ))}
+        </tr>
+      </thead>
+      {/* Rows */}
+      <tbody>
+        {sortedRows.map((row) => (
+          <tr key={`row-${row.id}`} className="border-b border-border-light">
+            {columns.map((column) => {
+              const cell = row.cells[column.id];
+              const cellDisplay = typeof cell === "object" ? cell.display : `${cell}`;
+
+              return (
+                <td key={`row-${row.id}-${column.id}`} className="px-2.5 py-3 border-l border-border-light first:border-l-0">
+                  {cellDisplay}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -63,8 +63,45 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
     );
   }, [rows, sortRules]);
 
-  const onSort = (column: ColumnKey, ascending: boolean) => () => setSortRules({ column, ascending });
-  const onClearSort = () => setSortRules({ column: null, ascending: true });
+  // Button and menu for controlling column sorting
+  const renderSortControls = (column: IInteractiveTableColumn<ColumnKey>) => {
+    const columnIsSorted = sortRules.column === column.id;
+
+    const sortButtonClasses = joinTailwindClasses(
+      "p-1 rounded-sm text-text-tertiary focus:bg-surface-heavy focus-visible:outline-none",
+      columnIsSorted ? "[&:not(:focus)]:text-text-brand" : "invisible group-hover:visible"
+    );
+
+    const onSort = (ascending: boolean) => () => setSortRules({ column: column.id, ascending });
+    const onClearSort = () => setSortRules({ column: null, ascending: true });
+
+    return (
+      <div className="flex-1 text-right">
+        <Menu.Root>
+          <Menu.Trigger className={sortButtonClasses}>
+            <LucideArrowUpDown size={16} />
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Backdrop />
+            <Menu.Positioner align="start" sideOffset={2}>
+              <MenuPopup>
+                <MenuItem disabled heading>
+                  Sort
+                </MenuItem>
+                <MenuItem onClick={onSort(true)}>Ascending</MenuItem>
+                <MenuItem onClick={onSort(false)}>Descending</MenuItem>
+                {columnIsSorted && (
+                  <MenuItem color="brand" onClick={onClearSort}>
+                    Clear sort
+                  </MenuItem>
+                )}
+              </MenuPopup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </div>
+    );
+  };
 
   return (
     <table className="w-full text-sm text-text-secondary leading-tight">
@@ -73,11 +110,6 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
         <tr className="border-b border-border-light">
           {columns.map((column) => {
             const columnIsSorted = sortRules.column === column.id;
-
-            const sortButtonClasses = joinTailwindClasses(
-              "p-1 rounded-sm text-text-tertiary focus:bg-surface-heavy focus-visible:outline-none",
-              columnIsSorted ? "[&:not(:focus)]:text-text-brand" : "invisible group-hover:visible"
-            );
 
             return (
               <td
@@ -91,37 +123,14 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
                       <LucideInfo size={16} className="text-text-tertiary opacity-50 group-hover:opacity-100" />
                     </Tooltip>
                   )}
-                  {/* Sort button & menu */}
-                  {column.sortable && (
-                    <div className="flex-1 text-right">
-                      <Menu.Root>
-                        <Menu.Trigger className={sortButtonClasses}>
-                          <LucideArrowUpDown size={16} />
-                        </Menu.Trigger>
-                        <Menu.Portal>
-                          <Menu.Backdrop />
-                          <Menu.Positioner align="start" sideOffset={2}>
-                            <MenuPopup>
-                              <MenuItem disabled heading>
-                                Sort
-                              </MenuItem>
-                              <MenuItem onClick={onSort(column.id, true)}>Ascending</MenuItem>
-                              <MenuItem onClick={onSort(column.id, false)}>Descending</MenuItem>
-                              <MenuItem color="brand" onClick={onClearSort}>
-                                Clear sort
-                              </MenuItem>
-                            </MenuPopup>
-                          </Menu.Positioner>
-                        </Menu.Portal>
-                      </Menu.Root>
-                    </div>
-                  )}
+                  {column.sortable && renderSortControls(column)}
                 </div>
               </td>
             );
           })}
         </tr>
       </thead>
+
       {/* Rows */}
       <tbody>
         {sortedRows.map((row) => (

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -92,6 +92,7 @@
   --color-surface-light: #ffffff;
   --color-surface-bg: #fafafa;
   --color-surface-ui: #f5f5f5;
+  --color-surface-heavy: #e5e5e5;
   --color-surface-brand: #005eeb;
   --color-surface-brand-dark: #0049b8;
   --color-surface-mono: #202020;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -108,7 +108,7 @@
 
   --shadow-lg: 0px 4px 48px 0px rgba(0, 0, 0, 0.08);
   --shadow-md: 0px 4px 16px 0px rgba(0, 0, 0, 0.08);
-  --shadow-xs: 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
+  --shadow-xs: 0px 2px 2px 0px rgba(0, 0, 0, 0.08);
   --shadow-oep: 0px 8px 44px 0px rgba(32, 32, 32, 0.16);
 
   --container-1/2-gap-4: calc(50% - (1 / 2 * 1rem));

--- a/src/utils/baseUI.tsx
+++ b/src/utils/baseUI.tsx
@@ -1,4 +1,9 @@
-export const BaseUIArrow = ({ fill }: { fill: string }) => (
+interface IProps {
+  fill: string;
+  stroke: string;
+}
+
+export const BaseUIArrow = ({ fill, stroke }: IProps) => (
   <svg width="20" height="10" viewBox="0 0 20 10" fill="none">
     <path
       d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
@@ -6,7 +11,7 @@ export const BaseUIArrow = ({ fill }: { fill: string }) => (
     />
     <path
       d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
-      className={fill}
+      className={stroke}
     />
   </svg>
 );

--- a/src/utils/tailwind.ts
+++ b/src/utils/tailwind.ts
@@ -1,4 +1,4 @@
-export const joinTailwindClasses = (...parts: (string | false | undefined)[]) =>
+export const joinTailwindClasses = (...parts: (string | 0 | false | undefined)[]) =>
   parts
     .map((part) => (part || "").trim())
     .filter((part) => part)

--- a/src/utils/tailwind.ts
+++ b/src/utils/tailwind.ts
@@ -1,4 +1,4 @@
-export const joinTailwindClasses = (...parts: (string | undefined)[]) =>
+export const joinTailwindClasses = (...parts: (string | false | undefined)[]) =>
   parts
     .map((part) => (part || "").trim())
     .filter((part) => part)


### PR DESCRIPTION
# What's changed

Added a new generic interactive table for use on subsequent family page work, as well as supporting front-end components.

- Added `Tooltip` component:
  - Builds upon Base UI's [Tooltip](https://base-ui.com/react/components/tooltip) component.
  - Can specify the display direction (top/bottom) and whether to render an arrow.
  - Accompanying Storybook stories.
- Added menu components:
  - `MenuPopup` is a thin styling wrapper around Base UI's [Menu](https://base-ui.com/react/components/menu) `Menu.Popup` (the menu itself).
  - `MenuItem` is a thin styling wrapper around Base UI's [Menu](https://base-ui.com/react/components/menu) `Menu.Item` (each button in the menu).
  - Full pass-through of the Base UI props so these can be used flexibly as normal.
  - Allows for consistently styled reuse when building future menus.
- Added `InteractiveTable` component:
  - Requires a generic for the column IDs (string union type).
  - `columns` prop describes each column: position in the table, width fraction, display name, sortable, and optional tooltip.
  - `rows` is an array of objects with a key for each column.
    - Can provide a primitive string or number for simple data displaying.
    - Can provide a more complex object to differentiate the display and underlying value (used for sorting).
    - Supports `null` values which default to a dash placeholder.
  - Styling can be applied to the table, each row, and each column (via its cells).
  - Sorting functionality:
    - Columns that are sortable show a sort button in their header when hovered.
    - Each sortable column can be sorted ascending or descending, or cleared if already sorted.
    - Uses the new menu components.
  - Chunky Storybook story example.
- Fixed the `Popover` component's arrow which was missing its border.
  - Added a new prop to specify the border colour.

## Why?

- [APP-779](https://linear.app/climate-policy-radar/issue/APP-779/component-feature-rich-table)
- Satisfies [Conor's designs](https://www.figma.com/design/Lg0Vfj7EbUUz8HeqLWRZuK/Q3-2025?node-id=0-1&m=dev) for an interactive table as part of the new family page's "Entries" block.
- It is reasonable to make this table generic for future consistent tabulation.

## Screenshots?

Example table:
<img width="992" alt="Screenshot 2025-06-25 at 14 56 26" src="https://github.com/user-attachments/assets/422abec5-8ee1-487f-8a0b-627d44b14783" />

Sortable column's heading cell on hover:
<img width="296" alt="Screenshot 2025-06-25 at 14 56 36" src="https://github.com/user-attachments/assets/0f34ce32-4f8c-4a95-a0c9-1e4b52b0714d" />

Sort menu when column not sorted:
<img width="433" alt="Screenshot 2025-06-25 at 14 56 52" src="https://github.com/user-attachments/assets/4dd1855d-c469-4a1e-82a2-5d3bdb570cca" />

Sort menu when column is sorted:
<img width="278" alt="Screenshot 2025-06-25 at 14 57 02" src="https://github.com/user-attachments/assets/8f8c533b-4a42-4f55-ba0b-d73dcc480f64" />

Example of adding styling to columns and rows:
<img width="990" alt="Screenshot 2025-06-25 at 14 57 11" src="https://github.com/user-attachments/assets/6f548954-da9a-45ab-bfea-7201cb5e20e2" />

Tooltip component:
<img width="606" alt="Screenshot 2025-06-25 at 15 15 33" src="https://github.com/user-attachments/assets/c964cfae-42ee-4c7e-bc6d-f12cddf7bd4a" />
