### PR TITLE
APP-1034: Data for family description component

### DIFF
--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -6,10 +6,9 @@ import { ReactNode, useMemo, useState } from "react";
 import { MenuItem } from "@/components/atoms/menu/MenuItem";
 import { MenuPopup } from "@/components/atoms/menu/MenuPopup";
 import { Tooltip } from "@/components/atoms/tooltip/Tooltip";
+import { EN_DASH } from "@/constants/chars";
 import { joinTailwindClasses } from "@/utils/tailwind";
 import { firstCase } from "@/utils/text";
-
-const NULL_VALUE_DISPLAY = "–";
 
 type TValue = string | number | null;
 
@@ -41,7 +40,7 @@ interface ISortRules<ColumnKey extends string> {
 }
 
 const renderCellDisplay = (cell: TInteractiveTableCell, showValues: boolean) => {
-  if (cell === null) return NULL_VALUE_DISPLAY;
+  if (cell === null) return EN_DASH;
 
   let content: ReactNode = `${cell}`;
   if (typeof cell === "object") content = showValues ? cell.value : cell.display;

--- a/src/constants/chars.ts
+++ b/src/constants/chars.ts
@@ -1,0 +1,2 @@
+export const EN_DASH = "–";
+export const ARROW_RIGHT = "→";

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -54,6 +54,16 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
 
   /* Filing year */
 
+  let filingTimestamp = family.events.find((event) => event.event_type === "Filing Year For Action")?.date;
+  if (isUSA && family.published_date) filingTimestamp = family.published_date;
+
+  metadata.push({
+    label: "Filing year",
+    value: filingTimestamp ? new Date(filingTimestamp).getFullYear() : EN_DASH,
+  });
+
+  // ---
+
   if (isUSA && family.published_date) {
     metadata.push({
       label: "Filing year",

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -62,23 +62,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
     value: filingTimestamp ? new Date(filingTimestamp).getFullYear() : EN_DASH,
   });
 
-  // ---
-
-  if (isUSA && family.published_date) {
-    metadata.push({
-      label: "Filing year",
-      value: formatDateShort(new Date(family.published_date)),
-    });
-  } else {
-    const filingYearEvent = family.events.find((event) => event.event_type === "Filing Year For Action");
-    if (filingYearEvent) {
-      metadata.push({
-        label: "Filing year",
-        value: new Date(filingYearEvent.date).getFullYear(),
-      });
-    }
-  }
-
   /* Status */
 
   metadata.push({


### PR DESCRIPTION
# What's changed

- Updated `getFamilyMetadata` function to more correctly map metadata to our desired list of metadata, with consideration for the difference between US and global (non-US) cases.
- Created a consts file for special characters - initially dash and right arrow.

## Why?

Satisfies [APP-1034](https://linear.app/climate-policy-radar/issue/APP-1034/data-for-family-description-component).

## Screenshots?

US:
<img width="1052" height="371" alt="Screenshot 2025-08-11 at 12 54 29" src="https://github.com/user-attachments/assets/b0b950b4-1e4c-47af-847d-b4228f5e610a" />

Global:
<img width="1047" height="367" alt="Screenshot 2025-08-11 at 12 54 17" src="https://github.com/user-attachments/assets/0cabafa9-ac7d-45cd-8108-9d6cf13d3c63" />
