### PR TITLE
Remove min-height on search results

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -624,7 +624,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                           </div>
                         </div>
                       </div>
-                      <section data-cy="search-results" className="min-h-screen">
+                      <section data-cy="search-results">
                         <h2 className="sr-only">Search results</h2>
                         {showCorporateDisclosuresInformation(router.query) && (
                           <Warning variant="info">


### PR DESCRIPTION
# What's changed
- Removing min-height on the list of search results

## Why?
- Causing the pagination to be hidden when we get few results per page
- No longer needed because the filters provide the height for the page now

## Screenshots?
