### PR TITLE
Feature/app 968 render the correct canonical in navigator frontend

### DIFF
--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -20,9 +20,10 @@ interface IProps {
   metadataKey?: string;
   text?: string;
   children?: ReactNode;
+  attributionUrl?: string | null;
 }
 
-const Layout: FC<IProps> = ({ children, title, theme, description, themeConfig, metadataKey, text }) => {
+const Layout: FC<IProps> = ({ children, title, theme, description, themeConfig, metadataKey, text, attributionUrl }) => {
   const router = useRouter();
   const { theme: contextTheme } = useContext(ThemeContext);
 
@@ -33,7 +34,7 @@ const Layout: FC<IProps> = ({ children, title, theme, description, themeConfig, 
         <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`} />
         <meta name="description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} key="desc" />
         <meta property="og:description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} />
-        <link rel="canonical" href={getCanonicalUrl(router, contextTheme)} />
+        <link rel="canonical" href={getCanonicalUrl(router, contextTheme, attributionUrl)} />
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -19,6 +19,7 @@ import { IProps } from "./familyOriginalPage";
 export const FamilyLitigationPage = ({ countries, family, theme, themeConfig }: IProps) => {
   const categoryName = getCategoryName(family.category, family.corpus_type_name, family.organisation);
   const [year] = convertDate(family.published_date);
+  const attributionUrl = family?.organisation_attribution_url;
 
   const pageHeaderMetadata: IPageHeaderMetadata[] = [
     { label: "Date", value: isNaN(year) ? "" : year },
@@ -51,6 +52,7 @@ export const FamilyLitigationPage = ({ countries, family, theme, themeConfig }: 
       theme={theme}
       themeConfig={themeConfig}
       metadataKey="family"
+      attributionUrl={attributionUrl}
     >
       <PageHeader label={categoryName} title={family.title} metadata={pageHeaderMetadata} />
       <Columns>

--- a/src/components/pages/familyOriginalPage.tsx
+++ b/src/components/pages/familyOriginalPage.tsx
@@ -84,6 +84,7 @@ export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page,
 
   const publishedTargets = sortFilterTargets(targets);
   const hasTargets = !!publishedTargets && publishedTargets?.length > 0;
+  const attributionUrl = page?.organisation_attribution_url;
 
   const geographyNames = page.geographies ? page.geographies.map((geo) => getCountryName(geo, countries)) : null;
   const geographyName = geographyNames ? geographyNames[0] : "";
@@ -212,7 +213,12 @@ export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page,
   };
 
   return (
-    <Layout title={`${page.title}`} description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)} theme={theme}>
+    <Layout
+      title={`${page.title}`}
+      description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)}
+      theme={theme}
+      attributionUrl={attributionUrl}
+    >
       <Script id="analytics">
         analytics.category = "{page.category}"; analytics.type = "{getDocumentCategories().join(",")}"; analytics.geography = "
         {page.geographies?.join(",")}";

--- a/src/utils/getCanonicalUrl.ts
+++ b/src/utils/getCanonicalUrl.ts
@@ -6,8 +6,8 @@ import getThemeDomain from "./getThemeDomain";
 
 // Get the canonical URL for the current page
 // This is used to tell search engines the preferred URL for the current page
-export const getCanonicalUrl = (router: NextRouter, theme: TTheme): string => {
-  const themeDomain = getThemeDomain(theme);
+export const getCanonicalUrl = (router: NextRouter, theme: TTheme, attribution_url = null): string => {
+  const themeDomain = attribution_url ? attribution_url : getThemeDomain(theme);
 
   // Get the length of the path slice to remove query params and hash
   // We specifically do not want to include query params or hash in the canonical URL


### PR DESCRIPTION
Per title we want to use the attribution url on a family to render the correct canonical url on our frontend document and family pages. 
