### PR TITLE
Fix getMostSpecificCourts looping infinitely

### DIFF
--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -52,7 +52,7 @@ const getMostSpecificCourts = (concepts: TFamilyConcept[]): TFamilyConcept[] => 
   // On each loop, remove legal entities without parents. Stops when the deepest level court remains
   while (courtConcepts.length > 1) {
     const moreSpecificConcepts = courtConcepts.filter((concept) =>
-      concept.subconcept_of_labels.some((id) => concepts.findIndex((con) => con.id === id) !== -1)
+      concept.subconcept_of_labels.some((id) => courtConcepts.findIndex((con) => con.id === id) !== -1)
     );
 
     // Prevent a situation where number of concepts goes from 2 to 0 on the last loop

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -56,7 +56,11 @@ const getMostSpecificCourts = (concepts: TFamilyConcept[]): TFamilyConcept[] => 
     );
 
     // Prevent a situation where number of concepts goes from 2 to 0 on the last loop
-    if (moreSpecificConcepts.length === 0) return courtConcepts;
+    if (moreSpecificConcepts.length === 0) {
+      return courtConcepts;
+    } else {
+      courtConcepts = moreSpecificConcepts;
+    }
   }
 
   return courtConcepts;


### PR DESCRIPTION
# What's changed

Fixed `getMostSpecificCourts` while loop not altering the array that it was looping around, so the list of court concepts never got shorter. This was overlooked as part of my previous fix for situations where there could be multiple bottom-level courts that need returning.

## Why?

Local env hanging when trying to load family pages.