### PR TITLE
Try to add regression assertions to fail the LHCI build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,11 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_BASE_HASH: ${{ github.event.pull_request.base.sha }}
+      - name: Check for performance regressions (Desktop)
+        run: node scripts/check-lighthouse-regression.js
+        env:
+          LHCI_BASE_HASH: ${{ github.event.pull_request.base.sha }}
 
   lhci-mobile:
     name: Lighthouse Mobile
@@ -59,6 +64,11 @@ jobs:
         run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_BASE_HASH: ${{ github.event.pull_request.base.sha }}
+      - name: Check for performance regressions (Mobile)
+        run: node scripts/check-lighthouse-regression.js
+        env:
+          LHCI_BASE_HASH: ${{ github.event.pull_request.base.sha }}
 
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,9 @@ jobs:
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - name: run Lighthouse Desktop
+        # The --baseHash parameter compares the current commit (the one being tested) against the specified base hash.
+        # E.g., if your PR branch has commit abc123, and the main branch has commit def456,
+        # --baseHash=def456 tells Lighthouse: "Compare abc123 against def456"
         run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
@@ -50,6 +53,9 @@ jobs:
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - name: run Lighthouse Mobile
+        # The --baseHash parameter compares the current commit (the one being tested) against the specified base hash.
+        # E.g., if your PR branch has commit abc123, and the main branch has commit def456,
+        # --baseHash=def456 tells Lighthouse: "Compare abc123 against def456"
         run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - name: run Lighthouse Desktop
-        run: lhci autorun --collect.settings.preset=desktop
+        run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 
@@ -50,7 +50,7 @@ jobs:
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - name: run Lighthouse Mobile
-        run: lhci autorun
+        run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 

--- a/scripts/check-lighthouse-regression.js
+++ b/scripts/check-lighthouse-regression.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Lighthouse CI Regression Checker
+ *
+ * Parses Lighthouse CI comparison output and fails if any metric degrades
+ * compared to the baseline branch.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Parse Lighthouse CI comparison data and check for regressions
+ *
+ * @param {string} comparisonData - JSON string containing comparison data
+ * @returns {Object} Object containing regression status and details
+ */
+function checkForRegressions(comparisonData) {
+  try {
+    const data = JSON.parse(comparisonData);
+    const regressions = [];
+
+    // Check each URL's metrics
+    Object.keys(data).forEach((url) => {
+      const urlData = data[url];
+
+      // Check category scores
+      if (urlData.categories) {
+        Object.keys(urlData.categories).forEach((category) => {
+          const categoryData = urlData.categories[category];
+          if (categoryData.score && categoryData.score.diff < 0) {
+            regressions.push({
+              url,
+              metric: `categories.${category}`,
+              baseline: categoryData.score.baseline,
+              current: categoryData.score.current,
+              diff: categoryData.score.diff,
+            });
+          }
+        });
+      }
+
+      // Check individual metrics
+      if (urlData.metrics) {
+        Object.keys(urlData.metrics).forEach((metric) => {
+          const metricData = urlData.metrics[metric];
+          if (metricData.diff < 0) {
+            regressions.push({
+              url,
+              metric,
+              baseline: metricData.baseline,
+              current: metricData.current,
+              diff: metricData.diff,
+            });
+          }
+        });
+      }
+    });
+
+    return {
+      hasRegressions: regressions.length > 0,
+      regressions,
+    };
+  } catch (error) {
+    console.error("❌ Error parsing Lighthouse comparison data:", error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Main function to run the regression check
+ */
+function main() {
+  console.log("🔍 Checking Lighthouse CI for performance regressions...");
+
+  // Check if we're in a PR context (baseHash should be provided)
+  const baseHash = process.env.LHCI_BASE_HASH;
+  if (!baseHash) {
+    console.log("⚠️  No base hash provided, skipping regression check");
+    process.exit(0);
+  }
+
+  // Look for Lighthouse CI output files
+  const lhciDir = path.join(process.cwd(), ".lighthouseci");
+  if (!fs.existsSync(lhciDir)) {
+    console.log("⚠️  No Lighthouse CI output found, skipping regression check");
+    process.exit(0);
+  }
+
+  // Find comparison data
+  const comparisonFile = path.join(lhciDir, "comparison.json");
+  if (!fs.existsSync(comparisonFile)) {
+    console.log("⚠️  No comparison data found, skipping regression check");
+    process.exit(0);
+  }
+
+  try {
+    const comparisonData = fs.readFileSync(comparisonFile, "utf8");
+    const result = checkForRegressions(comparisonData);
+
+    if (result.hasRegressions) {
+      console.error("❌ Performance regressions detected:");
+      result.regressions.forEach((regression) => {
+        const diffPercent = (regression.diff * 100).toFixed(2);
+        console.error(`   ${regression.url} - ${regression.metric}: ${diffPercent}% degradation`);
+        console.error(`     Baseline: ${regression.baseline}, Current: ${regression.current}`);
+      });
+      console.error("\n🚫 Build failed due to performance regressions");
+      process.exit(1);
+    } else {
+      console.log("✅ No performance regressions detected");
+      process.exit(0);
+    }
+  } catch (error) {
+    console.error("❌ Error reading Lighthouse comparison data:", error.message);
+    process.exit(1);
+  }
+}
+
+// Run the script
+if (require.main === module) {
+  main();
+}
+
+module.exports = { checkForRegressions };


### PR DESCRIPTION
# What's changed

Compare the current lighthouse results on the PR against the results from the base branch & fail the GitHub Lighthouse builds if there is any regression from the base.

## Why?

To prevent degradation in quality between PRs.


