### PR TITLE
Update jotform link for CCC data download

### DIFF
--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -31,7 +31,7 @@ const config: TThemeConfig = {
   links: [
     {
       key: "download-database",
-      url: "https://form.jotform.com/250202141318339",
+      url: "https://form.jotform.com/252292116187356",
     },
   ],
   metadata: [


### PR DESCRIPTION
# What's changed

Updated jotform link from CPR one to CCC one.

## Why?

When the user clicks download 'whole database', the download link should be specific to the custom app the user is on.


