### PR TITLE
APP 932 update metadata block display

### DIFF
--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -60,7 +60,7 @@ export const FamilyLitigationPage = ({ countries, family, theme, themeConfig }: 
           <TextBlock>
             <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
           </TextBlock>
-          <MetadataBlock title="About this case" metadata={getFamilyMetadata(family)} />
+          <MetadataBlock title="About this case" metadata={getFamilyMetadata(family, countries)} />
           <pre className="w-full max-h-[1000px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">{JSON.stringify(family, null, 2)}</pre>
         </main>
       </Columns>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -198,6 +198,7 @@ export type TFamilyPage = {
   published_date: string | null;
   last_updated_date: string | null;
   status?: string;
+  concepts: TFamilyConcept[];
 };
 
 export type TDocumentContentType = "application/pdf" | "text/html" | "application/octet-stream";
@@ -356,6 +357,15 @@ export type TConcept = {
   subconcept_of: string[];
   wikibase_id: string;
   type?: "principal_law" | "jurisdiction" | "category";
+};
+
+export type TFamilyConcept = {
+  id: string;
+  ids: string[];
+  type: string;
+  relation: string;
+  preferred_label: string;
+  subconcept_of_labels: string[];
 };
 
 export type TSearchResponse = {

--- a/src/utils/buildConceptHierarchy.ts
+++ b/src/utils/buildConceptHierarchy.ts
@@ -26,9 +26,9 @@ function buildTree(
   }
   visited.add(concept.id);
 
-  // Find children: concepts where this concept is a parent
+  // Find children: concepts where this concept is a parent and of the same type
   const children = allConcepts
-    .filter((child) => child.subconcept_of_labels.includes(concept.preferred_label))
+    .filter((child) => child.subconcept_of_labels.includes(concept.preferred_label) && child.type === concept.type)
     .map((child) => buildTree(child, labelMap, allConcepts, new Set(visited)));
 
   return {

--- a/src/utils/buildConceptHierarchy.ts
+++ b/src/utils/buildConceptHierarchy.ts
@@ -1,0 +1,52 @@
+import { TFamilyConcept } from "@/types";
+
+export type TFamilyConceptTreeNode = TFamilyConcept & {
+  children: TFamilyConceptTreeNode[];
+};
+
+// Helper: Build a lookup by preferred_label
+function buildLabelMap(concepts: TFamilyConcept[]): Map<string, TFamilyConcept> {
+  const map = new Map<string, TFamilyConcept>();
+  for (const concept of concepts) {
+    map.set(concept.preferred_label, concept);
+  }
+  return map;
+}
+
+// Recursive function to build the tree
+function buildTree(
+  concept: TFamilyConcept,
+  labelMap: Map<string, TFamilyConcept>,
+  allConcepts: TFamilyConcept[],
+  visited: Set<string>
+): TFamilyConceptTreeNode {
+  // Prevent cycles
+  if (visited.has(concept.id)) {
+    throw new Error(`Cycle detected at concept id: ${concept.id}`);
+  }
+  visited.add(concept.id);
+
+  // Find children: concepts where this concept is a parent
+  const children = allConcepts
+    .filter((child) => child.subconcept_of_labels.includes(concept.preferred_label))
+    .map((child) => buildTree(child, labelMap, allConcepts, new Set(visited)));
+
+  return {
+    ...concept,
+    children,
+  };
+}
+
+// Main function to build the full forest (array of root nodes)
+export function buildConceptHierarchy(concepts: TFamilyConcept[]): TFamilyConceptTreeNode[] {
+  const labelMap = buildLabelMap(concepts);
+
+  // Root concepts: those with no parents
+  const roots = concepts.filter((concept) => concept.subconcept_of_labels.length === 0);
+
+  // If a concept has multiple parents, it will appear under each parent branch
+  // If there are cycles, an error will be thrown
+
+  // Build the tree for each root
+  return roots.map((root) => buildTree(root, labelMap, concepts, new Set()));
+}

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -1,27 +1,44 @@
-import { ReactNode } from "react";
+import { Fragment } from "react";
 
-import { TFamilyPage, IMetadata } from "@/types";
+import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { TFamilyPage, IMetadata, TGeography } from "@/types";
 
 // Format the family metadata into a shape suitable for the MetadataBlock component
-export const getFamilyMetadata = (family: TFamilyPage): IMetadata[] => {
+export const getFamilyMetadata = (family: TFamilyPage, countries: TGeography[]): IMetadata[] => {
   const familyMetadata = [];
 
   // TODO: handle more categories and their specific metadata later
-  if (family.category === "Litigation") {
-    familyMetadata.push(...getLitigationMetaData(family));
+  if (family.category.toLowerCase() === "litigation") {
+    familyMetadata.push(...getLitigationMetaData(family, countries));
   }
 
   return familyMetadata;
 };
 
-function getLitigationMetaData(family: TFamilyPage): IMetadata[] {
+function getLitigationMetaData(family: TFamilyPage, countries: TGeography[]): IMetadata[] {
   const metadata = [];
 
-  if (family.published_date) {
-    const year = new Date(family.published_date).getFullYear();
+  const filingYearEvent = family.events.find((event) => event.event_type === "Filing Year For Action");
+  if (filingYearEvent) {
+    const year = new Date(filingYearEvent.date).getFullYear();
     metadata.push({
       label: "Filing year",
       value: year,
+    });
+  }
+
+  if (family.geographies.length > 0) {
+    metadata.push({
+      label: "Geography",
+      value: family.geographies.map((geo, index) => (
+        <Fragment key={geo}>
+          {index > 0 && getCountrySlug(geo, countries) && " → "}
+          <LinkWithQuery key={geo} href={`/geographies/${getCountrySlug(geo, countries)}`} className="underline">
+            {getCountryName(geo, countries)}
+          </LinkWithQuery>
+        </Fragment>
+      )),
     });
   }
 
@@ -46,14 +63,7 @@ function getLitigationMetaData(family: TFamilyPage): IMetadata[] {
     });
   }
 
-  if (family.metadata.core_object) {
-    metadata.push({
-      label: "Core object",
-      value: <div className="grid">{family.metadata.core_object?.map((label) => <span key={label}>{label}</span>) || "N/A"}</div>,
-    });
-  }
-
-  if (family.metadata.original_case_name) {
+  if (family.metadata.original_case_name.length > 0) {
     metadata.push({
       label: "Original case name",
       value: <div className="grid">{family.metadata.original_case_name?.map((label) => <span key={label}>{label}</span>) || "N/A"}</div>,

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -39,7 +39,7 @@ export const getFamilyMetadata = (family: TFamilyPage, countries: TGeography[]):
 function getLitigationMetaData(family: TFamilyPage, countries: TGeography[]): IMetadata[] {
   const metadata = [];
 
-  // Structure concepts into a hierarchy for use later
+  // Structure concepts into a hierarchy
   const hierarchy = buildConceptHierarchy(family.concepts);
 
   const filingYearEvent = family.events.find((event) => event.event_type === "Filing Year For Action");
@@ -89,17 +89,29 @@ function getLitigationMetaData(family: TFamilyPage, countries: TGeography[]): IM
     });
   }
 
-  if (family.metadata.concept_preferred_label) {
+  const caseCategories = hierarchy.filter((concept) => concept.type === "legal_category");
+  if (caseCategories.length > 0) {
     metadata.push({
-      label: "Concept preferred label",
-      value: <div className="grid">{family.metadata.concept_preferred_label?.map((label) => <span key={label}>{label}</span>) || "N/A"}</div>,
+      label: "Case category",
+      value: <div className="grid">{caseCategories.map((category) => displayConceptChildren(category))}</div>,
+    });
+  } else {
+    metadata.push({
+      label: "Case category",
+      value: "N/A",
     });
   }
 
-  if (family.metadata.original_case_name.length > 0) {
+  const principalLaws = hierarchy.filter((concept) => concept.type === "law");
+  if (principalLaws.length > 0) {
     metadata.push({
-      label: "Original case name",
-      value: <div className="grid">{family.metadata.original_case_name?.map((label) => <span key={label}>{label}</span>) || "N/A"}</div>,
+      label: "Principal law",
+      value: <div className="grid">{principalLaws.map((law) => displayConceptChildren(law))}</div>,
+    });
+  } else {
+    metadata.push({
+      label: "Principal law",
+      value: "N/A",
     });
   }
 

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -29,7 +29,7 @@ export const getFamilyMetadata = (family: TFamilyPage, countries: TGeography[]):
   const familyMetadata = [];
 
   // TODO: handle more categories and their specific metadata later
-  if (family.category.toLowerCase() === "litigation") {
+  if (family.corpus_type_name.toLowerCase() === "litigation") {
     familyMetadata.push(...getLitigationMetaData(family, countries));
   }
 
@@ -67,7 +67,11 @@ function getLitigationMetaData(family: TFamilyPage, countries: TGeography[]): IM
 
   metadata.push({
     label: "Docket number",
-    value: <div className="grid">{family.metadata.case_number?.map((label) => <span key={label}>{label}</span>) || "N/A"}</div>,
+    value: (
+      <div className="grid">
+        {family.metadata.case_number?.length > 0 ? family.metadata.case_number?.map((label) => <span key={label}>{label}</span>) : "N/A"}
+      </div>
+    ),
   });
 
   metadata.push({
@@ -77,43 +81,22 @@ function getLitigationMetaData(family: TFamilyPage, countries: TGeography[]): IM
 
   // Court/Admin entity
   const legalEntities = hierarchy.filter((concept) => concept.type === "legal_entity");
-  if (legalEntities.length > 0) {
-    metadata.push({
-      label: "Court/Admin entity",
-      value: <div className="grid">{legalEntities.map((entity) => displayConceptChildren(entity))}</div>,
-    });
-  } else {
-    metadata.push({
-      label: "Court/Admin entity",
-      value: "N/A",
-    });
-  }
+  metadata.push({
+    label: "Court/Admin entity",
+    value: <div className="grid">{legalEntities.length > 0 ? legalEntities.map((entity) => displayConceptChildren(entity)) : "N/A"}</div>,
+  });
 
   const caseCategories = hierarchy.filter((concept) => concept.type === "legal_category");
-  if (caseCategories.length > 0) {
-    metadata.push({
-      label: "Case category",
-      value: <div className="grid">{caseCategories.map((category) => displayConceptChildren(category))}</div>,
-    });
-  } else {
-    metadata.push({
-      label: "Case category",
-      value: "N/A",
-    });
-  }
+  metadata.push({
+    label: "Case category",
+    value: <div className="grid">{caseCategories.length > 0 ? caseCategories.map((category) => displayConceptChildren(category)) : "N/A"}</div>,
+  });
 
   const principalLaws = hierarchy.filter((concept) => concept.type === "law");
-  if (principalLaws.length > 0) {
-    metadata.push({
-      label: "Principal law",
-      value: <div className="grid">{principalLaws.map((law) => displayConceptChildren(law))}</div>,
-    });
-  } else {
-    metadata.push({
-      label: "Principal law",
-      value: "N/A",
-    });
-  }
+  metadata.push({
+    label: "Principal law",
+    value: <div className="grid">{principalLaws.length > 0 ? principalLaws.map((law) => displayConceptChildren(law)) : "N/A"}</div>,
+  });
 
   return metadata;
 }


### PR DESCRIPTION
# What's changed
- ensure correct values are displayed
- ensure hierarchy of concepts is respected
- ensure parent concepts are repeated when different hierarchy trees are present

## Why?
- so that we can accurately display the correct date for a given litigation case

## Screenshots?
