### PR TITLE
Turn robots on for LHCI jobs

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: npm run build
+      - run: ROBOTOS=true npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - id: upper-theme
@@ -58,7 +58,7 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: npm run build
+      - run: ROBOTOS=true npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - id: upper-theme

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: THEME=${{ matrix.theme }} npm run build
+      - run: THEME=${{ matrix.theme }} ROBOTOS=true npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
       - id: upper-theme
@@ -69,7 +69,7 @@ jobs:
           node-version: 22.12.0
       - run: npm install
       - run: cp .env.example .env
-      - run: THEME=${{ matrix.theme }} npm run build
+      - run: THEME=${{ matrix.theme }} ROBOTOS=true npm run build
       - name: install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
 


### PR DESCRIPTION
# What's changed

Turn robots on for LHCI jobs

## Why?

SEO score is being capped at around ~60 in LHCI because we don't enabled the app to be crawled by default. We (@PatFawbertMills and I) think turning this on for the LHCI builds is OK because the CI builds will never be able to be crawled as the builds only exist for the duration of the CI job
