### PR TITLE
Shard playright smoke tests

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -141,7 +141,6 @@ jobs:
       fail-fast: false
       matrix:
         theme: [cpr, cclw, mcf]
-
     env:
       PLAYWRIGHT_BROWSERS_PATH: $HOME/.cache/ms-playwright
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -182,7 +182,6 @@ jobs:
       fail-fast: false
       matrix:
         theme: [cpr, cclw, mcf]
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
# What's changed

Attempt to shard the playright tests by splitting tests across multiple CI jobs.

## Why?

Hoping this will half the time taken to actually run the playright smoke tests (note: key here is the actual test step, it shouldn't affect how long it takes to download & install the dependencies for example).

