### PR TITLE
Connect frontend litigation filters to vespa search

### DIFF
--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -39,7 +39,7 @@ type TFilterKeys = keyof typeof QUERY_PARAMS;
 const MAX_FILTER_CHARACTERS = 32;
 
 const getFilterDisplayValue = (key: TFilterKeys, value: string, themeConfig: TThemeConfig) => {
-  const filterDisplayLabel = themeConfig?.filters.find((f) => f.taxonomyKey === key).options.find((f) => f.slug === value);
+  const filterDisplayLabel = themeConfig?.filters.find((f) => f.taxonomyKey === key)?.options.find((f) => f.slug === value);
   return filterDisplayLabel ? filterDisplayLabel.label : value;
 };
 

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -64,7 +64,7 @@ const onConceptChange = (router: NextRouter, concept: TConcept) => {
   if (router.query.id) {
     query["id"] = router.query.id;
   }
-  let selectedConcepts = query[QUERY_PARAMS.concept_name] ? [query[QUERY_PARAMS.concept_name]].flat() : [];
+  let selectedConcepts = query[QUERY_PARAMS.concept_preferred_label] ? [query[QUERY_PARAMS.concept_preferred_label]].flat() : [];
 
   if (selectedConcepts.includes(concept.preferred_label)) {
     selectedConcepts = selectedConcepts.filter((c) => c !== concept.preferred_label);
@@ -72,7 +72,7 @@ const onConceptChange = (router: NextRouter, concept: TConcept) => {
     selectedConcepts = [...selectedConcepts, concept.preferred_label];
   }
 
-  query[QUERY_PARAMS.concept_name] = selectedConcepts;
+  query[QUERY_PARAMS.concept_preferred_label] = selectedConcepts;
 
   router.push({ query: query }, undefined, { shallow: true });
 };
@@ -163,7 +163,7 @@ export const FamilyConceptPicker = ({
                         <InputCheck
                           key={concept.wikibase_id + i}
                           label={firstCase(concept.preferred_label)}
-                          checked={isSelected(router.query[QUERY_PARAMS.concept_name], concept.preferred_label)}
+                          checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.preferred_label)}
                           onChange={() => {
                             onConceptChange(router, concept);
                           }}
@@ -183,7 +183,7 @@ export const FamilyConceptPicker = ({
                 <InputCheck
                   key={concept.wikibase_id}
                   label={firstCase(concept.preferred_label)}
-                  checked={isSelected(router.query[QUERY_PARAMS.concept_name], concept.preferred_label)}
+                  checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.preferred_label)}
                   onChange={() => {
                     onConceptChange(router, concept);
                   }}

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -28,4 +28,5 @@ export const QUERY_PARAMS = {
   // Pass through
   concept_id: "cfi",
   concept_name: "cfn",
+  concept_preferred_label: "cpl",
 };

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -95,6 +95,19 @@ export default function buildSearchQuery(
       : [{ name: "name", value: conceptFilters }];
   }
 
+  if (routerQuery[QUERY_PARAMS.concept_preferred_label]) {
+    const conceptPreferredLabelFilters = routerQuery[QUERY_PARAMS.concept_preferred_label];
+
+    Array.isArray(conceptPreferredLabelFilters)
+      ? conceptPreferredLabelFilters.map((name) => {
+          query.metadata.push({
+            name: "concept_preferred_label",
+            value: name,
+          });
+        })
+      : query.metadata.push({ name: "concept_preferred_label", value: conceptPreferredLabelFilters });
+  }
+
   const qCategory = (routerQuery[QUERY_PARAMS.category] as string) ?? "All";
   let category: string[];
   let corpusIds: string[] = [];

--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -101,11 +101,11 @@ export default function buildSearchQuery(
     Array.isArray(conceptPreferredLabelFilters)
       ? conceptPreferredLabelFilters.map((name) => {
           query.metadata.push({
-            name: "concept_preferred_label",
+            name: "family.concept_preferred_label",
             value: name,
           });
         })
-      : query.metadata.push({ name: "concept_preferred_label", value: conceptPreferredLabelFilters });
+      : query.metadata.push({ name: "family.concept_preferred_label", value: conceptPreferredLabelFilters });
   }
 
   const qCategory = (routerQuery[QUERY_PARAMS.category] as string) ?? "All";


### PR DESCRIPTION
# What's changed

Send litigation concept filters through to the vespa search query. 

We have followed the other formats of updating the metadata query param. 

The screenshot below is from the staging endpoint, currently our staging dataset is not as rich with all the available concepts (principle laws etc) so I use a concept label that I knew existed on these cases to test. 

## Why?

## Screenshots?
<img width="1323" height="671" alt="Screenshot 2025-07-10 at 10 30 59" src="https://github.com/user-attachments/assets/ca2f24e4-2ae4-4003-9b0e-dd7a52c6f74d" />
