### PR TITLE
Remove not applicable topics label from family concept filters quick search

### DIFF
--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -135,7 +135,6 @@ export const FamilyConceptPicker = ({
             />
           </div>
         </div>
-        {search !== "" && <p className="text-xs italic">The results below are also filtered using the topic's alternative labels</p>}
         <div className={`flex flex-col text-sm border-t border-border-light ${sort === "A-Z" ? "gap-2 border-t-0" : ""}`}>
           {/* GROUPED SORT */}
           {sort === "Grouped" &&


### PR DESCRIPTION
# What's changed
- remove the label that shows up when users start typing in the quick search of any of the legal concept filters as the text only applies to topics 

## Screenshots?
<img width="737" height="320" alt="Screenshot 2025-08-19 at 17 00 07" src="https://github.com/user-attachments/assets/ed6dcbe0-1ad8-4aa5-a96d-43656ccf738d" />
<img width="740" height="316" alt="Screenshot 2025-08-19 at 16 59 50" src="https://github.com/user-attachments/assets/2dc90fd1-a875-4ad8-94ef-6baf4a02507e" />
<img width="752" height="326" alt="Screenshot 2025-08-19 at 16 59 41" src="https://github.com/user-attachments/assets/49824a76-4d20-4c01-a3ca-d4b6cb9747b6" />
