### PR TITLE
Feature/app 831 update applied filters logic to work with new geographies api

### DIFF
--- a/src/components/CountryLink.tsx
+++ b/src/components/CountryLink.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 
 import { systemGeoCodes } from "@/constants/systemGeos";
-import { getCountrySlug } from "@/helpers/getCountryFields";
+import { getCountrySlug, getCountrySlugOld } from "@/helpers/getCountryFields";
 import useConfig from "@/hooks/useConfig";
 
 import { LinkWithQuery } from "./LinkWithQuery";
@@ -16,9 +16,9 @@ type TCountryLink = {
 
 export const CountryLink: FC<TCountryLink> = ({ countryCode, className = "", emptyContentFallback, children, showFlag = true }) => {
   const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
+  const { data: { countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
-  const slug = getCountrySlug(countryCode, countries);
+  const slug = getCountrySlugOld(countryCode, countries);
   // Force render without any empty content fallback the children without a link
   if (!slug && emptyContentFallback) return <>{emptyContentFallback}</>;
   if (!slug && !emptyContentFallback) return <>{children}</>;

--- a/src/components/CountryLink.tsx
+++ b/src/components/CountryLink.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 
 import { systemGeoCodes } from "@/constants/systemGeos";
-import { getCountrySlug, getCountrySlugOld } from "@/helpers/getCountryFields";
+import { getCountrySlugOld } from "@/helpers/getCountryFields";
 import useConfig from "@/hooks/useConfig";
 
 import { LinkWithQuery } from "./LinkWithQuery";

--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 
 import { CountryLink } from "@/components/CountryLink";
-import { getCountryName } from "@/helpers/getCountryFields";
+import { getCountryNameOld } from "@/helpers/getCountryFields";
 import { TGeography } from "@/types";
 import { isSystemGeo, isSystemInternational } from "@/utils/isSystemGeo";
 
@@ -14,7 +14,7 @@ type TCountriesLink = {
 export const CountryLinks = ({ geographies, countries, showFlag = true }: TCountriesLink) => (
   <>
     {geographies?.map((geography) => {
-      const countryName = getCountryName(geography, countries);
+      const countryName = getCountryNameOld(geography, countries);
       if (!countryName) return null;
 
       return (
@@ -43,7 +43,7 @@ export const CountryLinksAsList = ({ geographies, countries, showFlag = true }: 
       <Fragment key={geography}>
         {isSystemInternational(geography) && (
           <div className="flex">
-            <>{getCountryName(geography, countries)}</>
+            <>{getCountryNameOld(geography, countries)}</>
             {index !== geographies.length - 1 && <span>,</span>}
           </div>
         )}
@@ -54,7 +54,7 @@ export const CountryLinksAsList = ({ geographies, countries, showFlag = true }: 
               showFlag={showFlag}
               className="text-blue-600 underline truncate text-sm capitalize hover:text-blue-800"
             >
-              <span>{getCountryName(geography, countries)}</span>
+              <span>{getCountryNameOld(geography, countries)}</span>
             </CountryLink>
             {index !== geographies.length - 1 && <span>,</span>}
           </div>

--- a/src/components/blocks/CountryHeader.tsx
+++ b/src/components/blocks/CountryHeader.tsx
@@ -14,7 +14,7 @@ interface IProps {
 
 export const CountryHeader = ({ country, targetCount, onTargetClick, theme, totalProjects }: IProps) => {
   const configQuery = useConfig();
-  const { data: { regions = [], countries = [] } = {} } = configQuery;
+  const { data: { regions = [], countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
   const countryGeography = countries.find((c: TGeography) => c.display_value === country.name);
 

--- a/src/components/document/FamilyMeta.tsx
+++ b/src/components/document/FamilyMeta.tsx
@@ -17,7 +17,7 @@ interface IProps {
 
 export const FamilyMeta = ({ category, date, geographies, topics, author, corpus_type_name, document_type, source }: IProps) => {
   const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
+  const { data: { countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
   const [year] = convertDate(date);
 

--- a/src/components/document/McfFamilyMeta.tsx
+++ b/src/components/document/McfFamilyMeta.tsx
@@ -27,7 +27,7 @@ interface MultipleValuesContentProps {
 
 const ListOfCountries = ({ countryCodes, label }: ListOfCountriesProps) => {
   const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
+  const { data: { countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
   return (
     <>

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -11,7 +11,7 @@ import { SubNav } from "@/components/nav/SubNav";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { Heading } from "@/components/typography/Heading";
 import { MAX_FAMILY_SUMMARY_LENGTH_BRIEF } from "@/constants/document";
-import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { getCountryNameOld, getCountrySlug, getCountrySlugOld } from "@/helpers/getCountryFields";
 import useConfig from "@/hooks/useConfig";
 import { TDocumentPage, TFamilyPage } from "@/types";
 import { truncateString } from "@/utils/truncateString";
@@ -32,11 +32,11 @@ export const DocumentHead = ({ document, family, handleViewOtherDocsClick, handl
   const [summary, setSummary] = useState("");
 
   const configQuery = useConfig();
-  const { data: { countries = [], languages = {} } = {} } = configQuery;
+  const { data: { countries = [], languages = {} } = {} } = configQuery; // TODO: Update as part of APP-841
 
-  const geographyNames = family.geographies ? family.geographies.map((geo) => getCountryName(geo, countries)) : null;
+  const geographyNames = family.geographies ? family.geographies.map((geo) => getCountryNameOld(geo, countries)) : null;
   const geoName = geographyNames ? geographyNames[0] : "";
-  const geoSlug = family.geographies ? getCountrySlug(family.geographies[0], countries) : "";
+  const geoSlug = family.geographies ? getCountrySlugOld(family.geographies[0], countries) : "";
   const isMain = document.document_role.toLowerCase().includes("main");
   const breadcrumbGeography = family.geographies && family.geographies.length > 1 ? null : { label: geoName, href: `/geographies/${geoSlug}` };
   const breadcrumbFamily = {

--- a/src/components/documents/DocumentMeta.tsx
+++ b/src/components/documents/DocumentMeta.tsx
@@ -5,7 +5,7 @@ import { convertDate } from "@/utils/timedate";
 
 export const DocumentMeta = ({ family, isMain, document, document_type }: { family: any; isMain: boolean; document: any; document_type: any }) => {
   const configQuery = useConfig();
-  const { data: { countries = [], languages = {} } = {} } = configQuery;
+  const { data: { countries = [], languages = {} } = {} } = configQuery; // TODO: Update as part of APP-841
   const [year] = convertDate(family.published_date);
 
   return (

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -8,9 +8,11 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { sortOptions } from "@/constants/sortOptions";
 import { getConceptName } from "@/helpers/getConceptFields";
 import { getCountryName } from "@/helpers/getCountryFields";
+import { getRegionName } from "@/helpers/getRegionFields";
 import useConfig from "@/hooks/useConfig";
+import useCountries from "@/hooks/useCountries";
 import useGetThemeConfig from "@/hooks/useThemeConfig";
-import { TConcept, TGeography, TThemeConfig } from "@/types";
+import { TConcept, TCountry, TGeography, TThemeConfig } from "@/types";
 
 type TFilterChange = (type: string, value: string) => void;
 
@@ -19,8 +21,12 @@ interface IProps {
   concepts?: TConcept[];
 }
 
-const handleCountryRegion = (slug: string, dataSet: TGeography[]) => {
+const handleCountry = (slug: string, dataSet: TCountry[]) => {
   return getCountryName(slug, dataSet);
+};
+
+const handleRegion = (slug: string, dataSet: TGeography[]) => {
+  return getRegionName(slug, dataSet);
 };
 
 const handleConceptName = (label: string, concepts: TConcept[]) => {
@@ -48,7 +54,7 @@ const handleFilterDisplay = (
   queryParams: ParsedUrlQuery,
   key: TFilterKeys,
   value: string,
-  countries: TGeography[],
+  countries: TCountry[],
   regions: TGeography[],
   themeConfig: TThemeConfig,
   concepts?: TConcept[]
@@ -61,10 +67,10 @@ const handleFilterDisplay = (
       filterLabel = configCategory ? configCategory.label : value;
       break;
     case "country":
-      filterLabel = handleCountryRegion(value, countries);
+      filterLabel = handleCountry(value, countries);
       break;
     case "region":
-      filterLabel = handleCountryRegion(value, regions);
+      filterLabel = handleRegion(value, regions);
       break;
     case "concept_name":
       filterLabel = handleConceptName(value, concepts);
@@ -121,7 +127,7 @@ const handleFilterDisplay = (
 const generatePills = (
   queryParams: ParsedUrlQuery,
   filterChange: TFilterChange,
-  countries: TGeography[],
+  countries: TCountry[],
   regions: TGeography[],
   themeConfig: TThemeConfig,
   concepts?: TConcept[]
@@ -155,7 +161,10 @@ export const AppliedFilters = ({ filterChange, concepts }: IProps) => {
   const router = useRouter();
   const configQuery = useConfig();
   const { themeConfig } = useGetThemeConfig();
-  const { data: { countries = [], regions = [] } = {} } = configQuery;
+  const { data: { regions = [] } = {} } = configQuery;
+
+  const countriesQuery = useCountries();
+  const { data: countries = [] } = countriesQuery;
 
   const appliedFilters = useMemo(
     () => generatePills(router.query, filterChange, countries, regions, themeConfig, concepts).map((pill) => pill),

--- a/src/components/filters/MultiList.tsx
+++ b/src/components/filters/MultiList.tsx
@@ -1,5 +1,5 @@
 import { QUERY_PARAMS } from "@/constants/queryParams";
-import { getCountryName } from "@/helpers/getCountryFields";
+import { getCountryNameOld } from "@/helpers/getCountryFields";
 import useConfig from "@/hooks/useConfig";
 
 import FilterTag from "../labels/FilterTag";
@@ -13,7 +13,7 @@ interface IProps {
 
 const MultiList = ({ list, removeFilter, type, dataCy }: IProps) => {
   const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
+  const { data: { countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
   const handleClick = (item: string) => {
     removeFilter(type, item);
@@ -24,7 +24,7 @@ const MultiList = ({ list, removeFilter, type, dataCy }: IProps) => {
       {list.length > 0
         ? list.map((item, index) => (
             <div key={`tag${index}`} className="mr-2 mt-1">
-              <FilterTag onClick={() => handleClick(item)} item={type === QUERY_PARAMS.country ? getCountryName(item, countries) : item} />
+              <FilterTag onClick={() => handleClick(item)} item={type === QUERY_PARAMS.country ? getCountryNameOld(item, countries) : item} />
             </div>
           ))
         : null}

--- a/src/helpers/getCountryFields.ts
+++ b/src/helpers/getCountryFields.ts
@@ -14,7 +14,6 @@ export const getCountrySlugOld = (countrySearch: string, dataSet: TGeography[]) 
 };
 
 export const getCountryNameOld = (countrySearch: string, dataSet: TGeography[]) => {
-  // Official name is sometimes null.
   return findCountryObjectOld(countrySearch, dataSet)?.display_value;
 };
 

--- a/src/helpers/getCountryFields.ts
+++ b/src/helpers/getCountryFields.ts
@@ -1,21 +1,27 @@
-import { TGeography } from "@/types";
+import { TCountry } from "@/types";
 
-const findCountryObject = (countrySearch: string, dataSet: TGeography[]) => {
-  let country = dataSet.find((c) => c.value.toLowerCase() === countrySearch.toLowerCase());
-  if (!country) country = dataSet.find((c) => c.display_value.toLowerCase() === countrySearch.toLowerCase());
-  if (!country) country = dataSet.find((c) => c.slug.toLowerCase() === countrySearch.toLowerCase());
+const findCountryObject = (countrySearch: string, dataSet: TCountry[]) => {
+  if (dataSet.length === 0) return null;
+  if (!dataSet[0].alpha_3) return null; // FIXME Remove
+
+  let country = dataSet.find((c) => c.alpha_3.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) country = dataSet.find((c) => c.alpha_2.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) country = dataSet.find((c) => c.name.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) country = dataSet.find((c) => c.official_name.toLowerCase() === countrySearch.toLowerCase());
   if (!country) return null;
   return country;
 };
 
-export const getCountrySlug = (countrySearch: string, dataSet: TGeography[]) => {
-  return findCountryObject(countrySearch, dataSet)?.slug;
+export const getCountrySlug = (countrySearch: string, dataSet: TCountry[]) => {
+  // FIXME: Remove references.
+  return findCountryObject(countrySearch, dataSet)?.alpha_3;
 };
 
-export const getCountryName = (countrySearch: string, dataSet: TGeography[]) => {
-  return findCountryObject(countrySearch, dataSet)?.display_value;
+export const getCountryName = (countrySearch: string, dataSet: TCountry[]) => {
+  // Official name is sometimes null.
+  return findCountryObject(countrySearch, dataSet)?.name;
 };
 
-export const getCountryCode = (countrySearch: string, dataSet: TGeography[]) => {
-  return findCountryObject(countrySearch, dataSet)?.value;
+export const getCountryCode = (countrySearch: string, dataSet: TCountry[]) => {
+  return findCountryObject(countrySearch, dataSet)?.alpha_3;
 };

--- a/src/helpers/getCountryFields.ts
+++ b/src/helpers/getCountryFields.ts
@@ -1,9 +1,29 @@
-import { TCountry } from "@/types";
+import { TCountry, TGeography } from "@/types";
 
+// Old
+const findCountryObjectOld = (countrySearch: string, dataSet: TGeography[]) => {
+  let country = dataSet.find((c) => c.value.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) country = dataSet.find((c) => c.slug.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) country = dataSet.find((c) => c.display_value.toLowerCase() === countrySearch.toLowerCase());
+  if (!country) return null;
+  return country;
+};
+
+export const getCountrySlugOld = (countrySearch: string, dataSet: TGeography[]) => {
+  return findCountryObjectOld(countrySearch, dataSet)?.slug;
+};
+
+export const getCountryNameOld = (countrySearch: string, dataSet: TGeography[]) => {
+  // Official name is sometimes null.
+  return findCountryObjectOld(countrySearch, dataSet)?.display_value;
+};
+
+export const getCountryCodeOld = (countrySearch: string, dataSet: TGeography[]) => {
+  return findCountryObjectOld(countrySearch, dataSet)?.value;
+};
+
+// New geographies-api
 const findCountryObject = (countrySearch: string, dataSet: TCountry[]) => {
-  if (dataSet.length === 0) return null;
-  if (!dataSet[0].alpha_3) return null; // FIXME Remove
-
   let country = dataSet.find((c) => c.alpha_3.toLowerCase() === countrySearch.toLowerCase());
   if (!country) country = dataSet.find((c) => c.alpha_2.toLowerCase() === countrySearch.toLowerCase());
   if (!country) country = dataSet.find((c) => c.name.toLowerCase() === countrySearch.toLowerCase());

--- a/src/helpers/getRegionFields.ts
+++ b/src/helpers/getRegionFields.ts
@@ -1,0 +1,13 @@
+import { TGeography } from "@/types";
+
+const findRegionObject = (regionSearch: string, dataSet: TGeography[]) => {
+  let region = dataSet.find((c) => c.value.toLowerCase() === regionSearch.toLowerCase());
+  if (!region) region = dataSet.find((c) => c.display_value.toLowerCase() === regionSearch.toLowerCase());
+  if (!region) region = dataSet.find((c) => c.slug.toLowerCase() === regionSearch.toLowerCase());
+  if (!region) return null;
+  return region;
+};
+
+export const getRegionName = (regionSearch: string, dataSet: TGeography[]) => {
+  return findRegionObject(regionSearch, dataSet)?.display_value;
+};

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -31,7 +31,7 @@ import { MAX_PASSAGES } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { getCorpusInfo } from "@/helpers/getCorpusInfo";
-import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { getCountryNameOld, getCountrySlug, getCountrySlugOld } from "@/helpers/getCountryFields";
 import { getMainDocuments } from "@/helpers/getMainDocuments";
 import { useEffectOnce } from "@/hooks/useEffectOnce";
 import useSearch from "@/hooks/useSearch";
@@ -94,9 +94,10 @@ const FamilyPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   const publishedTargets = sortFilterTargets(targets);
   const hasTargets = !!publishedTargets && publishedTargets?.length > 0;
 
-  const geographyNames = page.geographies ? page.geographies.map((geo) => getCountryName(geo, countries)) : null;
+  // Update as part of APP-841
+  const geographyNames = page.geographies ? page.geographies.map((geo) => getCountryNameOld(geo, countries)) : null;
   const geographyName = geographyNames ? geographyNames[0] : "";
-  const geographySlug = page.geographies ? getCountrySlug(page.geographies[0], countries) : "";
+  const geographySlug = page.geographies ? getCountrySlugOld(page.geographies[0], countries) : "";
   const breadcrumbCategory = { label: "Search results", href: "/search" };
   const breadcrumbGeography =
     page.geographies && page.geographies.length > 1 ? null : { label: geographyName, href: `/geographies/${geographySlug}` };

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -25,7 +25,7 @@ import { Heading } from "@/components/typography/Heading";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { systemGeoNames } from "@/constants/systemGeos";
 import { withEnvConfig } from "@/context/EnvConfig";
-import { getCountryCode } from "@/helpers/getCountryFields";
+import { getCountryCodeOld } from "@/helpers/getCountryFields";
 import { TGeographyStats, TGeographySummary, TThemeConfig } from "@/types";
 import { TTarget, TEvent, TGeography, TTheme, TDocumentCategory } from "@/types";
 import { extractNestedData } from "@/utils/extractNestedData";
@@ -409,7 +409,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const configData = await client.getConfig();
     const response_geo = extractNestedData<TGeography>(configData.data?.geographies || []);
     countries = response_geo[1];
-    const country = getCountryCode(id as string, countries);
+    const country = getCountryCodeOld(id as string, countries);
     if (country) {
       const targetsRaw = await axios.get<TTarget[]>(`${process.env.TARGETS_URL}/geographies/${country.toLowerCase()}.json`);
       targetsData = targetsRaw.data;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ const IndexPage = () => {
   const { mutate: updateCountries } = useUpdateCountries();
 
   const configQuery = useConfig();
-  const { data: { regions = [], countries = [] } = {} } = configQuery;
+  const { data: { regions = [], countries = [] } = {} } = configQuery; // TODO: Update as part of APP-841
 
   const handleSearchInput = (term: string, filter?: string, filterValue?: string) => {
     triggerNewSearch(router, term, filter, filterValue);

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -115,7 +115,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
   }, [router]);
 
   const configQuery = useConfig();
-  const { data: { regions = [], countries = [], corpus_types = {} } = {} } = configQuery;
+  const { data: { regions = [], countries = [], corpus_types = {} } = {} } = configQuery; // TODO: Update as part of APP-841
 
   const { status: downloadCSVStatus, download: downloadCSV, resetStatus: resetCSVStatus } = useDownloadCsv();
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -62,8 +62,8 @@ export type TGeography = {
 };
 
 export type TCountry = {
-  alpha2: string;
-  alpha3: string;
+  alpha_2: string;
+  alpha_3: string;
   name: string;
   official_name: string;
   numeric: string;


### PR DESCRIPTION
# What's changed

New countries that were not previously in our database will now show the selected pill when they are selected from the published jurisdiction filter typeahead. 

## Why?

The geographies we had in our database are not identical to the new geographies we pull down from our API. There is overlap (Spain, Colombia etc) -- but the differences are geographies such as the Falklands, Faroe Islands etc.


