### PR TITLE
Update workflow to work for CPR prod & staging

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,11 +1,27 @@
 name: Smoke tests
-on: workflow_call
-# trunk-ignore(checkov/CKV2_GHA_1)
-permissions: write-all
+on:
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      environment:
+        type: environment
+        description: Environment
+        required: true
+        default: staging
+      theme:
+        description: Theme of the custom app to smoke test
+        required: true
+        type: choice
+        options:
+          - cpr
+
 jobs:
   test-e2e:
-    timeout-minutes: 60
+    environment: ${{ github.event.inputs.environment }}
+    name: Smoke Test [${{ github.event.inputs.theme }} - ${{ github.event.inputs.environment }}]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: write-all # trunk-ignore(checkov/CKV2_GHA_1)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -13,25 +29,10 @@ jobs:
           node-version: 22.12.0
       - run: npm ci
       - run: cp .env.example .env
-      - run: npm run build
+      - run: THEME=${{ github.event.inputs.theme }} npm run build
         env:
           NODE_ENV: production
       - run: npx playwright install --with-deps
       - run: npx playwright test
         env:
-          PLAYWRIGHT_ENV: production
-      - name: Upload Test Result
-        # Upload the results even if the tests fails to Trunk.io
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: trunk-io/analytics-uploader@main
-        with:
-          junit-paths: "**/playwright.xml"
-          org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
-          token: ${{ secrets.TRUNK_TOKEN }}
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
+          PLAYWRIGHT_ENV: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
Update the smoke test workflow to work for both CPR production and staging.

Next steps:
- Get this workflow to work for the other custom apps, because at the moment it is CPR specific