### PR TITLE
Feature/app 793 separate out reports for desktop and mobile

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -26,6 +26,7 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
 
   lhci-mobile:
     name: Lighthouse Mobile
@@ -45,6 +46,7 @@ jobs:
         run: lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
 
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,7 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
 
   lhci-mobile:
     name: Lighthouse Mobile
@@ -59,6 +60,7 @@ jobs:
         run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
 
   percy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What's changed

Upload results for both desktop and mobile to our lighthouse server under different projects

## Why?

Both mobile and desktop jobs are using the same Lighthouse CI server and token, causing a race condition where only one set of results gets uploaded per commit hash.

The solution I'm going with is to separate the reports by using different project tokens - as Lighthouse CI only allows one report per project per commit hash. If you run both desktop and mobile jobs for the same project and commit (what we are doing), the second upload will overwrite the first.
