### PR TITLE
APP-1032: Remove category from the menu on CCC app

### DIFF
--- a/src/utils/buildSearchQuery.ts
+++ b/src/utils/buildSearchQuery.ts
@@ -201,9 +201,7 @@ export default function buildSearchQuery(
   }
   // ---- End of Laws and Policies specific ----
 
-  // ---- MCF specific ----
-  // These are the filters that are specific to the MCFs corpus types
-  // TODO: handle this more elegantly and scaleably
+  // defaultCorpora is defined in apps without any category filters
   if (themeConfig.defaultCorpora) {
     query.corpus_import_ids = themeConfig.defaultCorpora;
   }
@@ -224,7 +222,7 @@ export default function buildSearchQuery(
         if (fundOption?.value) corpusIds.push(...fundOption.value);
       }
     }
-    query.corpus_import_ids = corpusIds; // this will overrite the defaultCorpora - which is fine
+    query.corpus_import_ids = corpusIds; // this will overwrite the defaultCorpora - which is fine
   }
 
   if (routerQuery[QUERY_PARAMS.fund_doc_type]) {
@@ -247,7 +245,7 @@ export default function buildSearchQuery(
       // If the user has also selected a fund, we only want to display the selected type of document for that fund
       query.corpus_import_ids = query.corpus_import_ids.filter((id) => corpusIds.includes(id));
     } else {
-      query.corpus_import_ids = corpusIds; // this will overrite the defaultCorpora - which is fine
+      query.corpus_import_ids = corpusIds; // this will overwrite the defaultCorpora - which is fine
     }
   }
 
@@ -258,7 +256,6 @@ export default function buildSearchQuery(
   if (routerQuery[QUERY_PARAMS.implementing_agency]) {
     query.metadata = buildSearchQueryMetadata(query.metadata, routerQuery[QUERY_PARAMS.implementing_agency], "implementing_agency", themeConfig);
   }
-  // ---- End of MCF specific ----
 
   // ---- Reports & UNFCCC specific ----
   // These are the filters that are specific to the Reports and UNFCCC corpus types - note: we pass in the corpusIds to check as there are multiple instances of the same filter

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -1,22 +1,7 @@
 import { TThemeConfig } from "@/types";
 
 const config: TThemeConfig = {
-  categories: {
-    label: "Category",
-    options: [
-      {
-        label: "All",
-        slug: "All",
-        value: ["Academic.corpus.Litigation.n0000"],
-      },
-      {
-        label: "Litigation",
-        slug: "Litigation",
-        value: ["Academic.corpus.Litigation.n0000"],
-        category: ["Litigation"],
-      },
-    ],
-  },
+  defaultCorpora: ["Academic.corpus.Litigation.n0000"],
   filters: [
     {
       label: "Type",
@@ -40,7 +25,7 @@ const config: TThemeConfig = {
     {
       key: "date",
       label: "First published",
-      category: ["MCF.corpus.GCF.n0000", "MCF.corpus.GEF.n0000", "MCF.corpus.AF.n0000", "MCF.corpus.CIF.n0000"],
+      category: [],
     },
   ],
   links: [


### PR DESCRIPTION
# What's changed

- Removed `categories` and added `defaultCorpora` in CCC config.
- Updated `labelVariations` to remove category corpora to prevent a runtime error.
- Updated `buildSearchQuery` comments to remove MCF-specific wording.

## Why?

Satisfies [APP-1032](https://linear.app/climate-policy-radar/issue/APP-1032/remove-category-from-the-menu-on-ccc-app).

## Screenshots

<img width="1437" height="491" alt="Screenshot 2025-08-11 at 11 29 22" src="https://github.com/user-attachments/assets/8647b393-308a-483e-ab01-c069282cdec0" />
