### PR TITLE
APP-910: Documents Block: Component for family page

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 
-import { TFamilyPage } from "@/types";
+import { FAMILY_PAGE_STUB } from "@/stubs/familyPageStub";
 
 import { DocumentsBlock } from "./DocumentsBlock";
 
@@ -15,8 +15,8 @@ export default meta;
 
 export const Default: TStory = {
   args: {
-    documents: [],
-    family: {} as TFamilyPage,
+    countries: [{ id: 31, display_value: "Hungary", slug: "hungary", value: "HUN", type: "ISO-3166", parent_id: 10 }],
+    family: FAMILY_PAGE_STUB,
     status: "success",
   },
 };

--- a/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import { TFamilyPage } from "@/types";
+
+import { DocumentsBlock } from "./DocumentsBlock";
+
+const meta = {
+  title: "Blocks/DocumentsBlock",
+  component: DocumentsBlock,
+  argTypes: {},
+} satisfies Meta<typeof DocumentsBlock>;
+type TStory = StoryObj<typeof DocumentsBlock>;
+
+export default meta;
+
+export const Default: TStory = {
+  args: {
+    documents: [],
+    family: {} as TFamilyPage,
+    status: "success",
+  },
+};

--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -3,14 +3,14 @@ import { useMemo, useState } from "react";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Card } from "@/components/atoms/card/Card";
+import { DocumentCard } from "@/components/molecules/documentCard/DocumentCard";
 import { Section } from "@/components/molecules/section/Section";
 import { Toggle } from "@/components/molecules/toggleGroup/Toggle";
 import { ToggleGroup } from "@/components/molecules/toggleGroup/ToggleGroup";
 import { InteractiveTable, IInteractiveTableColumn, IInteractiveTableRow } from "@/components/organisms/interactiveTable/InteractiveTable";
 import { getCategoryName } from "@/helpers/getCategoryName";
 import { getCountryName } from "@/helpers/getCountryFields";
-import useConfig from "@/hooks/useConfig";
-import { TDocumentPage, TFamily, TFamilyPage, TLoadingStatus } from "@/types";
+import { TFamilyPage, TGeography, TLoadingStatus } from "@/types";
 import { convertDate } from "@/utils/timedate";
 
 type TTableColumn = "year" | "geography" | "type" | "document";
@@ -22,15 +22,19 @@ const TABLE_COLUMNS: IInteractiveTableColumn<TTableColumn>[] = [
 ];
 
 interface IProps {
-  documents: (TDocumentPage & { matches?: number })[];
+  countries: TGeography[];
   family: TFamilyPage;
   status: TLoadingStatus;
 }
 
-export const DocumentsBlock = ({ documents, family }: IProps) => {
-  const configQuery = useConfig();
-  const { data: { countries = [] } = {} } = configQuery;
+/**
+ * TODO LIST
+ * - Better matches handling (including loading state)
+ */
+
+export const DocumentsBlock = ({ countries, family }: IProps) => {
   const [view, setView] = useState("card");
+  const { documents } = family;
 
   const onToggleChange = (toggleValue: string[]) => {
     setView(toggleValue[0]);
@@ -50,7 +54,11 @@ export const DocumentsBlock = ({ documents, family }: IProps) => {
           geography: family.geographies.map((geo) => getCountryName(geo, countries)).join(", "),
           type: categoryName,
           document: {
-            display: <LinkWithQuery href={`/documents/${doc.slug}`}>{doc.title}</LinkWithQuery>,
+            display: (
+              <LinkWithQuery href={`/documents/${doc.slug}`} className="text-text-brand underline">
+                {doc.title}
+              </LinkWithQuery>
+            ),
             value: doc.title,
           },
         },
@@ -70,6 +78,15 @@ export const DocumentsBlock = ({ documents, family }: IProps) => {
         </div>
 
         {/* Cards TODO */}
+        {view === "card" && (
+          <div className="flex flex-col gap-4">
+            {documents.map((doc) => (
+              <LinkWithQuery key={doc.slug} href={`/documents/${doc.slug}`}>
+                <DocumentCard countries={countries} document={doc} family={family} />
+              </LinkWithQuery>
+            ))}
+          </div>
+        )}
 
         {/* Table */}
         {view === "table" && <InteractiveTable columns={TABLE_COLUMNS} rows={tableRows} />}

--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -1,0 +1,79 @@
+import { LucideScrollText, LucideTable } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { Card } from "@/components/atoms/card/Card";
+import { Section } from "@/components/molecules/section/Section";
+import { Toggle } from "@/components/molecules/toggleGroup/Toggle";
+import { ToggleGroup } from "@/components/molecules/toggleGroup/ToggleGroup";
+import { InteractiveTable, IInteractiveTableColumn, IInteractiveTableRow } from "@/components/organisms/interactiveTable/InteractiveTable";
+import { getCategoryName } from "@/helpers/getCategoryName";
+import { getCountryName } from "@/helpers/getCountryFields";
+import useConfig from "@/hooks/useConfig";
+import { TDocumentPage, TFamily, TFamilyPage, TLoadingStatus } from "@/types";
+import { convertDate } from "@/utils/timedate";
+
+type TTableColumn = "year" | "geography" | "type" | "document";
+const TABLE_COLUMNS: IInteractiveTableColumn<TTableColumn>[] = [
+  { id: "year" },
+  { id: "geography", fraction: 2 },
+  { id: "type", fraction: 2 },
+  { id: "document", fraction: 4 },
+];
+
+interface IProps {
+  documents: (TDocumentPage & { matches?: number })[];
+  family: TFamilyPage;
+  status: TLoadingStatus;
+}
+
+export const DocumentsBlock = ({ documents, family }: IProps) => {
+  const configQuery = useConfig();
+  const { data: { countries = [] } = {} } = configQuery;
+  const [view, setView] = useState("card");
+
+  const onToggleChange = (toggleValue: string[]) => {
+    setView(toggleValue[0]);
+  };
+
+  const [year] = convertDate(family.published_date);
+  const categoryName = getCategoryName(family.category, family.corpus_type_name, family.organisation);
+
+  const tableRows: IInteractiveTableRow<TTableColumn>[] = useMemo(() => {
+    if (documents.length === 0) return [];
+
+    return documents.map((doc) => {
+      return {
+        id: doc.slug,
+        cells: {
+          year,
+          geography: family.geographies.map((geo) => getCountryName(geo, countries)).join(", "),
+          type: categoryName,
+          document: {
+            display: <LinkWithQuery href={`/documents/${doc.slug}`}>{doc.title}</LinkWithQuery>,
+            value: doc.title,
+          },
+        },
+      };
+    });
+  }, [categoryName, countries, documents, family, year]);
+
+  return (
+    <Section id="section-documents" title="Documents">
+      <Card variant="outlined" className="flex flex-col rounded-lg !p-5">
+        {/* Controls */}
+        <div className="pb-6">
+          <ToggleGroup value={[view]} onValueChange={onToggleChange}>
+            <Toggle Icon={LucideScrollText} text="Card" value="card" />
+            <Toggle Icon={LucideTable} text="Table" value="table" />
+          </ToggleGroup>
+        </div>
+
+        {/* Cards TODO */}
+
+        {/* Table */}
+        {view === "table" && <InteractiveTable columns={TABLE_COLUMNS} rows={tableRows} />}
+      </Card>
+    </Section>
+  );
+};

--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -29,7 +29,8 @@ interface IProps {
 
 /**
  * TODO LIST
- * - Better matches handling (including loading state)
+ * - Add matches counts, handle loading state
+ * - Better unify the data used by both DocumentCard and InteractiveTable to remove compute repetition
  */
 
 export const DocumentsBlock = ({ countries, family }: IProps) => {

--- a/src/components/molecules/documentCard/DocumentCard.stories.tsx
+++ b/src/components/molecules/documentCard/DocumentCard.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
+import { FAMILY_PAGE_STUB } from "@/stubs/familyPageStub";
+
 import { DocumentCard } from "./DocumentCard";
 
 const meta = {
@@ -11,27 +13,12 @@ type TStory = StoryObj<typeof DocumentCard>;
 
 export default meta;
 
-export const PolicyDocument: TStory = {
+export const UNFCCCSubmission: TStory = {
+  name: "UNFCC Submission",
   args: {
-    document: {
-      import_id: "CCLW.document.i00004157.n0000",
-      variant: "Original Language",
-      slug: "croatia-final-updated-necp-annex-1-2021-2030_1de4",
-      title: "Croatia - Final Updated NECP (Annex 1) 2021 - 2030",
-      md5_sum: "b0ee9b3d4c26e1b3d40d00d28761e843",
-      cdn_object:
-        "https://cdn.climatepolicyradar.org/navigator/HRV/2025/croatia-final-updated-national-energy-and-climate-plan-necp-2021-2030_b0ee9b3d4c26e1b3d40d00d28761e843.pdf",
-      source_url:
-        "https://commission.europa.eu/document/download/93d8e8a1-74d0-4e47-b0f8-99329e023b1b_en?filename=Croatia%20-%20Final%20Updated%20NECP%20%28Annex%201%29%202021%20-%202030.pdf",
-      content_type: "application/pdf",
-      language: "eng",
-      languages: ["eng"],
-      document_type: "Plan",
-      document_role: "ANNEX",
-    },
-    languages: {
-      eng: "English",
-    },
+    countries: [{ id: 31, display_value: "Hungary", slug: "hungary", value: "HUN", type: "ISO-3166", parent_id: 10 }],
+    document: FAMILY_PAGE_STUB.documents[0],
+    family: FAMILY_PAGE_STUB,
     matches: 12,
   },
 };

--- a/src/components/molecules/documentCard/DocumentCard.tsx
+++ b/src/components/molecules/documentCard/DocumentCard.tsx
@@ -1,27 +1,27 @@
 import { Card } from "@/components/atoms/card/Card";
-import { getDocumentType } from "@/helpers/getDocumentType";
-import { getLanguage } from "@/helpers/getLanguage";
-import { TDocumentPage, TLanguages } from "@/types";
+import { getCategoryName } from "@/helpers/getCategoryName";
+import { getCountryName } from "@/helpers/getCountryFields";
+import { TDocumentPage, TFamilyPage, TGeography } from "@/types";
 import { pluralise } from "@/utils/pluralise";
-import { firstCase } from "@/utils/text";
+import { convertDate } from "@/utils/timedate";
 
 interface IProps {
+  countries: TGeography[];
   document: TDocumentPage;
-  languages: TLanguages;
+  family: TFamilyPage;
   matches?: number;
 }
 
-export const DocumentCard = ({ document, languages, matches }: IProps) => {
-  const { content_type, document_role, language } = document;
-
-  const isMain = Boolean(document_role?.toLowerCase().includes("main"));
+export const DocumentCard = ({ countries, document, family, matches }: IProps) => {
+  const [year] = convertDate(family.published_date);
+  const categoryName = getCategoryName(family.category, family.corpus_type_name, family.organisation);
 
   return (
     <Card className="!p-8 bg-surface-brand-darker/4 rounded-sm">
       <div className="mb-2 flex gap-4 flex-wrap text-sm text-text-tertiary leading-none">
-        <span>{language && getLanguage(language, languages)}</span>
-        {!isMain && <span>{firstCase(document_role?.toLowerCase())}</span>}
-        <span>{getDocumentType(content_type)}</span>
+        {family.geographies.length > 0 && <span>{getCountryName(family.geographies[0], countries)}</span>}
+        <span>{year}</span>
+        <span>{categoryName}</span>
       </div>
       <span className="text-lg text-text-brand-darker font-[660] leading-tight">{document.title}</span>
       {matches && (

--- a/src/components/molecules/toggleGroup/Toggle.tsx
+++ b/src/components/molecules/toggleGroup/Toggle.tsx
@@ -1,0 +1,18 @@
+import { Toggle as BaseToggle } from "@base-ui-components/react/toggle";
+import { LucideIcon } from "lucide-react";
+
+interface IProps extends BaseToggle.Props {
+  children?: never;
+  Icon: LucideIcon;
+  text: string;
+}
+
+export const Toggle = ({ Icon, text, ...props }: IProps) => (
+  <BaseToggle
+    className="flex gap-1 items-center px-3 py-2 rounded-full text-sm text-text-tertiary font-semibold leading-none hover:bg-surface-ui data-[pressed]:bg-surface-ui data-[pressed]:text-text-primary"
+    {...props}
+  >
+    <Icon size={16} className="text-text-tertiary" />
+    {text}
+  </BaseToggle>
+);

--- a/src/components/molecules/toggleGroup/ToggleGroup.stories.tsx
+++ b/src/components/molecules/toggleGroup/ToggleGroup.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { LucideScrollText, LucideTable } from "lucide-react";
+
+import { Toggle } from "./Toggle";
+import { ToggleGroup } from "./ToggleGroup";
+
+const meta = {
+  title: "Molecules/ToggleGroup",
+  component: ToggleGroup,
+  argTypes: {
+    bordered: { control: "boolean" },
+    children: { control: false },
+  },
+} satisfies Meta<typeof ToggleGroup>;
+type TStory = StoryObj<typeof ToggleGroup>;
+
+export default meta;
+
+export const DocumentsBlock: TStory = {
+  args: {
+    bordered: false,
+    children: (
+      <>
+        <Toggle Icon={LucideTable} text="Table" value="table" />
+        <Toggle Icon={LucideScrollText} text="List" value="list" />
+      </>
+    ),
+    className: "",
+    defaultValue: ["table"],
+  },
+};

--- a/src/components/molecules/toggleGroup/ToggleGroup.stories.tsx
+++ b/src/components/molecules/toggleGroup/ToggleGroup.stories.tsx
@@ -21,11 +21,11 @@ export const DocumentsBlock: TStory = {
     bordered: false,
     children: (
       <>
+        <Toggle Icon={LucideScrollText} text="Card" value="card" />
         <Toggle Icon={LucideTable} text="Table" value="table" />
-        <Toggle Icon={LucideScrollText} text="List" value="list" />
       </>
     ),
     className: "",
-    defaultValue: ["table"],
+    defaultValue: ["card"],
   },
 };

--- a/src/components/molecules/toggleGroup/ToggleGroup.tsx
+++ b/src/components/molecules/toggleGroup/ToggleGroup.tsx
@@ -1,0 +1,20 @@
+import { ToggleGroup as BaseToggleGroup } from "@base-ui-components/react/toggle-group";
+import { ReactNode } from "react";
+
+import { joinTailwindClasses } from "@/utils/tailwind";
+
+interface IProps extends BaseToggleGroup.Props {
+  bordered?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+export const ToggleGroup = ({ bordered, children, className, ...props }: IProps) => {
+  const allClasses = joinTailwindClasses("inline-flex gap-1", bordered && "p-[3px] border border-border-light rounded-full", className);
+
+  return (
+    <BaseToggleGroup className={allClasses} {...props}>
+      {children}
+    </BaseToggleGroup>
+  );
+};

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -28,33 +28,28 @@ export const Generic: TStory<TWainwrightColumns> = {
     columns: [
       {
         id: "wainwright",
-        name: "Wainwright",
-        sortable: true,
         fraction: 2,
       },
       {
         id: "height",
-        name: "Height",
-        sortable: true,
       },
       {
         id: "region",
-        name: "Region",
         tooltip: (
           <div className="w-[200px]">
             Which of Alfred Wainwright's books the Wainwright features in. The series of 7 books divides the Lakeland Fells by geographic region.
           </div>
         ),
         fraction: 2,
+        sortable: false,
       },
       {
         id: "link",
         name: "WalkLakes",
+        sortable: false,
       },
       {
         id: "summited",
-        name: "Summited",
-        sortable: true,
       },
     ],
     defaultSort: {

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -7,17 +7,18 @@ import { MenuItem } from "@/components/atoms/menu/MenuItem";
 import { MenuPopup } from "@/components/atoms/menu/MenuPopup";
 import { Tooltip } from "@/components/atoms/tooltip/Tooltip";
 import { joinTailwindClasses } from "@/utils/tailwind";
+import { firstCase } from "@/utils/text";
 
 const NULL_VALUE_DISPLAY = "–";
 
 type TValue = string | number | null;
 
-interface IInteractiveTableColumn<ColumnKey extends string> {
+export interface IInteractiveTableColumn<ColumnKey extends string> {
   classes?: string; // Styles every cell in the column
   fraction?: number; // CSS grid fractional units - the column's relative width
   id: ColumnKey;
-  name: string;
-  sortable?: boolean;
+  name?: string; // defaults to first-cased id
+  sortable?: boolean; // defaults to true
   tooltip?: ReactNode;
 }
 
@@ -28,7 +29,7 @@ export type TInteractiveTableCell =
       value: TValue;
     };
 
-interface IInteractiveTableRow<ColumnKey extends string> {
+export interface IInteractiveTableRow<ColumnKey extends string> {
   id: string;
   cells: Record<ColumnKey, TInteractiveTableCell>;
   classes?: string; // Styles every cell in the row
@@ -142,13 +143,13 @@ export const InteractiveTable = <ColumnKey extends string>({ columns, defaultSor
           return (
             <div key={`heading-${column.id}`} className={cellClasses}>
               <div className="flex items-center gap-1 min-h-6">
-                <span className="block">{column.name}</span>
+                <span className="block">{column.name || firstCase(column.id)}</span>
                 {column.tooltip && (
                   <Tooltip content={column.tooltip} popupClasses="text-wrap max-w-[250px]">
                     <LucideInfo size={16} className="text-text-tertiary opacity-50 group-hover:opacity-100" />
                   </Tooltip>
                 )}
-                {column.sortable && renderSortControls(column)}
+                {column.sortable !== false && renderSortControls(column)}
               </div>
             </div>
           );

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -1,5 +1,6 @@
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Columns } from "@/components/atoms/columns/Columns";
+import { DocumentsBlock } from "@/components/blocks/documentsBlock/DocumentsBlock";
 import { MetadataBlock } from "@/components/blocks/metadataBlock/MetadataBlock";
 import { TextBlock } from "@/components/blocks/textBlock/TextBlock";
 import Layout from "@/components/layouts/Main";
@@ -55,6 +56,7 @@ export const FamilyLitigationPage = ({ countries, family, theme, themeConfig, ne
       <Columns>
         <ContentsSideBar items={FAMILY_PAGE_SIDE_BAR_ITEMS_SORTED} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
         <main className="flex flex-col py-3 gap-3 cols-2:py-6 cols-2:gap-6 cols-3:py-8 cols-3:gap-8 cols-3:col-span-2 cols-4:col-span-3">
+          <DocumentsBlock countries={countries} family={family} status="success" />
           <TextBlock>
             <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
           </TextBlock>

--- a/src/stubs/familyPageStub.tsx
+++ b/src/stubs/familyPageStub.tsx
@@ -1,0 +1,114 @@
+import { TFamilyPage } from "@/types";
+
+export const FAMILY_PAGE_STUB = {
+  organisation: "UNFCCC",
+  import_id: "UNFCCC.family.i00002894.n0000",
+  title: "Hungary National Inventory Report (NIR). 2025",
+  summary: "<p>Hungary National Inventory Report (NIR). 2025</p>",
+  geographies: ["HUN"],
+  category: "UNFCCC",
+  status: "Published",
+  metadata: { author: ["Hungary"], author_type: ["Party"] },
+  slug: "hungary-national-inventory-report-nir-2025_73b2",
+  events: [{ title: "Submitted", date: "2025-06-10T00:00:00Z", event_type: "Passed/Approved", status: "Ok" }],
+  published_date: "2025-06-10T00:00:00Z",
+  last_updated_date: "2025-06-10T00:00:00Z",
+  documents: [
+    {
+      import_id: "UNFCCC.document.i00002895.n0000",
+      variant: "Original Language",
+      slug: "hungary-national-inventory-document-for-1985-2023_3447",
+      title: "Hungary - National Inventory Document for 1985-2023",
+      md5_sum: "26623a7427bf38b2e90aee13a7ce5d90",
+      cdn_object:
+        "https://cdn.climatepolicyradar.org/navigator/HUN/2025/hungary-national-inventory-report-nir-2025_26623a7427bf38b2e90aee13a7ce5d90.pdf",
+      source_url: "https://unfccc.int/sites/default/files/resource/HUN_NID_2023.pdf",
+      content_type: "application/pdf",
+      language: "eng",
+      languages: ["eng"],
+      document_type: "National Inventory Report",
+      document_role: "MAIN",
+    },
+    {
+      import_id: "UNFCCC.document.i00002901.n0000",
+      variant: "Original Language",
+      slug: "hungary-2025-common-reporting-table-crt_557c",
+      title: "Hungary. 2025 Common Reporting Table (CRT)",
+      md5_sum: "209de32b285d3a3a42c5f8f32e32a16e",
+      cdn_object:
+        "https://cdn.climatepolicyradar.org/navigator/HUN/2025/hungary-national-inventory-report-nir-2025_209de32b285d3a3a42c5f8f32e32a16e.pdf",
+      source_url: "https://unfccc.int/documents/647382",
+      content_type: "text/html",
+      language: "eng",
+      languages: ["eng"],
+      document_type: "National Inventory Report",
+      document_role: "SUPPORTING DOCUMENTATION",
+    },
+    {
+      import_id: "UNFCCC.document.i00002897.n0000",
+      variant: "Original Language",
+      slug: "hungary-2025-national-inventory-document-nid-annex_8588",
+      title: "Hungary. 2025 National Inventory Document (NID). Annex",
+      md5_sum: "36e174e00395fbaa7719465d34cdf697",
+      cdn_object:
+        "https://cdn.climatepolicyradar.org/navigator/HUN/2025/hungary-national-inventory-report-nir-2025_36e174e00395fbaa7719465d34cdf697.pdf",
+      source_url: "https://unfccc.int/sites/default/files/resource/HU_NID_ANNEXES_2023.pdf",
+      content_type: "application/pdf",
+      language: "eng",
+      languages: ["eng"],
+      document_type: "National Inventory Report",
+      document_role: "ANNEX",
+    },
+  ],
+  collections: [
+    {
+      import_id: "UNFCCC.collection.i00001979.n0000",
+      title: "Hungary's National Inventory Reports",
+      description: "Hungary's National Inventory Reports",
+      families: [
+        {
+          title: "Hungary. 2021 National Inventory Report (NIR)",
+          slug: "hungary-2021-national-inventory-report-nir_9d88",
+          description: "<p>Hungary. 2021 National Inventory Report (NIR), National Inventory Report from Hungary in 2021</p>",
+        },
+        {
+          title: "Hungary. 2022 National Inventory Report (NIR)",
+          slug: "hungary-2022-national-inventory-report-nir_b36a",
+          description: "<p>Hungary. 2022 National Inventory Report (NIR), National Inventory Report from Hungary in 2022</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2023",
+          slug: "hungary-national-inventory-report-nir-2023_4140",
+          description: "<p>Hungary's National Inventory Report submitted in 2023.</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2025",
+          slug: "hungary-national-inventory-report-nir-2025_73b2",
+          description: "<p>Hungary National Inventory Report (NIR). 2025</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2020",
+          slug: "hungary-national-inventory-report-nir-2020_e211",
+          description: "<p>Hungary National Inventory Report (NIR). 2020</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2019",
+          slug: "hungary-national-inventory-report-nir-2019_4cf9",
+          description: "<p>Hungary National Inventory Report (NIR). 2019</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2018",
+          slug: "hungary-national-inventory-report-nir-2018_582e",
+          description: "<p>Hungary National Inventory Report (NIR). 2018</p>",
+        },
+        {
+          title: "Hungary National Inventory Report (NIR). 2024",
+          slug: "hungary-national-inventory-report-nir-2024_3f20",
+          description: "<p>Hungary National Inventory Report (NIR). 2024</p>",
+        },
+      ],
+      slug: "hungary-s-national-inventory-reports_aea0",
+    },
+  ],
+  corpus_id: "UNFCCC.corpus.i00000001.n0000",
+} as unknown as TFamilyPage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@/interfaces/*": ["src/interfaces/*"],
       "@/types": ["src/types/index"],
       "@/pages/*": ["src/pages/*"],
+      "@/stubs/*": ["src/stubs/*"],
       "@/utils/*": ["src/utils/*"],
       "@/ccc/*": ["themes/ccc/*"],
       "@/cclw/*": ["themes/cclw/*"],


### PR DESCRIPTION
# What's changed

- Added `DocumentsBlock` to display cards or a table of document details for the given family page.
  - Story example, including adding a stub of family API data for use in Storybook stories.
  - Added to family page.
- Changed the `DocumentCard` props to be less repetitious.
- Added `Toggle` and `ToggleGroup` components to wrap Base UI's equivalents and give us a more opinionated button.
- `InteractiveTable` columns are now sortable by default.

## Why?

Satisfies [APP-910](https://linear.app/climate-policy-radar/issue/APP-910/documents-block-component-for-family-page)

## Screenshots?

Displaying cards:
<img width="963" height="530" alt="Screenshot 2025-07-24 at 16 43 59" src="https://github.com/user-attachments/assets/da7bc4f8-1b99-4e74-9a6a-5242515640e5" />

Displaying a table:
<img width="968" height="352" alt="Screenshot 2025-07-24 at 16 44 05" src="https://github.com/user-attachments/assets/ab314cc8-0265-456f-bce1-8f045a79a299" />
