### PR TITLE
feat: familyConceptsSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ Themes are configured in `themes/[theme-name]/config.ts`. Each theme can overrid
 - Feature flags
 - Environment-specific configurations
 
+## 🏴‍☠️ Feature flags
+
+### Theme features
+
+We have the ability to turn features on per theme. These are controlled via the
+[`themeConfig.features`](./src/types/themeConfig.ts#l75).
+
+These are accessed via [`./src/utils/features.ts`](./src/utils/features.ts).
+
 ## 📜 License
 
 This project is licensed under the terms specified in [LICENSE.md](LICENSE.md).

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -37,8 +37,9 @@ import useConfig from "@/hooks/useConfig";
 import { useDownloadCsv } from "@/hooks/useDownloadCsv";
 import useSearch from "@/hooks/useSearch";
 import { TConcept, TFeatureFlags, TTheme, TThemeConfig } from "@/types";
+import { FamilyConcept, groupFamilyConcepts } from "@/utils/familyConcepts";
 import { getFeatureFlags } from "@/utils/featureFlags";
-import { isKnowledgeGraphEnabled } from "@/utils/features";
+import { isFamilyConceptsSearchEnabled, isKnowledgeGraphEnabled } from "@/utils/features";
 import { getCurrentSearchChoice } from "@/utils/getCurrentSearchChoice";
 import { getCurrentSortChoice } from "@/utils/getCurrentSortChoice";
 import { ResultsTopicsContext } from "@/utils/getPassageResultsContext";
@@ -654,6 +655,19 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       const { data: returnedData } = await client.get(`/concepts/search?limit=10000&has_classifier=true`);
       conceptsData = returnedData;
     } catch (error) {
+      // TODO: handle error more elegantly
+    }
+  }
+
+  // TODO: Next - start rendering this data
+  let familyConceptsData: { data: FamilyConcept[] } | undefined;
+  let groupedFamilyConcepts: ReturnType<typeof groupFamilyConcepts> | undefined;
+  if (isFamilyConceptsSearchEnabled(themeConfig)) {
+    try {
+      const familyConceptsResponse = await fetch(`${process.env.CONCEPTS_API_URL}/families/concepts`);
+      familyConceptsData = await familyConceptsResponse.json();
+      groupedFamilyConcepts = groupFamilyConcepts(familyConceptsData.data);
+    } catch (e) {
       // TODO: handle error more elegantly
     }
   }

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -2,6 +2,6 @@ export const featureFlagKeys = ["concepts-v1", "litigation", "unfccc-filters"] a
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
 
-export const configFeatureKeys = ["knowledgeGraph", "searchFamilySummary"] as const;
+export const configFeatureKeys = ["knowledgeGraph", "searchFamilySummary", "familyConceptsSearch"] as const;
 export type TConfigFeature = (typeof configFeatureKeys)[number];
 export type TConfigFeatures = Record<TConfigFeature, boolean>;

--- a/src/utils/buildSearchQuery.test.ts
+++ b/src/utils/buildSearchQuery.test.ts
@@ -29,7 +29,7 @@ describe("buildSearchQuery: ", () => {
       metadata: [],
       documentCategories: ["All"],
       defaultDocumentCategory: "All",
-      features: { knowledgeGraph: true, searchFamilySummary: true },
+      features: { knowledgeGraph: true, searchFamilySummary: true, familyConceptsSearch: false },
     };
 
     const searchQueryWithNoCategory = buildSearchQuery({}, themeConfig);
@@ -52,7 +52,7 @@ describe("buildSearchQuery: ", () => {
       metadata: [],
       documentCategories: [],
       defaultDocumentCategory: "All",
-      features: { knowledgeGraph: true, searchFamilySummary: true },
+      features: { knowledgeGraph: true, searchFamilySummary: true, familyConceptsSearch: false },
     };
 
     const searchQuery = buildSearchQuery({}, themeConfig);

--- a/src/utils/buildSearchQueryMetadata.test.ts
+++ b/src/utils/buildSearchQueryMetadata.test.ts
@@ -21,6 +21,7 @@ const testThemeConfig: TThemeConfig = {
   features: {
     knowledgeGraph: false,
     searchFamilySummary: true,
+    familyConceptsSearch: false,
   },
 };
 

--- a/src/utils/canDisplayFilter.test.ts
+++ b/src/utils/canDisplayFilter.test.ts
@@ -54,6 +54,7 @@ const testThemeConfig: TThemeConfig = {
   features: {
     knowledgeGraph: false,
     searchFamilySummary: true,
+    familyConceptsSearch: false,
   },
 };
 

--- a/src/utils/familyConcepts.test.ts
+++ b/src/utils/familyConcepts.test.ts
@@ -1,0 +1,78 @@
+import { FamilyConcept, groupFamilyConcepts } from "./familyConcepts";
+
+const familyConcepts: FamilyConcept[] = [
+  {
+    relation: "jurisdiction",
+    preferred_label: "New South Wales",
+    subconcept_of_labels: ["Australia"],
+  },
+  {
+    relation: "jurisdiction",
+    preferred_label: "Australia",
+    subconcept_of_labels: [],
+  },
+  {
+    relation: "jurisdiction",
+    preferred_label: "Supreme Court of New south Wales",
+    subconcept_of_labels: ["Australia", "New South Wales"],
+  },
+  {
+    relation: "jurisdiction",
+    preferred_label: "Bucharest Court of First Instance",
+    subconcept_of_labels: ["Romania"],
+  },
+  {
+    relation: "jurisdiction",
+    preferred_label: "Bucharest Court of Appeal",
+    subconcept_of_labels: ["Romania"],
+  },
+  {
+    relation: "jurisdiction",
+    preferred_label: "Romania",
+    subconcept_of_labels: [],
+  },
+];
+
+const expectedGroupConcepts = {
+  Australia: [
+    {
+      relation: "jurisdiction",
+      preferred_label: "Australia",
+      subconcept_of_labels: [],
+    },
+    {
+      relation: "jurisdiction",
+      preferred_label: "New South Wales",
+      subconcept_of_labels: ["Australia"],
+    },
+    {
+      relation: "jurisdiction",
+      preferred_label: "Supreme Court of New south Wales",
+      subconcept_of_labels: ["Australia", "New South Wales"],
+    },
+  ],
+  Romania: [
+    {
+      relation: "jurisdiction",
+      preferred_label: "Romania",
+      subconcept_of_labels: [],
+    },
+    {
+      relation: "jurisdiction",
+      preferred_label: "Bucharest Court of Appeal",
+      subconcept_of_labels: ["Romania"],
+    },
+    {
+      relation: "jurisdiction",
+      preferred_label: "Bucharest Court of First Instance",
+      subconcept_of_labels: ["Romania"],
+    },
+  ],
+};
+
+describe("groupFamilyConcepts", () => {
+  it("should group family concepts by their root ancestor", () => {
+    const result = groupFamilyConcepts(familyConcepts);
+    expect(result).toEqual(expectedGroupConcepts);
+  });
+});

--- a/src/utils/familyConcepts.ts
+++ b/src/utils/familyConcepts.ts
@@ -1,0 +1,39 @@
+export type FamilyConcept = {
+  relation: "category" | "jurisdiction" | "principle_law";
+  preferred_label: string;
+  subconcept_of_labels: string[];
+};
+
+export function groupFamilyConcepts(items: FamilyConcept[]) {
+  const rootFamilyConcepts = items.filter((item) => item.subconcept_of_labels.length === 0);
+  const findRootAncestor = (item: FamilyConcept) => {
+    const root = rootFamilyConcepts.find((root) => item.subconcept_of_labels.find((label) => label === root.preferred_label));
+    return root;
+  };
+
+  const groupedByRoot = Object.groupBy(items, (item: FamilyConcept) => {
+    if (item.subconcept_of_labels.length === 0) {
+      return item.preferred_label;
+    } else {
+      const root = findRootAncestor(item);
+      if (!root) {
+        // We shouldn't really reach this - but the data is whacky
+        // so: Fallback to the item's preferred label
+        return item.preferred_label;
+      }
+      return root.preferred_label;
+    }
+  });
+
+  // Order these by how many subconcepts they have
+  // And then their preferred_label
+  for (const group in groupedByRoot) {
+    groupedByRoot[group].sort((a, b) => {
+      if (a.subconcept_of_labels.length === b.subconcept_of_labels.length) {
+        return a.preferred_label.localeCompare(b.preferred_label);
+      }
+      return a.subconcept_of_labels.length - b.subconcept_of_labels.length;
+    });
+  }
+  return groupedByRoot;
+}

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -34,3 +34,8 @@ export const isSearchFamilySummaryEnabled = (themeConfig: TThemeConfig) =>
   isFeatureEnabled({
     configFeature: themeConfig.features.searchFamilySummary,
   });
+
+export const isFamilyConceptsSearchEnabled = (themeConfig: TThemeConfig) =>
+  isFeatureEnabled({
+    configFeature: themeConfig.features.familyConceptsSearch,
+  });

--- a/tests/unit/components/blocks/FilterOptions.test.tsx
+++ b/tests/unit/components/blocks/FilterOptions.test.tsx
@@ -25,6 +25,7 @@ describe("FilterOptions", () => {
       features: {
         knowledgeGraph: false,
         searchFamilySummary: true,
+        familyConceptsSearch: false,
       },
     };
 

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -72,6 +72,7 @@ const config: TThemeConfig = {
   features: {
     knowledgeGraph: false,
     searchFamilySummary: true,
+    familyConceptsSearch: true,
   },
 };
 

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -165,6 +165,7 @@ const config: TThemeConfig = {
   features: {
     knowledgeGraph: true,
     searchFamilySummary: true,
+    familyConceptsSearch: false,
   },
 };
 

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -353,6 +353,7 @@ const config: TThemeConfig = {
   features: {
     knowledgeGraph: true,
     searchFamilySummary: false,
+    familyConceptsSearch: false,
   },
 };
 

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -136,6 +136,7 @@ const config: TThemeConfig = {
   features: {
     knowledgeGraph: false,
     searchFamilySummary: true,
+    familyConceptsSearch: false,
   },
 };
 


### PR DESCRIPTION
# What's changed
- adds `familyConceptsSearch` theme feature flag
- adds getting [concepts from the families-api](https://api.climatepolicyradar.org/families/concepts) behind a theme feature flag
- adds docs on theme feature flags

## Why?
We'd like to start rendering these in the filter panel of CCC.

