### PR TITLE
Feature/app 759 exact matches checkbox on homepage defaults to ticked

### DIFF
--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -115,6 +115,17 @@ const handleFilterDisplay = (
   if (!filterLabel) {
     return null;
   }
+
+  // Special handling for exact_match - toggle between true and false
+  if (key === "exact_match") {
+    const toggleValue = value === "true" ? "false" : "true";
+    return (
+      <Pill key={value} onClick={() => filterChange(QUERY_PARAMS[key], toggleValue)}>
+        {filterLabel}
+      </Pill>
+    );
+  }
+
   return (
     <Pill key={value} onClick={() => filterChange(QUERY_PARAMS[key], filterValue)}>
       {filterLabel}
@@ -139,6 +150,13 @@ const generatePills = (
 
     // Exclude the search query from pills as it displays in NavSearch instead
     if (key === "query_string") return;
+
+    // Special handling for exact_match - always show a pill since it's always present
+    if (key === "exact_match") {
+      const isExactMatch = value === "true";
+      const pillValue = isExactMatch ? "true" : "false";
+      return pills.push(handleFilterDisplay(filterChange, queryParams, key, pillValue, countries, regions, themeConfig, concepts));
+    }
 
     if (value) {
       if (key === "year_range")

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -117,6 +117,9 @@ const handleFilterDisplay = (
   }
 
   // Special handling for exact_match - toggle between true and false
+  // Without this, the exact_match pill will not be displayed if it is not present in the query string
+  // and the exact match param is removed from the query string, which is confusing now we
+  // have temporarily set exact match search as the default
   if (key === "exact_match") {
     const toggleValue = value === "true" ? "false" : "true";
     return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,13 +34,22 @@ const IndexPage = () => {
     });
   }, [updateCountries, regions, countries]);
 
+  // Set default exact match parameter if not present
+  useEffect(() => {
+    const exactMatchParam = router.query[QUERY_PARAMS.exact_match];
+    if (!exactMatchParam && router.isReady) {
+      const newQuery = { ...router.query, [QUERY_PARAMS.exact_match]: "true" };
+      router.replace({ query: newQuery }, undefined, { shallow: true });
+    }
+  }, [router, router.isReady]);
+
   return (
     <>
       <Homepage
         handleSearchInput={handleSearchInput}
         handleSearchChange={handleSearchChange}
         searchInput={(router.query[QUERY_PARAMS.query_string] as string) ?? ""}
-        exactMatch={router.query[QUERY_PARAMS.exact_match] === "true"}
+        exactMatch={router.query[QUERY_PARAMS.exact_match] === "true" || !router.query[QUERY_PARAMS.exact_match]}
       />
     </>
   );

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -185,6 +185,9 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({ theme,
     delete router.query[QUERY_PARAMS.continuation_tokens];
 
     // Special handling for exact_match - toggle between true and false
+    // Without this, the exact_match pill will not be displayed if it is not present in the query string
+    // and the exact match param is removed from the query string, which is confusing now we
+    // have temporarily set exact match search as the default
     if (type === QUERY_PARAMS.exact_match) {
       const currentValue = router.query[type];
       const newValue = currentValue === "true" ? "false" : "true";


### PR DESCRIPTION
# What's changed

- Exact matches checkbox on homepage defaults to checked (checked if exact_match is true or not present, false if exact_match explicitly set to false)
- Update router param for exact_match to true by default 
- Updated the AppliedFilter logic and make sure that we don't remove the router param for exact match so that we preserve the correct query string

## Why?

Semantic search is no longer the default

## Screenshots?

![image](https://github.com/user-attachments/assets/856d3d43-c900-42ed-9f84-376b31ee9392)
