### PR TITLE
CPR site: Unchecking exact match will perform semantic search

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,16 @@ const IndexPage = () => {
   };
 
   const handleSearchChange = (type: string, value: any) => {
-    router.query[type] = [value];
+    // Handle exact_match specially - only include when false
+    if (type === QUERY_PARAMS.exact_match) {
+      if (value === false) {
+        router.query[type] = "false";
+      } else {
+        delete router.query[type];
+      }
+    } else {
+      router.query[type] = [value];
+    }
     router.push({ query: router.query });
   };
 

--- a/src/utils/triggerNewSearch.ts
+++ b/src/utils/triggerNewSearch.ts
@@ -12,8 +12,9 @@ export const triggerNewSearch = (router: NextRouter, term: string, filter?: stri
   if (filter && filterValue && filter.length && filterValue.length) {
     newQuery[filter] = [filterValue.toLowerCase()];
   }
-  if (router.query[QUERY_PARAMS.exact_match] === "true") {
-    newQuery[QUERY_PARAMS.exact_match] = "true";
+  // Preserve exact_match parameter if it exists (both true and false)
+  if (router.query[QUERY_PARAMS.exact_match] !== undefined) {
+    newQuery[QUERY_PARAMS.exact_match] = router.query[QUERY_PARAMS.exact_match];
   }
   router.push({ pathname: "/search", query: { ...newQuery } });
 };

--- a/tests/cpr/cpr.spec.ts
+++ b/tests/cpr/cpr.spec.ts
@@ -338,10 +338,6 @@ test.describe("CPR Hero Search", () => {
   });
 
   test("should perform semantic search if exact match checkbox is not checked", async ({ page }) => {
-    // TODO: This test is currently failing because unchecking the exact match checkbox does not result in
-    // a semantic search. Re-enable as part of APP-898.
-    test.fail(); // Mark as expected to fail until APP-898 is resolved
-
     const searchInput = page.locator('[data-cy="search-input"]');
     const searchButton = page.locator('button[aria-label="Search"]');
     const exactMatchCheckbox = page.locator("#exact-match");
@@ -350,8 +346,17 @@ test.describe("CPR Hero Search", () => {
     const searchTerm = "climate policy";
     await searchInput.fill(searchTerm);
 
-    // Uncheck the exact match checkbox
-    await exactMatchCheckbox.uncheck();
+    // Uncheck only if currently checked
+    if (await exactMatchCheckbox.isChecked()) {
+      // Use click instead of uncheck to trigger the onChange handler properly
+      await exactMatchCheckbox.click();
+
+      // Wait a moment for the state to update
+      await page.waitForTimeout(100);
+
+      // Verify it's actually unchecked
+      await expect(exactMatchCheckbox).not.toBeChecked();
+    }
 
     // Click search button
     await searchButton.click();


### PR DESCRIPTION
# What's changed

- Unchecking the exact match checkbox on the CPR homepage and clicking search will make a semantic search happen instead of an exact match search
- The state of e=false persists when the user navigates to the search page
- The state of e=false persists when navigating BACK to the homepage --- NOTE: is this what we want?

## Why?

Realised the state of the uncheck wasn't actually bound to search, so it was always performing an exact match search even when unchecked

