### PR TITLE
APP-903: Add to pages: ContentsSideBar

### DIFF
--- a/src/components/blocks/metadataBlock/MetadataBlock.tsx
+++ b/src/components/blocks/metadataBlock/MetadataBlock.tsx
@@ -8,7 +8,7 @@ interface IProps {
 
 export const MetadataBlock = ({ title, metadata }: IProps) => {
   return (
-    <Section title={title} id="metadata-block">
+    <Section title={title} id="section-metadata">
       <div className="rounded border border-border-light p-12">
         <div className="grid gap-3">
           {metadata.length === 0 && <div className="text-text-secondary">Sorry, there is no data available at this time.</div>}

--- a/src/components/molecules/section/Section.tsx
+++ b/src/components/molecules/section/Section.tsx
@@ -8,7 +8,7 @@ export interface IProps {
 
 export const Section = ({ children, id, title }: IProps) => {
   return (
-    <section className="cols-3:col-span-2 cols-4:col-span-3" id={id}>
+    <section className="cols-3:col-span-2 cols-4:col-span-3 scroll-mt-35 sm:scroll-mt-21" id={id}>
       {title && <h2 className="mb-5 text-xl text-text-primary font-semibold leading-tight">{title}</h2>}
       {children}
     </section>

--- a/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
+++ b/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
@@ -3,9 +3,14 @@ import { MouseEvent, useState } from "react";
 
 import { Button } from "@/components/atoms/button/Button";
 import { Badge } from "@/components/atoms/label/Badge";
-import { ISideBarItem } from "@/constants/sideBarItems";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { joinTailwindClasses } from "@/utils/tailwind";
+
+export interface ISideBarItem {
+  id: string;
+  display: string;
+  badge?: string;
+}
 
 interface IProps {
   items: ISideBarItem[];
@@ -17,7 +22,7 @@ export const ContentsSideBar = ({ containerClasses, items, stickyClasses }: IPro
   const [activeId, setActiveId] = useState("");
   useIntersectionObserver({ elementsQuery: "section", rootMargin: "-15% 0px 0px 0px", setActiveId });
 
-  const scrollToItem = (id: string, itemIndex: number) => (event: MouseEvent<HTMLAnchorElement>) => {
+  const scrollToItem = (id: string) => (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
 
     const element = document.getElementById(id);
@@ -34,13 +39,13 @@ export const ContentsSideBar = ({ containerClasses, items, stickyClasses }: IPro
         <div className="pt-2">
           {items.map((item, itemIndex) => {
             const buttonClasses = joinTailwindClasses(
-              "inline-block !px-2 !text-base leading-none text-text-tertiary",
+              "inline-block !px-2 !text-base text-text-tertiary text-left leading-none",
               item.id === activeId ? "font-semibold" : "font-normal"
             );
 
             return (
               <div key={item.id}>
-                <Link href={`#${item.id}`} onClick={scrollToItem(item.id, itemIndex)}>
+                <Link href={`#${item.id}`} onClick={scrollToItem(item.id)}>
                   <Button color="mono" size="small" variant="ghost" className={buttonClasses}>
                     {item.display}
                   </Button>

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -4,9 +4,10 @@ import { DocumentsBlock } from "@/components/blocks/documentsBlock/DocumentsBloc
 import { MetadataBlock } from "@/components/blocks/metadataBlock/MetadataBlock";
 import { TextBlock } from "@/components/blocks/textBlock/TextBlock";
 import Layout from "@/components/layouts/Main";
+import { Section } from "@/components/molecules/section/Section";
 import { ContentsSideBar } from "@/components/organisms/contentsSideBar/ContentsSideBar";
 import { IPageHeaderMetadata, PageHeader } from "@/components/organisms/pageHeader/PageHeader";
-import { FAMILY_PAGE_SIDE_BAR_ITEMS_SORTED } from "@/constants/sideBarItems";
+import { FAMILY_PAGE_SIDE_BAR_ITEMS } from "@/constants/sideBarItems";
 import { getCategoryName } from "@/helpers/getCategoryName";
 import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
 import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
@@ -65,14 +66,16 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
     >
       <PageHeader label={categoryName} title={family.title} metadata={pageHeaderMetadata} />
       <Columns>
-        <ContentsSideBar items={FAMILY_PAGE_SIDE_BAR_ITEMS_SORTED} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
+        <ContentsSideBar items={FAMILY_PAGE_SIDE_BAR_ITEMS} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
         <main className="flex flex-col py-3 gap-3 cols-2:py-6 cols-2:gap-6 cols-3:py-8 cols-3:gap-8 cols-3:col-span-2 cols-4:col-span-3">
           <DocumentsBlock countries={countries} family={family} status="success" />
           <TextBlock>
             <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
           </TextBlock>
           <MetadataBlock title="About this case" metadata={getFamilyMetadata(family, countries, subdivisions)} />
-          <pre className="w-full max-h-[1000px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">{JSON.stringify(family, null, 2)}</pre>
+          <Section id="section-debug" title="Debug">
+            <pre className="w-full max-h-[1000px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">{JSON.stringify(family, null, 2)}</pre>
+          </Section>
         </main>
       </Columns>
     </Layout>

--- a/src/constants/sideBarItems.ts
+++ b/src/constants/sideBarItems.ts
@@ -1,56 +1,21 @@
-export interface ISideBarItem {
-  id: string;
-  display: string;
-  badge?: string;
-  order?: number;
-}
+import { ISideBarItem } from "@/components/organisms/contentsSideBar/ContentsSideBar";
 
 export const FAMILY_PAGE_SIDE_BAR_ITEMS: ISideBarItem[] = [
   {
     id: "section-documents",
     display: "Documents",
-    order: 1,
   },
   {
     id: "section-summary",
     display: "Summary",
-    order: 2,
   },
   {
-    id: "section-targets",
-    display: "Targets",
-    order: 3,
+    id: "section-metadata",
+    display: "About",
   },
   {
-    id: "section-collection",
-    display: "Collection",
-    order: 4,
-  },
-  {
-    id: "section-topics",
-    display: "Topics",
-    badge: "Experimental",
-  },
-  {
-    id: "section-data",
-    display: "Get the data",
-    order: 6,
-  },
-  {
-    id: "section-download",
-    display: "Download documents",
-    order: 7,
-  },
-  {
-    id: "section-notes",
-    display: "Citation & Notes",
-    order: 8,
+    id: "section-debug",
+    display: "Debug",
+    badge: "Developer",
   },
 ];
-
-export const FAMILY_PAGE_SIDE_BAR_ITEMS_SORTED = FAMILY_PAGE_SIDE_BAR_ITEMS.slice().sort((a, b) => {
-  if (a.order === undefined && b.order === undefined) return 0;
-  if (a.order === undefined) return 1;
-  if (b.order === undefined) return -1;
-  return a.order - b.order;
-});

--- a/src/pages/collection/[id].tsx
+++ b/src/pages/collection/[id].tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps, InferGetStaticPropsType } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { ApiClient } from "@/api/http-common";
 import { Columns } from "@/components/atoms/columns/Columns";
@@ -7,7 +7,8 @@ import { EventsBlock } from "@/components/blocks/eventsBlock/EventsBlock";
 import { FamilyBlock } from "@/components/blocks/familyBlock/FamilyBlock";
 import { TextBlock } from "@/components/blocks/textBlock/TextBlock";
 import Layout from "@/components/layouts/Main";
-import { ContentsSideBar } from "@/components/organisms/contentsSideBar/ContentsSideBar";
+import { Section } from "@/components/molecules/section/Section";
+import { ContentsSideBar, ISideBarItem } from "@/components/organisms/contentsSideBar/ContentsSideBar";
 import { IPageHeaderTab, PageHeader } from "@/components/organisms/pageHeader/PageHeader";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { TCollectionPublicWithFamilies, TTheme, TThemeConfig } from "@/types";
@@ -32,6 +33,11 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
 
   const onTabChange = (tab: TCollectionTab) => setCurrentTab(tab);
 
+  const sideBarItems: ISideBarItem[] = families.map((family) => ({
+    id: `section-${family.slug}`,
+    display: family.title,
+  }));
+
   return (
     <Layout title={collection.title} description={collection.description} theme={theme} themeConfig={themeConfig} metadataKey="collection">
       <PageHeader<TCollectionTab>
@@ -45,7 +51,7 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
       <Columns>
         {currentTab === "cases" && (
           <>
-            <ContentsSideBar items={[]} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
+            <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
             <main className="flex flex-col py-3 gap-4 cols-2:py-6 cols-2:gap-8 cols-3:py-8 cols-3:gap-12 cols-3:col-span-2 cols-4:col-span-3">
               {families.map((family) => (
                 <FamilyBlock key={family.slug} family={family} />
@@ -67,9 +73,11 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
               <TextBlock>
                 <div className="text-content" dangerouslySetInnerHTML={{ __html: collection.description }} />
               </TextBlock>
-              <pre className="w-full max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">
-                {JSON.stringify(collection, null, 2)}
-              </pre>
+              <Section id="section-debug" title="Debug">
+                <pre className="w-full max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">
+                  {JSON.stringify(collection, null, 2)}
+                </pre>
+              </Section>
             </main>
           </>
         )}

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -89,7 +89,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (familyData) {
     const allSubdivisions = await Promise.all<TGeographySubdivision[]>(
       familyData.geographies
-        .filter((country) => country.length === 3)
+        .filter((country) => country.length === 3 && !["XAA", "XAB"].includes(country))
         .map(async (country) => {
           try {
             const { data: subDivisionResponse } = await apiClient.get(`/geographies/subdivisions/${country}`);
@@ -97,7 +97,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
           } catch (error) {}
         })
     );
-    subdivisionsData = allSubdivisions.flat();
+    subdivisionsData = allSubdivisions.flat().filter((subdivision) => subdivision !== undefined);
   }
 
   if (!familyData) {


### PR DESCRIPTION
# What's changed

- Tightened up scroll to section in `ContentsSideBar` to account for the heading (and its differing height at breakpoints).
- On the collections page, sidebar items is one per family
- Family page application of `ContentsSideBar` refined:
  - Removed item ordering as this was a premature optimisation. If later we need variable sections reflected in the sidebar, we should write a function to manipulate the sidebar items const instead.
- Fixed an issue where the family page would crash if one of our custom geographies is used to query the subdivisions endpoint.

## Why?

Satisfies [APP-903](https://linear.app/climate-policy-radar/issue/APP-903/add-to-pages-contentssidebar)

## Screenshots?

Family page:
<img width="1334" height="977" alt="Screenshot 2025-08-05 at 14 18 54" src="https://github.com/user-attachments/assets/0777a9ee-1e8f-4695-abdb-1b1cffddf50e" />

Collection page:
<img width="1331" height="621" alt="Screenshot 2025-08-05 at 14 20 19" src="https://github.com/user-attachments/assets/de392148-72a0-4e26-a569-d9840078d0ce" />
