### PR TITLE
APP-325 Updating meta to pull from config

### DIFF
--- a/src/components/layouts/LandingPage.tsx
+++ b/src/components/layouts/LandingPage.tsx
@@ -1,7 +1,8 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useContext } from "react";
 
+import { ThemeContext } from "@/context/ThemeContext";
 import { TTheme, TThemeConfig } from "@/types";
 import { getAppTitle } from "@/utils/getAppTitle";
 import { getCanonicalUrl } from "@/utils/getCanonicalUrl";
@@ -20,14 +21,18 @@ interface IProps {
 
 const Layout = ({ children, title, theme, description, themeConfig, metadataKey, text }: IProps) => {
   const router = useRouter();
+  const { themeConfig: contextThemeConfig } = useContext(ThemeContext);
 
   return (
     <>
       <Head>
-        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(themeConfig)}`}</title>
-        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(themeConfig)}`} />
-        <meta name="description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} key="desc" />
-        <meta property="og:description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} />
+        <title>{`${title ?? getPageTitle(themeConfig ?? contextThemeConfig, metadataKey, text)} - ${getAppTitle(themeConfig ?? contextThemeConfig)}`}</title>
+        <meta
+          property="og:title"
+          content={`${title ?? getPageTitle(themeConfig ?? contextThemeConfig, metadataKey, text)} - ${getAppTitle(themeConfig ?? contextThemeConfig)}`}
+        />
+        <meta name="description" content={description ?? getPageDescription(themeConfig ?? contextThemeConfig, metadataKey, text)} key="desc" />
+        <meta property="og:description" content={description ?? getPageDescription(themeConfig ?? contextThemeConfig, metadataKey, text)} />
         <link rel="canonical" href={getCanonicalUrl(router, theme)} />
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />

--- a/src/components/layouts/LandingPage.tsx
+++ b/src/components/layouts/LandingPage.tsx
@@ -24,8 +24,8 @@ const Layout = ({ children, title, theme, description, themeConfig, metadataKey,
   return (
     <>
       <Head>
-        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme)}`}</title>
-        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme)}`} />
+        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(themeConfig)}`}</title>
+        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(themeConfig)}`} />
         <meta name="description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} key="desc" />
         <meta property="og:description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} />
         <link rel="canonical" href={getCanonicalUrl(router, theme)} />

--- a/src/components/layouts/Main.tsx
+++ b/src/components/layouts/Main.tsx
@@ -14,27 +14,30 @@ const Wrapper = dynamic<{ children: ReactNode }>(() => import(`../../../themes/$
 
 interface IProps {
   title?: string;
-  theme?: TTheme;
   description?: string;
-  themeConfig?: TThemeConfig;
   metadataKey?: string;
   text?: string;
+  theme?: TTheme;
+  themeConfig?: TThemeConfig;
   children?: ReactNode;
   attributionUrl?: string | null;
 }
 
-const Layout: FC<IProps> = ({ children, title, theme, description, themeConfig, metadataKey, text, attributionUrl }) => {
+const Layout: FC<IProps> = ({ children, title, description, metadataKey, text, attributionUrl, themeConfig, theme }) => {
   const router = useRouter();
-  const { theme: contextTheme } = useContext(ThemeContext);
+  const { themeConfig: contextThemeConfig } = useContext(ThemeContext);
 
   return (
     <div className="h-full min-h-lvh flex flex-col">
       <Head>
-        <title>{`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`}</title>
-        <meta property="og:title" content={`${title ?? getPageTitle(themeConfig, metadataKey, text)} - ${getAppTitle(theme, contextTheme)}`} />
-        <meta name="description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} key="desc" />
-        <meta property="og:description" content={description ?? getPageDescription(themeConfig, metadataKey, text)} />
-        <link rel="canonical" href={getCanonicalUrl(router, contextTheme, attributionUrl)} />
+        <title>{`${title ?? getPageTitle(themeConfig ?? contextThemeConfig, metadataKey, text)} - ${getAppTitle(themeConfig ?? contextThemeConfig)}`}</title>
+        <meta
+          property="og:title"
+          content={`${title ?? getPageTitle(themeConfig ?? contextThemeConfig, metadataKey, text)} - ${getAppTitle(themeConfig ?? contextThemeConfig)}`}
+        />
+        <meta name="description" content={description ?? getPageDescription(themeConfig ?? contextThemeConfig, metadataKey, text)} key="desc" />
+        <meta property="og:description" content={description ?? getPageDescription(themeConfig ?? contextThemeConfig, metadataKey, text)} />
+        <link rel="canonical" href={getCanonicalUrl(router, theme, attributionUrl)} />
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -58,7 +58,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
   return (
     <Layout
       title={family.title}
-      description={getFamilyMetaDescription(family.summary, "", family.category)}
+      description={getFamilyMetaDescription(family.summary, family.geographies.join(", "), family.category)}
       theme={theme}
       themeConfig={themeConfig}
       metadataKey="family"

--- a/src/components/pages/familyOriginalPage.tsx
+++ b/src/components/pages/familyOriginalPage.tsx
@@ -77,7 +77,7 @@ const documentIsPublished = (familyDocuments: TDocumentPage[], documentImportId:
   return isPublished;
 };
 
-export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page, targets = [], theme, vespaFamilyData }: IProps) => {
+export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page, targets = [], theme, themeConfig, vespaFamilyData }: IProps) => {
   // TODO remove when only the newer API endpoint is being called in getServerSideProps
   if (isNewEndpointData(page)) {
     throw new Error("Cannot render FamilyOriginalPage with V2 API data");
@@ -227,6 +227,7 @@ export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page,
       title={`${page.title}`}
       description={getFamilyMetaDescription(page.summary, geographyNames?.join(", "), page.category)}
       theme={theme}
+      themeConfig={themeConfig}
       attributionUrl={attributionUrl}
     >
       <Script id="analytics">

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -9,7 +9,7 @@ export const GeographyLitigationPage = ({ geography, theme, themeConfig }: IProp
   const pageHeaderMetadata: IPageHeaderMetadata[] = [{ label: "Metadata", value: "TODO" }];
 
   return (
-    <Layout metadataKey="geography" theme={theme} themeConfig={themeConfig} title={geography.name}>
+    <Layout metadataKey="geography" theme={theme} themeConfig={themeConfig} title={geography.name} text={geography.name}>
       <PageHeader label="Geography" title={geography.name} metadata={pageHeaderMetadata} />
       <Columns>
         <ContentsSideBar items={[]} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -22,7 +22,7 @@ import { MAX_PASSAGES, MAX_RESULTS } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { withEnvConfig } from "@/context/EnvConfig";
 import useSearch from "@/hooks/useSearch";
-import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TSlugResponse } from "@/types";
+import { TDocumentPage, TFamilyPage, TPassage, TTheme, TSearchResponse, TSlugResponse, TThemeConfig } from "@/types";
 import { CleanRouterQuery } from "@/utils/cleanRouterQuery";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { isKnowledgeGraphEnabled } from "@/utils/features";
@@ -34,6 +34,7 @@ interface IProps {
   document: TDocumentPage;
   family: TFamilyPage; // TODO switch to V2 API and use TFamilyPublic
   theme: TTheme;
+  themeConfig: TThemeConfig;
   vespaFamilyData?: TSearchResponse;
   vespaDocumentData?: TSearchResponse;
 }
@@ -62,6 +63,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
   document,
   family,
   theme,
+  themeConfig,
   vespaFamilyData,
   vespaDocumentData,
 }: IProps) => {
@@ -155,6 +157,7 @@ const DocumentPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({
       title={`${document.title}`}
       description={getDocumentDescription(document.title)}
       theme={theme}
+      themeConfig={themeConfig}
       attributionUrl={family.organisation_attribution_url}
     >
       <section
@@ -354,6 +357,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       document: documentData,
       family: familyData,
       theme: theme,
+      themeConfig: themeConfig,
       vespaFamilyData: vespaFamilyData ?? null,
       vespaDocumentData: vespaDocumentData ?? null,
     }),

--- a/src/utils/getAppTitle.ts
+++ b/src/utils/getAppTitle.ts
@@ -1,19 +1,9 @@
-import { TTheme } from "@/types";
+import { TThemeConfig } from "@/types";
 
-const DEFAULT_APP_NAME = "Climate Policy Radar";
-
-export const getAppTitle = (site: TTheme, contextTheme?: TTheme) => {
-  let title = DEFAULT_APP_NAME;
-
-  const theme = site ?? contextTheme;
-
-  switch (theme) {
-    case "cclw":
-      title = "Climate Change Laws of the World";
-      break;
-    case "mcf":
-      title = "Climate Project Explorer";
-      break;
+export const getAppTitle = (themeConfig?: TThemeConfig) => {
+  let title = "";
+  if (themeConfig) {
+    title = themeConfig.metadata.find((meta) => meta.key === "default")?.title ?? "";
   }
   return title;
 };

--- a/src/utils/getFamilyMetaDescription.ts
+++ b/src/utils/getFamilyMetaDescription.ts
@@ -6,5 +6,5 @@ const stripHtml = (html: string) => {
 };
 
 export const getFamilyMetaDescription = (summary: string, geo: string, category: TCategory) => {
-  return `${geo} | ${getCategoryName(category)} | ${stripHtml(summary).substring(0, 600)}`;
+  return `${geo} | ${getCategoryName(category) ?? category} | ${stripHtml(summary).substring(0, 600)}`;
 };

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -51,19 +51,25 @@ const config: TThemeConfig = {
   ],
   metadata: [
     {
+      // default - used for app title (i.e. on each page after the title)
       key: "default",
-      title: "Climate Case Chart",
-      description: "WIP",
+      title: "Sabin Center for Climate Change Law",
+      description: "",
+    },
+    {
+      key: "homepage",
+      title: "Climate Change Litigation Databases",
+      description:
+        "Sabin Center for Climate Change Law provides two comprehensive databases of climate change caselaw - US Climate Change Litigation and Global Climate Change Litigation.",
     },
     {
       key: "geography",
-      title: "{text} climate laws and policies",
-      description:
-        "Find climate change laws, policies, targets and other climate policy data and indicators for {text}, alongside information about their legislative process.",
+      title: "{text} litigation",
+      description: "Find climate change litigation data and indicators for {text}.",
     },
     {
       key: "search",
-      title: "Law and Policy Search",
+      title: "Search the Climate Case Chart database",
       description: "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country.",
     },
   ],

--- a/themes/ccc/constants/pageMetadata.ts
+++ b/themes/ccc/constants/pageMetadata.ts
@@ -1,4 +1,0 @@
-export const PAGE_DESCRIPTION =
-  "The Climate Change Laws of the World database gives you access to national-level climate change legislation and policies from around the world.";
-
-export const APP_NAME = "cclw";

--- a/themes/ccc/pages/homepage.tsx
+++ b/themes/ccc/pages/homepage.tsx
@@ -2,22 +2,25 @@ import dynamic from "next/dynamic";
 
 import Header from "@/ccc/components/Header";
 import { Hero } from "@/ccc/components/Hero";
-import { APP_NAME, PAGE_DESCRIPTION } from "@/ccc/constants/pageMetadata";
 import Layout from "@/components/layouts/LandingPage";
 import { FullWidth } from "@/components/panels/FullWidth";
+import { TTheme, TThemeConfig } from "@/types";
 
 const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
   loading: () => <p>Loading world map...</p>,
   ssr: false,
 });
+
 interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
+  theme: TTheme;
+  themeConfig: TThemeConfig;
 }
 
-const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
+const LandingPage = ({ handleSearchInput, searchInput, theme, themeConfig }: IProps) => {
   return (
-    <Layout title="Climate Case Chart" theme={APP_NAME} description={PAGE_DESCRIPTION}>
+    <Layout theme={theme} themeConfig={themeConfig} metadataKey="homepage">
       <main id="main" className="h-screen flex flex-col bg-[rebeccapurple]">
         <Header />
         <div className="flex-1 flex items-center justify-center">

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -149,8 +149,14 @@ const config: TThemeConfig = {
   ],
   metadata: [
     {
+      // default - used for app title (i.e. on each page after the title)
       key: "default",
       title: "Climate Change Laws of the World",
+      description: "",
+    },
+    {
+      key: "homepage",
+      title: "Law and Policy Search",
       description:
         "The Climate Change Laws of the World database gives you access to national-level climate change legislation and policies from around the world.",
     },
@@ -162,7 +168,7 @@ const config: TThemeConfig = {
     },
     {
       key: "search",
-      title: "Law and Policy Search",
+      title: "Search the Climate Change Laws of the World database",
       description: "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country.",
     },
   ],

--- a/themes/cclw/constants/pageMetadata.ts
+++ b/themes/cclw/constants/pageMetadata.ts
@@ -1,4 +1,0 @@
-export const PAGE_DESCRIPTION =
-  "The Climate Change Laws of the World database gives you access to national-level climate change legislation and policies from around the world.";
-
-export const APP_NAME = "cclw";

--- a/themes/cclw/pages/homepage.tsx
+++ b/themes/cclw/pages/homepage.tsx
@@ -11,11 +11,10 @@ import { HelpUs } from "@/cclw/components/HelpUs";
 import { Hero } from "@/cclw/components/Hero";
 import { Partners } from "@/cclw/components/Partners";
 import { PoweredBy } from "@/cclw/components/PoweredBy";
-import { PAGE_DESCRIPTION, APP_NAME } from "@/cclw/constants/pageMetadata";
 import Layout from "@/components/layouts/LandingPage";
-import { FullWidth } from "@/components/panels/FullWidth";
 import { SiteWidth } from "@/components/panels/SiteWidth";
 import { Heading } from "@/components/typography/Heading";
+import { TTheme, TThemeConfig } from "@/types";
 
 // TODO temporarily disabled: https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349
 // const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
@@ -26,11 +25,13 @@ import { Heading } from "@/components/typography/Heading";
 interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
+  theme: TTheme;
+  themeConfig: TThemeConfig;
 }
 
-const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
+const LandingPage = ({ handleSearchInput, searchInput, theme, themeConfig }: IProps) => {
   return (
-    <Layout title="Law and Policy Search" theme={APP_NAME} description={PAGE_DESCRIPTION}>
+    <Layout theme={theme} themeConfig={themeConfig} metadataKey="homepage">
       <main id="main" className="flex flex-col flex-1">
         <div className="bg-cclw-dark">
           <BrazilImplementingNDCBanner />

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -334,20 +334,26 @@ const config: TThemeConfig = {
   ],
   metadata: [
     {
+      // default - used for app title (i.e. on each page after the title)
       key: "default",
       title: "Climate Policy Radar",
+      description: "",
+    },
+    {
+      key: "homepage",
+      title: "Law and Policy Search",
       description:
         "Use Climate Policy Radar's data science and AI-powered platform to search and explore thousands of climate change laws, policies and legal cases worldwide.",
     },
     {
       key: "geography",
-      title: "{text} climate laws and policies",
+      title: "{text} climate laws, policies and reports",
       description:
         "Find climate change laws, policies, targets and other climate policy data and indicators for {text}, alongside information about their legislative process.",
     },
     {
       key: "search",
-      title: "Law and Policy Search",
+      title: "Search the Climate Policy Radar database",
       description: "Quickly and easily search through the complete text of thousands of climate change law and policy documents from every country.",
     },
   ],

--- a/themes/cpr/constants/pageMetadata.ts
+++ b/themes/cpr/constants/pageMetadata.ts
@@ -1,4 +1,0 @@
-export const PAGE_DESCRIPTION =
-  "Use Climate Policy Radar’s data science and AI-powered platform to search and explore thousands of climate change laws, policies and legal cases worldwide";
-
-export const APP_NAME = "cpr";

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -10,6 +10,7 @@ import LandingSearchForm from "@/cpr/components/LandingSearchForm";
 import Partners from "@/cpr/components/Partners";
 import Summary from "@/cpr/components/Summary";
 import { PAGE_DESCRIPTION, APP_NAME } from "@/cpr/constants/pageMetadata";
+import { TTheme, TThemeConfig } from "@/types";
 
 // TODO temporarily disabled: https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349
 // const WorldMap = dynamic(() => import("@/components/map/WorldMap"), {
@@ -26,6 +27,8 @@ export interface IProps {
   handleSearchChange: (type: string, value: any) => void;
   searchInput: string;
   exactMatch: boolean;
+  theme: TTheme;
+  themeConfig: TThemeConfig;
 }
 
 const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exactMatch }: IProps) => {

--- a/themes/cpr/pages/homepage.tsx
+++ b/themes/cpr/pages/homepage.tsx
@@ -9,7 +9,6 @@ import LandingPageLinks from "@/cpr/components/LandingPageLinks";
 import LandingSearchForm from "@/cpr/components/LandingSearchForm";
 import Partners from "@/cpr/components/Partners";
 import Summary from "@/cpr/components/Summary";
-import { PAGE_DESCRIPTION, APP_NAME } from "@/cpr/constants/pageMetadata";
 import { TTheme, TThemeConfig } from "@/types";
 
 // TODO temporarily disabled: https://climate-policy-radar.slack.com/archives/C08Q8GD1CUT/p1745941756888349
@@ -31,9 +30,9 @@ export interface IProps {
   themeConfig: TThemeConfig;
 }
 
-const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exactMatch }: IProps) => {
+const LandingPage = ({ handleSearchInput, handleSearchChange, searchInput, exactMatch, theme, themeConfig }: IProps) => {
   return (
-    <Layout title="Law and Policy Search" theme={APP_NAME} description={PAGE_DESCRIPTION}>
+    <Layout metadataKey="homepage" theme={theme} themeConfig={themeConfig}>
       <div className="relative">
         <Header />
         <main className="relative h-full">

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -117,6 +117,11 @@ const config: TThemeConfig = {
     {
       key: "default",
       title: "Climate Project Explorer",
+      description: "",
+    },
+    {
+      key: "homepage",
+      title: "Climate Fund Search",
       description:
         "Climate Project Explorer is a single point of entry for navigating and exploring the MCF's documents (including project documents and policies).",
     },
@@ -127,7 +132,7 @@ const config: TThemeConfig = {
     },
     {
       key: "search",
-      title: "Climate Project Search",
+      title: "Search the Climate Project Explorer database",
       description: "Quickly and easily search through the complete text of thousands of project documents.",
     },
   ],

--- a/themes/mcf/constants/pageMetadata.ts
+++ b/themes/mcf/constants/pageMetadata.ts
@@ -1,4 +1,0 @@
-export const PAGE_DESCRIPTION =
-  "Climate Project Explorer is a single point of entry for navigating and exploring the MCF's documents (including project documents and policies).";
-
-export const APP_NAME = "mcf";

--- a/themes/mcf/pages/homepage.tsx
+++ b/themes/mcf/pages/homepage.tsx
@@ -10,16 +10,18 @@ import {
   ContextualSearchContent,
   AboutClimateProjectExplorer,
 } from "@/mcf/components";
-import { PAGE_DESCRIPTION, APP_NAME } from "@/mcf/constants/pageMetadata";
+import { TTheme, TThemeConfig } from "@/types";
 
 interface IProps {
   handleSearchInput: (term: string, filter?: string, filterValue?: string) => void;
   searchInput: string;
+  theme: TTheme;
+  themeConfig: TThemeConfig;
 }
 
-const LandingPage = ({ handleSearchInput, searchInput }: IProps) => {
+const LandingPage = ({ handleSearchInput, searchInput, theme, themeConfig }: IProps) => {
   return (
-    <Layout title="Climate Fund Search" theme={APP_NAME} description={PAGE_DESCRIPTION}>
+    <Layout theme={theme} themeConfig={themeConfig} metadataKey="homepage">
       <main id="main" className="flex flex-col flex-1">
         <div>
           <Header />


### PR DESCRIPTION
# What's changed
- Meta data is now driven by the config file for the given theme
- If not provided by the server-side render, the fallback is to use the context (in the client-side - see content pages which are client-side rendered (this is a known `TODO`))
- Update meta titles for the search pages for each theme as per ticket

## Why?
- More consistent and scalable to new pages rather than constant files that we need to remember to create
- More scalable for when we want to drive the data from an external provider (CMS, etc)
