### PR TITLE
Feature/app 887 revamp geography filter on search page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@tailwindcss/forms": "^0.5.0",
         "@tailwindcss/postcss": "^4.0.6",
         "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/gtag.js": "^0.0.14",
@@ -6489,6 +6490,26 @@
         "storybook": "^8.6.14"
       }
     },
+    "node_modules/@storybook/test/node_modules/@testing-library/jest-dom": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/@storybook/test/node_modules/@testing-library/user-event": {
       "version": "14.5.2",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
@@ -6502,6 +6523,12 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@storybook/test/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
     },
     "node_modules/@storybook/theming": {
       "version": "8.6.14",
@@ -6859,11 +6886,10 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
-      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@storybook/test": "^8.5.8",
     "@tailwindcss/forms": "^0.5.0",
     "@tailwindcss/postcss": "^4.0.6",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/components/blocks/FilterOptions.test.tsx
+++ b/src/components/blocks/FilterOptions.test.tsx
@@ -60,6 +60,6 @@ describe("FilterOptions", () => {
 
     render(<FilterOptions filter={testFilter} query={{}} handleFilterChange={() => {}} corpus_types={testTaxonomy} themeConfig={testThemeConfig} />);
 
-    expect(screen.getByText("Allowed topic")).toBeDefined();
+    expect(screen.getByText("Allowed topic")).toBeInTheDocument();
   });
 });

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -249,23 +249,22 @@ const SearchFilters = ({
         </InputListContainer>
       </Accordian>
 
-      <Accordian
-        title={getFilterLabel("Published jurisdiction", "country", query[QUERY_PARAMS.category], themeConfig)}
-        data-cy="countries"
-        overflowOverride
-        className="relative z-10"
-      >
-        <InputListContainer>
-          <TypeAhead
-            list={availableCountries}
-            selectedList={countryFilters}
-            keyField={"slug"}
-            keyFieldDisplay={"display_value"}
-            filterType={QUERY_PARAMS.country}
-            handleFilterChange={handleFilterChange}
-          />
-        </InputListContainer>
-      </Accordian>
+      <>
+        <button
+          className="items-center justify-between cursor-pointer group flex"
+          onClick={() => setCurrentSlideOut(currentSlideOut === "geographies" ? "" : "geographies")}
+          {...{ [SLIDE_OUT_DATA_KEY]: "geographies" }}
+        >
+          <Heading>Geography</Heading>
+          <span
+            className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+              currentSlideOut === "geographies" ? "transform rotate-180" : ""
+            }`}
+          >
+            <ChevronRight />
+          </span>
+        </button>
+      </>
 
       <Accordian
         title={getFilterLabel("Date", "date", query[QUERY_PARAMS.category], themeConfig)}

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -11,17 +11,14 @@ import { FilterOptions } from "@/components/blocks/FilterOptions";
 import { AppliedFilters } from "@/components/filters/AppliedFilters";
 import { DateRange } from "@/components/filters/DateRange";
 import { InputListContainer } from "@/components/filters/InputListContainer";
-import { InputCheck } from "@/components/forms/Checkbox";
 import { InputRadio } from "@/components/forms/Radio";
-import { TypeAhead } from "@/components/forms/TypeAhead";
 import { Info } from "@/components/molecules/info/Info";
 import { SLIDE_OUT_DATA_KEY } from "@/constants/dataAttributes";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { currentYear, minYear } from "@/constants/timedate";
 import { SlideOutContext } from "@/context/SlideOutContext";
-import { getCountriesFromRegions } from "@/helpers/getCountriesFromRegions";
 import useGetThemeConfig from "@/hooks/useThemeConfig";
-import { TConcept, TCorpusTypeDictionary, TFeatureFlags, TGeography, TSearchCriteria, TThemeConfigOption } from "@/types";
+import { TConcept, TCorpusTypeDictionary, TFeatureFlags, TSearchCriteria, TThemeConfigOption } from "@/types";
 import { canDisplayFilter } from "@/utils/canDisplayFilter";
 import { isKnowledgeGraphEnabled } from "@/utils/features";
 import { getFilterLabel } from "@/utils/getFilterLabel";
@@ -41,14 +38,11 @@ const isCategoryChecked = (selectedCategory: string | undefined, themeConfigCate
 interface IProps {
   searchCriteria: TSearchCriteria;
   query: ParsedUrlQuery;
-  regions: TGeography[];
-  countries: TGeography[];
   corpus_types: TCorpusTypeDictionary;
   conceptsData?: TConcept[];
   familyConceptsData?: TConcept[];
   handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
   handleYearChange(values: string[], reset?: boolean): void;
-  handleRegionChange(region: string): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;
   featureFlags: TFeatureFlags;
@@ -57,14 +51,11 @@ interface IProps {
 const SearchFilters = ({
   searchCriteria,
   query,
-  regions,
-  countries,
   corpus_types,
   conceptsData,
   familyConceptsData,
   handleFilterChange,
   handleYearChange,
-  handleRegionChange,
   handleClearSearch,
   handleDocumentCategoryClick,
   featureFlags,
@@ -73,22 +64,7 @@ const SearchFilters = ({
   const [showClear, setShowClear] = useState(false);
   const { currentSlideOut, setCurrentSlideOut } = useContext(SlideOutContext);
 
-  const {
-    keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
-  } = searchCriteria;
-
   const thisYear = currentYear();
-
-  // memoize the filtered countries
-  const availableCountries = useMemo(() => {
-    return regionFilters.length > 0
-      ? getCountriesFromRegions({
-          regions,
-          countries,
-          selectedRegions: regionFilters,
-        })
-      : countries;
-  }, [regionFilters, regions, countries]);
 
   // Show clear button if there are filters applied
   useEffect(() => {
@@ -228,26 +204,6 @@ const SearchFilters = ({
             </Accordian>
           );
         })}
-
-      <Accordian
-        title={getFilterLabel("Region", "region", query[QUERY_PARAMS.category], themeConfig)}
-        data-cy="regions"
-        startOpen={!!query[QUERY_PARAMS.region]}
-      >
-        <InputListContainer>
-          {regions.map((region) => (
-            <InputCheck
-              key={region.slug}
-              label={region.display_value}
-              checked={regionFilters && regionFilters.includes(region.slug)}
-              onChange={() => {
-                handleRegionChange(region.slug);
-              }}
-              name={`region-${region.slug}`}
-            />
-          ))}
-        </InputListContainer>
-      </Accordian>
 
       <>
         <button

--- a/src/components/blocks/SearchFilters.tsx
+++ b/src/components/blocks/SearchFilters.tsx
@@ -1,7 +1,7 @@
 import { ParsedUrlQuery } from "querystring";
 
 import { ChevronRight } from "lucide-react";
-import { useEffect, useState, useMemo, useContext } from "react";
+import { useEffect, useState, useContext } from "react";
 
 import Loader from "@/components/Loader";
 import { Accordian } from "@/components/accordian/Accordian";

--- a/src/context/EnvConfig.test.tsx
+++ b/src/context/EnvConfig.test.tsx
@@ -12,7 +12,7 @@ test("should not error when component does not use useEnvConfig nor uses withEnv
   const WithNoUseEnvConfig = <App router={mockRouter} Component={ComponentWithNoEnvConfig} pageProps={{}} theme={""} adobeApiKey={""} />;
 
   const rendered = render(WithNoUseEnvConfig);
-  expect(rendered.getByText("Hello testing library")).toBeDefined();
+  expect(rendered.getByText("Hello testing library")).toBeInTheDocument();
 });
 
 test("should error when component uses useEnvConfig without using withEnvConfig", async () => {
@@ -26,7 +26,7 @@ test("should error when component uses useEnvConfig without using withEnvConfig"
   const WithUseEnvConfig = <App router={mockRouter} Component={ComponentWithUseEnvConfig} pageProps={{}} theme={""} adobeApiKey={""} />;
 
   const rendered = render(WithUseEnvConfig);
-  expect(rendered.getByText("Sorry, the app has encountered an error")).toBeDefined();
+  expect(rendered.getByText("Sorry, the app has encountered an error")).toBeInTheDocument();
   expect(consoleSpy).toHaveBeenCalled();
 
   consoleSpy.mockRestore();
@@ -50,5 +50,5 @@ test("should not error when component uses useEnvConfig with using withEnvConfig
   const WithNoNoEnvConfig = <App router={mockRouter} Component={ComponentWithUseEnvConfig} pageProps={pageProps.props} theme={""} adobeApiKey={""} />;
 
   const rendered = render(WithNoNoEnvConfig);
-  expect(rendered.getByText("Hello testing library my_var")).toBeDefined();
+  expect(rendered.getByText("Hello testing library my_var")).toBeInTheDocument();
 });

--- a/src/context/SlideOutContext.ts
+++ b/src/context/SlideOutContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-export type TSlideOutContent = "concepts" | "familyConcepts" | "";
+export type TSlideOutContent = "concepts" | "familyConcepts" | "geographies" | "";
 
 interface IProps {
   currentSlideOut: TSlideOutContent;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -135,6 +135,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     keyword_filters: { countries: countryFilters = [], regions: regionFilters = [] },
   } = searchQuery;
 
+  const alphabetisedCountries = countries.sort((c1, c2) => c1.display_value.localeCompare(c2.display_value));
+
   const availableCountries = useMemo(() => {
     return regionFilters.length > 0
       ? getCountriesFromRegions({
@@ -510,14 +512,17 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                         className="relative z-10"
                       >
                         <InputListContainer>
-                          <TypeAhead
-                            list={availableCountries}
-                            selectedList={countryFilters}
-                            keyField={"slug"}
-                            keyFieldDisplay={"display_value"}
-                            filterType={QUERY_PARAMS.country}
-                            handleFilterChange={handleFilterChange}
-                          />
+                          {alphabetisedCountries.map((country) => (
+                            <InputCheck
+                              key={country.slug}
+                              label={country.display_value}
+                              checked={countryFilters && countryFilters.includes(country.slug)}
+                              onChange={() => {
+                                handleFilterChange(QUERY_PARAMS["country"], country.slug);
+                              }}
+                              name={`country-${country.slug}`}
+                            />
+                          ))}
                         </InputListContainer>
                       </Accordian>
                     </div>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -508,8 +508,8 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                       <Accordian
                         title={getFilterLabel("Published jurisdiction", "country", router.query[QUERY_PARAMS.category], themeConfig)}
                         data-cy="countries"
-                        overflowOverride
                         className="relative z-10"
+                        showFade={"true"}
                       >
                         <InputListContainer>
                           {alphabetisedCountries.map((country) => (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -20,6 +20,7 @@ import Drawer from "@/components/drawer/Drawer";
 import { FamilyMatchesDrawer } from "@/components/drawer/FamilyMatchesDrawer";
 import { InputListContainer } from "@/components/filters/InputListContainer";
 import { SearchSettings } from "@/components/filters/SearchSettings";
+import { InputCheck } from "@/components/forms/Checkbox";
 import { TypeAhead } from "@/components/forms/TypeAhead";
 import Layout from "@/components/layouts/Main";
 import { DownloadCsvPopup } from "@/components/modals/DownloadCsv";
@@ -462,14 +463,11 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                     <SearchFilters
                       searchCriteria={searchQuery}
                       query={router.query}
-                      regions={regions}
-                      countries={countries}
                       corpus_types={corpus_types}
                       conceptsData={conceptsData}
                       familyConceptsData={familyConceptsData}
                       handleFilterChange={handleFilterChange}
                       handleYearChange={handleYearChange}
-                      handleRegionChange={handleRegionChange}
                       handleClearSearch={handleClearSearch}
                       handleDocumentCategoryClick={handleDocumentCategoryClick}
                       featureFlags={featureFlags}
@@ -500,6 +498,26 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                           filterType={QUERY_PARAMS.country}
                           handleFilterChange={handleFilterChange}
                         />
+                      </InputListContainer>
+                    </Accordian>
+
+                    <Accordian
+                      title={getFilterLabel("Region", "region", router.query[QUERY_PARAMS.category], themeConfig)}
+                      data-cy="regions"
+                      startOpen={!!router.query[QUERY_PARAMS.region]}
+                    >
+                      <InputListContainer>
+                        {regions.map((region) => (
+                          <InputCheck
+                            key={region.slug}
+                            label={region.display_value}
+                            checked={regionFilters && regionFilters.includes(region.slug)}
+                            onChange={() => {
+                              handleRegionChange(region.slug);
+                            }}
+                            name={`region-${region.slug}`}
+                          />
+                        ))}
                       </InputListContainer>
                     </Accordian>
                   </SlideOut>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -483,43 +483,44 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                     </SlideOut>
                   )}
                   <SlideOut showCloseButton={false}>
-                    <Accordian
-                      title={getFilterLabel("Published jurisdiction", "country", router.query[QUERY_PARAMS.category], themeConfig)}
-                      data-cy="countries"
-                      overflowOverride
-                      className="relative z-10"
-                    >
-                      <InputListContainer>
-                        <TypeAhead
-                          list={availableCountries}
-                          selectedList={countryFilters}
-                          keyField={"slug"}
-                          keyFieldDisplay={"display_value"}
-                          filterType={QUERY_PARAMS.country}
-                          handleFilterChange={handleFilterChange}
-                        />
-                      </InputListContainer>
-                    </Accordian>
-
-                    <Accordian
-                      title={getFilterLabel("Region", "region", router.query[QUERY_PARAMS.category], themeConfig)}
-                      data-cy="regions"
-                      startOpen={!!router.query[QUERY_PARAMS.region]}
-                    >
-                      <InputListContainer>
-                        {regions.map((region) => (
-                          <InputCheck
-                            key={region.slug}
-                            label={region.display_value}
-                            checked={regionFilters && regionFilters.includes(region.slug)}
-                            onChange={() => {
-                              handleRegionChange(region.slug);
-                            }}
-                            name={`region-${region.slug}`}
+                    <div className="text-sm text-text-secondary flex flex-col gap-5">
+                      <Accordian
+                        title={getFilterLabel("Region", "region", router.query[QUERY_PARAMS.category], themeConfig)}
+                        data-cy="regions"
+                        startOpen={!!router.query[QUERY_PARAMS.region]}
+                      >
+                        <InputListContainer>
+                          {regions.map((region) => (
+                            <InputCheck
+                              key={region.slug}
+                              label={region.display_value}
+                              checked={regionFilters && regionFilters.includes(region.slug)}
+                              onChange={() => {
+                                handleRegionChange(region.slug);
+                              }}
+                              name={`region-${region.slug}`}
+                            />
+                          ))}
+                        </InputListContainer>
+                      </Accordian>
+                      <Accordian
+                        title={getFilterLabel("Published jurisdiction", "country", router.query[QUERY_PARAMS.category], themeConfig)}
+                        data-cy="countries"
+                        overflowOverride
+                        className="relative z-10"
+                      >
+                        <InputListContainer>
+                          <TypeAhead
+                            list={availableCountries}
+                            selectedList={countryFilters}
+                            keyField={"slug"}
+                            keyFieldDisplay={"display_value"}
+                            filterType={QUERY_PARAMS.country}
+                            handleFilterChange={handleFilterChange}
                           />
-                        ))}
-                      </InputListContainer>
-                    </Accordian>
+                        </InputListContainer>
+                      </Accordian>
+                    </div>
                   </SlideOut>
 
                   <div className="absolute z-50 bottom-0 left-0 w-full flex pb-[100px] bg-white md:hidden">

--- a/tests/core/pages/geographies.test.tsx
+++ b/tests/core/pages/geographies.test.tsx
@@ -34,8 +34,8 @@ describe("CountryPage", () => {
 
     // @ts-ignore
     renderWithAppContext(CountryPage, usa_props);
-    expect(screen.getByRole("heading", { name: "United States of America", level: 1 })).toBeDefined();
-    expect(screen.getByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).toBeDefined();
+    expect(screen.getByRole("heading", { name: "United States of America", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).toBeInTheDocument();
 
     const link = screen.getByRole("link", { name: "Sabin Center's Climate Backtracker" });
     expect(link.getAttribute("href")).toBe("https://climate.law.columbia.edu/content/climate-backtracker");
@@ -60,11 +60,11 @@ describe("CountryPage", () => {
 
     // @ts-ignore
     renderWithAppContext(CountryPage, props);
-    expect(screen.getByRole("heading", { name: "Brazil", level: 1 })).toBeDefined();
-    expect(screen.queryByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).toBeNull();
+    expect(screen.getByRole("heading", { name: "Brazil", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).not.toBeInTheDocument();
 
     const link = screen.queryByRole("link", { name: "Sabin Center's Climate Backtracker" });
-    expect(link).toBeNull();
+    expect(link).not.toBeInTheDocument();
   });
 
   it("does not display alert with Sabin tracker link on the mcf theme", async () => {
@@ -86,10 +86,10 @@ describe("CountryPage", () => {
 
     // @ts-ignore
     renderWithAppContext(CountryPage, usa_props);
-    expect(screen.getByRole("heading", { name: "United States of America", level: 1 })).toBeDefined();
-    expect(screen.queryByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).toBeNull();
+    expect(screen.getByRole("heading", { name: "United States of America", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByText(/To see developments in the Trump-Vance administration's climate rollback, visit the/)).not.toBeInTheDocument();
 
     const link = screen.queryByRole("link", { name: "Sabin Center's Climate Backtracker" });
-    expect(link).toBeNull();
+    expect(link).not.toBeInTheDocument();
   });
 });

--- a/tests/core/pages/search.test.tsx
+++ b/tests/core/pages/search.test.tsx
@@ -28,11 +28,18 @@ describe("SearchPage", async () => {
 
     expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeDefined();
 
+    const geographyFilterControl = await screen.findByText(/Geography/);
+
+    expect(geographyFilterControl).toBeDefined();
+    // We have to wrap our user interactions in act() here due to some async updates that happen in the component,
+    // like animations that were causing warnings in the console.
+    await act(async () => {
+      await userEvent.click(geographyFilterControl);
+    });
+
     const countryFilterControl = await screen.findByText(/Published jurisdiction/i);
 
     expect(countryFilterControl).toBeDefined();
-    // We have to wrap our user interactions in act() here due to some async updates that happen in the component,
-    // like animations that were causing warnings in the console.
     await act(async () => {
       await userEvent.click(countryFilterControl);
     });

--- a/tests/core/pages/search.test.tsx
+++ b/tests/core/pages/search.test.tsx
@@ -26,11 +26,11 @@ describe("SearchPage", async () => {
     // @ts-ignore
     renderWithAppContext(Search, search_props);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeDefined();
+    expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeInTheDocument();
 
     const geographyFilterControl = await screen.findByText(/Geography/);
 
-    expect(geographyFilterControl).toBeDefined();
+    expect(geographyFilterControl).toBeInTheDocument();
     // We have to wrap our user interactions in act() here due to some async updates that happen in the component,
     // like animations that were causing warnings in the console.
     await act(async () => {
@@ -39,7 +39,7 @@ describe("SearchPage", async () => {
 
     const countryFilterControl = await screen.findByText(/Published jurisdiction/i);
 
-    expect(countryFilterControl).toBeDefined();
+    expect(countryFilterControl).toBeInTheDocument();
     await act(async () => {
       await userEvent.click(countryFilterControl);
     });
@@ -62,9 +62,9 @@ describe("SearchPage", async () => {
       await userEvent.click(countryOptions[0]);
     });
 
-    expect(await screen.findByText("Results")).toBeDefined();
-    expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeDefined();
-    expect(screen.queryByText("Argentina Biennial Transparency Report. BTR1")).toBeNull();
+    expect(await screen.findByText("Results")).toBeInTheDocument();
+    expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeInTheDocument();
+    expect(screen.queryByText("Argentina Biennial Transparency Report. BTR1")).not.toBeInTheDocument();
   });
 
   it("filters search results by region", async () => {
@@ -88,11 +88,11 @@ describe("SearchPage", async () => {
     // @ts-ignore
     renderWithAppContext(Search, search_props);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeDefined();
+    expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeInTheDocument();
 
     const geographyFilterControl = await screen.findByText(/Geography/);
 
-    expect(geographyFilterControl).toBeDefined();
+    expect(geographyFilterControl).toBeInTheDocument();
     // We have to wrap our user interactions in act() here due to some async updates that happen in the component,
     // like animations that were causing warnings in the console.
     await act(async () => {
@@ -101,7 +101,7 @@ describe("SearchPage", async () => {
 
     const regionFilterControl = await screen.findByText(/Region/i);
 
-    expect(regionFilterControl).toBeDefined();
+    expect(regionFilterControl).toBeInTheDocument();
     await act(async () => {
       await userEvent.click(regionFilterControl);
     });
@@ -110,13 +110,13 @@ describe("SearchPage", async () => {
       await userEvent.click(await screen.findByRole("checkbox", { name: "Latin America & Caribbean" }));
     });
 
-    expect(await screen.findByText("Results")).toBeDefined();
-    expect(screen.getByText("Argentina Biennial Transparency Report. BTR1")).toBeDefined();
-    expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeDefined();
+    expect(await screen.findByText("Results")).toBeInTheDocument();
+    expect(screen.getByText("Argentina Biennial Transparency Report. BTR1")).toBeInTheDocument();
+    expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeInTheDocument();
     expect(
       screen.queryByText(
         "Technical analysis of the first biennial update report of Afghanistan submitted on 13 October 2019. Summary report by the team of technical experts"
       )
-    ).toBeNull();
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/core/pages/search.test.tsx
+++ b/tests/core/pages/search.test.tsx
@@ -90,6 +90,15 @@ describe("SearchPage", async () => {
 
     expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeDefined();
 
+    const geographyFilterControl = await screen.findByText(/Geography/);
+
+    expect(geographyFilterControl).toBeDefined();
+    // We have to wrap our user interactions in act() here due to some async updates that happen in the component,
+    // like animations that were causing warnings in the console.
+    await act(async () => {
+      await userEvent.click(geographyFilterControl);
+    });
+
     const regionFilterControl = await screen.findByText(/Region/i);
 
     expect(regionFilterControl).toBeDefined();

--- a/tests/core/pages/search.test.tsx
+++ b/tests/core/pages/search.test.tsx
@@ -44,23 +44,12 @@ describe("SearchPage", async () => {
       await userEvent.click(countryFilterControl);
     });
 
-    const countryInput = screen.getByRole("textbox", {
-      name: "Search for a jurisdiction",
-    });
-
-    expect(countryInput).toBeInTheDocument();
-
     await act(async () => {
-      await userEvent.type(countryInput, "Belize");
+      await userEvent.click(await screen.findByRole("checkbox", { name: "Belize" }));
     });
-    expect(countryInput).toHaveValue("Belize");
 
-    const countryOptions = within(screen.getByTestId("countries")).getAllByRole("listitem");
-    expect(countryOptions).toHaveLength(1);
-
-    await act(async () => {
-      await userEvent.click(countryOptions[0]);
-    });
+    const countryOptions = within(screen.getByTestId("countries")).getAllByRole("checkbox");
+    expect(countryOptions).toHaveLength(3);
 
     expect(await screen.findByText("Results")).toBeInTheDocument();
     expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeInTheDocument();

--- a/tests/core/pages/search.test.tsx
+++ b/tests/core/pages/search.test.tsx
@@ -66,4 +66,48 @@ describe("SearchPage", async () => {
     expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeDefined();
     expect(screen.queryByText("Argentina Biennial Transparency Report. BTR1")).toBeNull();
   });
+
+  it("filters search results by region", async () => {
+    const search_props = {
+      envConfig: {
+        BACKEND_API_URL: process.env.BACKEND_API_URL,
+        CONCEPTS_API_URL: process.env.CONCEPTS_API_URL,
+      },
+      theme: "cpr",
+      themeConfig: {
+        documentCategories: ["All"],
+        features: { knowledgeGraph: false, searchFamilySummary: false },
+        metadata: [
+          {
+            key: "search",
+            title: "Law and Policy Search",
+          },
+        ],
+      },
+    };
+    // @ts-ignore
+    renderWithAppContext(Search, search_props);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Search results" })).toBeDefined();
+
+    const regionFilterControl = await screen.findByText(/Region/i);
+
+    expect(regionFilterControl).toBeDefined();
+    await act(async () => {
+      await userEvent.click(regionFilterControl);
+    });
+
+    await act(async () => {
+      await userEvent.click(await screen.findByRole("checkbox", { name: "Latin America & Caribbean" }));
+    });
+
+    expect(await screen.findByText("Results")).toBeDefined();
+    expect(screen.getByText("Argentina Biennial Transparency Report. BTR1")).toBeDefined();
+    expect(screen.getByText("Belize Nationally Determined Contribution. NDC3 (Update)")).toBeDefined();
+    expect(
+      screen.queryByText(
+        "Technical analysis of the first biennial update report of Afghanistan submitted on 13 October 2019. Summary report by the team of technical experts"
+      )
+    ).toBeNull();
+  });
 });

--- a/tests/mocks/api/configHandlers.ts
+++ b/tests/mocks/api/configHandlers.ts
@@ -43,10 +43,35 @@ export const configHandlers = [
       geographies: [
         {
           node: {
+            id: 1,
             display_value: "South Asia",
             slug: "south-asia",
-            type: "region",
             value: "South Asia",
+            type: "World Bank Region",
+            parent_id: null,
+          },
+          children: [
+            {
+              node: {
+                id: 2,
+                display_value: "Afghanistan",
+                slug: "afghanistan",
+                value: "AFG",
+                type: "ISO-3166",
+                parent_id: 1,
+              },
+              children: [],
+            },
+          ],
+        },
+        {
+          node: {
+            id: 138,
+            display_value: "Latin America & Caribbean",
+            slug: "latin-america-caribbean",
+            value: "Latin America & Caribbean",
+            type: "World Bank Region",
+            parent_id: null,
           },
           children: [
             {
@@ -55,6 +80,17 @@ export const configHandlers = [
                 slug: "BLZ",
                 type: "country",
                 value: "Belize",
+              },
+              children: [],
+            },
+            {
+              node: {
+                id: 140,
+                display_value: "Argentina",
+                slug: "argentina",
+                value: "ARG",
+                type: "ISO-3166",
+                parent_id: 138,
               },
               children: [],
             },

--- a/tests/mocks/api/geographiesHandlers.ts
+++ b/tests/mocks/api/geographiesHandlers.ts
@@ -4,12 +4,28 @@ export const geographiesHandlers = [
   http.get("*/geographies/", () => {
     return HttpResponse.json([
       {
+        alpha_2: "AR",
+        alpha_3: "ARG",
+        name: "Argentina",
+        official_name: "Argentine Republic",
+        numeric: "032",
+        flag: "🇦🇷",
+      },
+      {
         alpha_3: "BLZ",
         display_value: "Belize",
         name: "Belize",
         slug: "belize",
         type: "country",
         value: "Belize",
+      },
+      {
+        alpha_2: "CU",
+        alpha_3: "CUB",
+        name: "Cuba",
+        official_name: "Republic of Cuba",
+        numeric: "192",
+        flag: "🇨🇺",
       },
     ]);
   }),

--- a/themes/cclw/components/Instructions.test.tsx
+++ b/themes/cclw/components/Instructions.test.tsx
@@ -6,8 +6,8 @@ import { renderWithAppContext } from "@/mocks/renderWithAppContext";
 describe("Instructions: ", () => {
   it("displays the correct aggregated statistics for the number of documents available per category", async () => {
     renderWithAppContext(Instructions);
-    expect(await screen.findByRole("link", { name: "2 laws" })).toBeDefined();
-    expect(screen.getByRole("link", { name: "3 policies" })).toBeDefined();
-    expect(screen.getByRole("link", { name: "4 UNFCCC submissions" })).toBeDefined();
+    expect(await screen.findByRole("link", { name: "2 laws" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "3 policies" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "4 UNFCCC submissions" })).toBeInTheDocument();
   });
 });

--- a/themes/mcf/pages/homepage.test.tsx
+++ b/themes/mcf/pages/homepage.test.tsx
@@ -13,6 +13,6 @@ describe("Landing Page: ", () => {
 
     renderWithAppContext(LandingPage, landingPageProps);
 
-    expect(screen.getByText("Multilateral Climate Funds")).toBeDefined();
+    expect(screen.getByText("Multilateral Climate Funds")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# What's changed
- add new button "Geography" to the filters on the search page which opens a slideout to the right
- move existing existing geography filters ("Region" and "Published Jurisdiction") to the new slideout
- change the country filter to be a full alphabetised list of multiselect checkboxes instead of a TypeAhead component

- drive-by: install @testing-library/jest-dom to get better test matchers and update all relevant tests to assert on items being actually rendered and visible in the DOM as the vitest matchers we were using before were not doing that


## Why?

## Screenshots?
<img width="1434" height="640" alt="Screenshot 2025-07-10 at 12 57 18" src="https://github.com/user-attachments/assets/f48155ba-0898-488a-89de-550c8007492d" />
