### PR TITLE
fix: make deploy-production deployable

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,10 +17,6 @@ on:
           - cclw
           - mcf
           - ccc
-      sha:
-        description: Git SHA to deploy
-        type: string
-        required: true
 
 permissions:
   id-token: write
@@ -32,6 +28,10 @@ jobs:
     environment:
       name: production
     steps:
+      - if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "This workflow can only be run from main."
+          exit 1
       - uses: actions/checkout@v4
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4.1.0

--- a/README.md
+++ b/README.md
@@ -87,11 +87,21 @@ npm run test-e2e
 
 ## 🏭 Deployment
 
-Containers are automatically:
+- Go to the [Deploy to production](https://github.com/climatepolicyradar/navigator-frontend/actions/workflows/deploy-production.yml)
+  GitHub action
+- You can only deploy from from `main`
+- Select the app you want to deploy
+- "Run workflow"
 
-1. Built and tested via GitHub Actions
-2. Pushed to AWS ECR
-3. Deployed via [navigator-infra](https://github.com/climatepolicyradar/navigator-infra)
+This builds and pushes to the ECR `latest` tag which then
+[automatically triggers a deploy](https://docs.aws.amazon.com/apprunner/latest/dg/manage-deploy.html).
+
+### 🔙 Rollback
+
+- To rollback find [the merge commit](https://github.com/climatepolicyradar/navigator-frontend/commits/main/)
+  which will have a corresponding ECR container built
+- use the navigator-infra [Deploy frontend GitHub action](https://github.com/climatepolicyradar/navigator-infra/actions/workflows/deploy-frontend.yml)
+  to deploy the SHA
 
 ## 🎨 Theming
 


### PR DESCRIPTION
# What's changed
- allows us to deploy `main` => production
- remove unused code

## Why?
Having a different deploy cycle to other apps is confusing.

For clarity - this doesn't auto deploy - it just allows us to manually use the same mechanic we do elsewhere i.e. push to `latest` in ECR.
