### PR TITLE
APP-896: Add a Litigation app config feature

### DIFF
--- a/src/components/blocks/FilterOptions.test.tsx
+++ b/src/components/blocks/FilterOptions.test.tsx
@@ -23,9 +23,10 @@ describe("FilterOptions", () => {
       documentCategories: [],
       defaultDocumentCategory: "All",
       features: {
-        knowledgeGraph: false,
-        searchFamilySummary: true,
         familyConceptsSearch: false,
+        knowledgeGraph: false,
+        litigation: false,
+        searchFamilySummary: true,
       },
     };
 

--- a/src/pages/collection/[id].tsx
+++ b/src/pages/collection/[id].tsx
@@ -12,16 +12,19 @@ import { withEnvConfig } from "@/context/EnvConfig";
 import { TCollection, TTheme } from "@/types";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { isLitigationEnabled } from "@/utils/features";
+import { readConfigFile } from "@/utils/readConfigFile";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
   const featureFlags = getFeatureFlags(context.req.cookies);
 
   const theme = process.env.THEME;
+  const themeConfig = await readConfigFile(theme);
+
   const id = context.params.id;
   const client = new ApiClient(process.env.BACKEND_API_URL);
 
-  if (!isLitigationEnabled(featureFlags)) {
+  if (!isLitigationEnabled(featureFlags, themeConfig)) {
     return { notFound: true };
   }
 

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -2,6 +2,6 @@ export const featureFlagKeys = ["concepts-v1", "litigation", "unfccc-filters"] a
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
 
-export const configFeatureKeys = ["knowledgeGraph", "searchFamilySummary", "familyConceptsSearch"] as const;
+export const configFeatureKeys = ["familyConceptsSearch", "knowledgeGraph", "litigation", "searchFamilySummary"] as const;
 export type TConfigFeature = (typeof configFeatureKeys)[number];
 export type TConfigFeatures = Record<TConfigFeature, boolean>;

--- a/src/utils/buildSearchQuery.test.ts
+++ b/src/utils/buildSearchQuery.test.ts
@@ -29,7 +29,12 @@ describe("buildSearchQuery: ", () => {
       metadata: [],
       documentCategories: ["All"],
       defaultDocumentCategory: "All",
-      features: { knowledgeGraph: true, searchFamilySummary: true, familyConceptsSearch: false },
+      features: {
+        familyConceptsSearch: false,
+        knowledgeGraph: true,
+        litigation: false,
+        searchFamilySummary: true,
+      },
     };
 
     const searchQueryWithNoCategory = buildSearchQuery({}, themeConfig);
@@ -52,7 +57,12 @@ describe("buildSearchQuery: ", () => {
       metadata: [],
       documentCategories: [],
       defaultDocumentCategory: "All",
-      features: { knowledgeGraph: true, searchFamilySummary: true, familyConceptsSearch: false },
+      features: {
+        familyConceptsSearch: false,
+        knowledgeGraph: true,
+        litigation: false,
+        searchFamilySummary: true,
+      },
     };
 
     const searchQuery = buildSearchQuery({}, themeConfig);

--- a/src/utils/buildSearchQueryMetadata.test.ts
+++ b/src/utils/buildSearchQueryMetadata.test.ts
@@ -19,9 +19,10 @@ const testThemeConfig: TThemeConfig = {
   defaultDocumentCategory: "All",
   metadata: [],
   features: {
-    knowledgeGraph: false,
-    searchFamilySummary: true,
     familyConceptsSearch: false,
+    knowledgeGraph: false,
+    litigation: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/src/utils/canDisplayFilter.test.ts
+++ b/src/utils/canDisplayFilter.test.ts
@@ -52,9 +52,10 @@ const testThemeConfig: TThemeConfig = {
   defaultDocumentCategory: "All",
   metadata: [],
   features: {
-    knowledgeGraph: false,
-    searchFamilySummary: true,
     familyConceptsSearch: false,
+    knowledgeGraph: false,
+    litigation: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -20,8 +20,9 @@ export const isKnowledgeGraphEnabled = (featureFlags: TFeatureFlags, themeConfig
     featureFlag: featureFlags["concepts-v1"],
   });
 
-export const isLitigationEnabled = (featureFlags: TFeatureFlags) =>
+export const isLitigationEnabled = (featureFlags: TFeatureFlags, themeConfig: TThemeConfig) =>
   isFeatureEnabled({
+    configFeature: themeConfig.features.litigation,
     featureFlag: featureFlags["litigation"],
   });
 

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -70,9 +70,10 @@ const config: TThemeConfig = {
   documentCategories: ["All", "Laws", "Policies", "UNFCCC Submissions", "Litigation", "Climate Finance Projects", "Offshore Wind Reports"],
   defaultDocumentCategory: "All",
   features: {
-    knowledgeGraph: true,
-    searchFamilySummary: true,
     familyConceptsSearch: true,
+    knowledgeGraph: true,
+    litigation: true,
+    searchFamilySummary: true,
   },
 };
 

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -163,9 +163,10 @@ const config: TThemeConfig = {
   documentCategories: ["All", "UNFCCC Submissions", "Laws", "Policies", "Litigation"],
   defaultDocumentCategory: "All",
   features: {
-    knowledgeGraph: true,
-    searchFamilySummary: true,
     familyConceptsSearch: false,
+    knowledgeGraph: true,
+    litigation: false,
+    searchFamilySummary: true,
   },
 };
 

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -351,9 +351,10 @@ const config: TThemeConfig = {
   documentCategories: ["All", "UNFCCC Submissions", "Laws", "Policies", "Climate Finance Projects", "Offshore Wind Reports", "Litigation"],
   defaultDocumentCategory: "Laws",
   features: {
-    knowledgeGraph: true,
-    searchFamilySummary: false,
     familyConceptsSearch: false,
+    knowledgeGraph: true,
+    litigation: false,
+    searchFamilySummary: false,
   },
 };
 

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -134,9 +134,10 @@ const config: TThemeConfig = {
   documentCategories: ["All"],
   defaultDocumentCategory: "All",
   features: {
-    knowledgeGraph: false,
-    searchFamilySummary: true,
     familyConceptsSearch: false,
+    knowledgeGraph: false,
+    litigation: false,
+    searchFamilySummary: true,
   },
 };
 


### PR DESCRIPTION
# What's changed

- Adds a new app config feature: `litigation`.
- Updates `isLitigationEnabled` function to require a config argument.
  - Updated existing references.

## Why?

- Prepares for having litigation UI changes behind a feature flag, but on by default on CCC.
- Satisfies [APP-896](https://linear.app/climate-policy-radar/issue/APP-896/add-a-litigation-app-config-feature)
