### PR TITLE
Feature/app 795 add reporting for other themes other than just cpr

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -11,6 +11,13 @@ jobs:
   lhci-desktop:
     name: Lighthouse Desktop
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [cpr, cclw, mcf, ccc]
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 22.12.0
@@ -22,15 +29,27 @@ jobs:
       - run: npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
+      - id: upper-theme
+        name: Theme to uppercase
+        run: |
+          theme=$(echo ${{ matrix.theme }} | tr '[:lower:]' '[:upper:]')
+          echo "theme=$theme" >> $GITHUB_OUTPUT
       - name: run Lighthouse Desktop
         run: lhci autorun --collect.settings.preset=desktop
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets[format('LHCI_{0}_DESKTOP_TOKEN', steps.upper-theme.outputs.theme)] }}
 
   lhci-mobile:
     name: Lighthouse Mobile
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [cpr, cclw, mcf, ccc]
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 22.12.0
@@ -42,11 +61,16 @@ jobs:
       - run: npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
+      - id: upper-theme
+        name: Theme to uppercase
+        run: |
+          theme=$(echo ${{ matrix.theme }} | tr '[:lower:]' '[:upper:]')
+          echo "theme=$theme" >> $GITHUB_OUTPUT
       - name: run Lighthouse Mobile
         run: lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
+          LHCI_TOKEN: ${{ secrets[format('LHCI_{0}_MOBILE_TOKEN', steps.upper-theme.outputs.theme)] }}
 
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -26,6 +26,7 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
 
   lhci-mobile:
     name: Lighthouse Mobile
@@ -45,6 +46,7 @@ jobs:
         run: lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
 
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,8 +17,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   lhci-desktop:
-    name: Lighthouse Desktop
+    name: Lighthouse Desktop (${{ matrix.theme }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [cpr, cclw, mcf, ccc]
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 22.12.0
@@ -27,9 +34,14 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: npm run build
+      - run: THEME=${{ matrix.theme }} npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
+      - id: upper-theme
+        name: Theme to uppercase
+        run: |
+          theme=$(echo ${{ matrix.theme }} | tr '[:lower:]' '[:upper:]')
+          echo "theme=$theme" >> $GITHUB_OUTPUT
       - name: run Lighthouse Desktop
         # The --baseHash parameter compares the current commit (the one being tested) against the specified base hash.
         # E.g., if your PR branch has commit abc123, and the main branch has commit def456,
@@ -37,11 +49,18 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets[format('LHCI_{0}_DESKTOP_TOKEN', steps.upper-theme.outputs.theme)] }}
 
   lhci-mobile:
-    name: Lighthouse Mobile
+    name: Lighthouse Mobile (${{ matrix.theme }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [cpr, cclw, mcf, ccc]
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 22.12.0
@@ -50,9 +69,16 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: npm run build
+      - run: THEME=${{ matrix.theme }} npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
+
+      - id: upper-theme
+        name: Theme to uppercase
+        run: |
+          theme=$(echo ${{ matrix.theme }} | tr '[:lower:]' '[:upper:]')
+          echo "theme=$theme" >> $GITHUB_OUTPUT
+
       - name: run Lighthouse Mobile
         # The --baseHash parameter compares the current commit (the one being tested) against the specified base hash.
         # E.g., if your PR branch has commit abc123, and the main branch has commit def456,
@@ -60,7 +86,7 @@ jobs:
         run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
+          LHCI_TOKEN: ${{ secrets[format('LHCI_{0}_MOBILE_TOKEN', steps.upper-theme.outputs.theme)] }}
 
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,7 @@ jobs:
         run: lhci autorun --collect.settings.preset=desktop --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_DESKTOP_TOKEN }}
 
   lhci-mobile:
     name: Lighthouse Mobile
@@ -59,6 +60,7 @@ jobs:
         run: lhci autorun --baseHash=${{ github.event.pull_request.base.sha }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_TOKEN: ${{ secrets.LHCI_CPR_MOBILE_TOKEN }}
 
   percy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What's changed

Add LHCI reporting for all themes across both desktop and mobile

## Why?

Currently our LH reports cover only the CPR app (which is arguably the least important to be reported on, as we do not prioritising SEO yet).

NOTE: We will need to update the baselines for mobile and desktop once we have the new baselines on main.
