### PR TITLE
APP-1018: JSON-LD for litigation cases

### DIFF
--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -1,3 +1,5 @@
+import Head from "next/head";
+
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Columns } from "@/components/atoms/columns/Columns";
 import { DocumentsBlock } from "@/components/blocks/documentsBlock/DocumentsBlock";
@@ -10,12 +12,31 @@ import { IPageHeaderMetadata, PageHeader } from "@/components/organisms/pageHead
 import { FAMILY_PAGE_SIDE_BAR_ITEMS } from "@/constants/sideBarItems";
 import { getCategoryName } from "@/helpers/getCategoryName";
 import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { TFamilyPublic } from "@/types";
 import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
 import { getFamilyMetadata } from "@/utils/getFamilyMetadata";
 import { joinNodes } from "@/utils/reactNode";
 import { convertDate } from "@/utils/timedate";
 
 import { IProps, isNewEndpointData } from "./familyOriginalPage";
+
+const generateLitigationJSONLD = (familyCase: TFamilyPublic) => {
+  let jsonLd = `"@context": "https://schema.org",
+    "@type": "Legislation",
+    "@id": "${process.env.HOSTNAME}/document/${familyCase.slug}",
+    "url": "${process.env.HOSTNAME}/document/${familyCase.slug}",
+    "name": "${familyCase.title}",
+    "description": "${familyCase.summary}",
+    "legislationDate": "${familyCase.published_date}"`;
+
+  if (familyCase.metadata.case_number.length) {
+    jsonLd += `,
+    "legislationIdentifier": "${familyCase.metadata.case_number}"
+    `;
+  }
+
+  return jsonLd;
+};
 
 export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, themeConfig }: IProps) => {
   // TODO remove when only the newer API endpoint is being called in getServerSideProps
@@ -78,6 +99,14 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
           </Section>
         </main>
       </Columns>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: `{${generateLitigationJSONLD(family)}}`,
+          }}
+        />
+      </Head>
     </Layout>
   );
 };

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -1,3 +1,4 @@
+import sortBy from "lodash/sortBy";
 import Head from "next/head";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
@@ -12,7 +13,7 @@ import { IPageHeaderMetadata, PageHeader } from "@/components/organisms/pageHead
 import { FAMILY_PAGE_SIDE_BAR_ITEMS } from "@/constants/sideBarItems";
 import { getCategoryName } from "@/helpers/getCategoryName";
 import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
-import { TFamilyPublic } from "@/types";
+import { TFamilyPublic, TGeography, TGeographySubdivision } from "@/types";
 import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
 import { getFamilyMetadata } from "@/utils/getFamilyMetadata";
 import { joinNodes } from "@/utils/reactNode";
@@ -20,7 +21,9 @@ import { convertDate } from "@/utils/timedate";
 
 import { IProps, isNewEndpointData } from "./familyOriginalPage";
 
-const generateLitigationJSONLD = (familyCase: TFamilyPublic) => {
+const generateLitigationJSONLD = (familyCase: TFamilyPublic, countries: TGeography[], subdivisions: TGeographySubdivision[]) => {
+  const geosOrdered = sortBy(familyCase.geographies, [(geo) => geo.length !== 3, (geo) => geo.toLowerCase()]);
+
   let jsonLd = `"@context": "https://schema.org",
     "@type": "Legislation",
     "@id": "${process.env.HOSTNAME}/document/${familyCase.slug}",
@@ -33,6 +36,33 @@ const generateLitigationJSONLD = (familyCase: TFamilyPublic) => {
     jsonLd += `,
     "legislationIdentifier": "${familyCase.metadata.case_number}"
     `;
+  }
+
+  if (geosOrdered.length > 0) {
+    let jsonLdGeos = [];
+    geosOrdered.forEach((geo) => {
+      const countryName = getCountryName(geo, countries);
+      if (countryName) {
+        jsonLdGeos.push(`{
+          "@type": "Country",
+          "name": "${countryName}",
+          "url": "${process.env.HOSTNAME}/geographies/${getCountrySlug(geo, countries)}"
+        }`);
+      } else {
+        const subdivision = subdivisions.find((sub) => sub.code === geo);
+        if (subdivision) {
+          jsonLdGeos.push(`{
+            "@type": "AdministrativeArea",
+            "name": "${subdivision.name}",
+            "url": "${process.env.HOSTNAME}/geographies/${subdivision.code}"
+          }`);
+        }
+      }
+    });
+    if (jsonLdGeos.length > 0) {
+      jsonLd += `,
+      "jurisdiction": [${jsonLdGeos.join(", ")}]`;
+    }
   }
 
   return jsonLd;
@@ -103,7 +133,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: `{${generateLitigationJSONLD(family)}}`,
+            __html: `{${generateLitigationJSONLD(family, countries, subdivisions)}}`,
           }}
         />
       </Head>

--- a/src/utils/json-ld/getLitigationCaseJSONLD.ts
+++ b/src/utils/json-ld/getLitigationCaseJSONLD.ts
@@ -1,0 +1,145 @@
+import sortBy from "lodash/sortBy";
+
+import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
+import { TFamilyPublic, TGeography, TGeographySubdivision } from "@/types";
+
+/**
+ * Generates JSON-LD structured data for a litigation case.
+ * @param familyCase - The family case data.
+ * @param countries - List of countries for geography mapping.
+ * @param subdivisions - List of subdivisions for geography mapping.
+ * @returns JSON-LD string for the litigation case.
+ */
+
+/*
+ * IMPORTANT READING: https://schema.org/Legislation
+ * We've taken the schema for legislation as a base for litigation cases.
+ * This is because litigation cases are often treated as legal documents and can be structured similarly.
+ * The schema can be validated here: https://validator.schema.org/
+ */
+
+export const getLitigationJSONLD = (familyCase: TFamilyPublic, countries: TGeography[], subdivisions: TGeographySubdivision[]) => {
+  const geosOrdered = sortBy(familyCase.geographies, [(geo) => geo.length !== 3, (geo) => geo.toLowerCase()]);
+
+  // Default JSON-LD legislation structure
+  let jsonLd = `"@context": "https://schema.org",
+    "@type": "Legislation",
+    "@id": "${process.env.HOSTNAME}/document/${familyCase.slug}",
+    "url": "${process.env.HOSTNAME}/document/${familyCase.slug}",
+    "isAccessibleForFree": true,
+    "name": "${familyCase.title}",
+    "description": "${familyCase.summary}",
+    "dateCreated": "${familyCase.published_date}",
+    "dateModified": "${familyCase.last_updated_date}"`;
+
+  if (familyCase.corpus?.organisation) {
+    jsonLd += `,
+    "publisher": {
+      "@type": "Organization",
+      "name": "${familyCase.corpus.organisation.name}",
+      "url": "${familyCase.corpus.organisation.attribution_url}"
+    }`;
+  }
+
+  // Case metadata for JSON-LD
+  if (familyCase.metadata.case_number.length) {
+    jsonLd += `,
+    "legislationIdentifier": "${familyCase.metadata.case_number}"
+    `;
+  }
+
+  // Geography related JSON-LD
+  if (geosOrdered.length > 0) {
+    let jurisdictions = [];
+    let spatialCoverage = [];
+    geosOrdered.forEach((geo) => {
+      const countryName = getCountryName(geo, countries);
+      if (countryName) {
+        jurisdictions.push(`{
+          "@type": "Country",
+          "name": "${countryName}",
+          "url": "${process.env.HOSTNAME}/geographies/${getCountrySlug(geo, countries)}"
+        }`);
+        spatialCoverage.push(`{
+          "@type": "Place",
+          "name": "${countryName}",
+          "url": "${process.env.HOSTNAME}/geographies/${getCountrySlug(geo, countries)}"
+        }`);
+      } else {
+        const subdivision = subdivisions.find((sub) => sub.code === geo);
+        if (subdivision) {
+          jurisdictions.push(`{
+            "@type": "AdministrativeArea",
+            "name": "${subdivision.name}",
+            "url": "${process.env.HOSTNAME}/geographies/${subdivision.code}"
+          }`);
+          spatialCoverage.push(`{
+            "@type": "Place",
+            "name": "${subdivision.name}",
+            "url": "${process.env.HOSTNAME}/geographies/${subdivision.code}"
+          }`);
+        }
+      }
+    });
+    if (spatialCoverage.length > 0) {
+      jsonLd += `,
+      "spatialCoverage": [${spatialCoverage.join(", ")}]`;
+    }
+  }
+
+  // Translating concepts into JSON-LD attributes
+  if (familyCase.concepts.length > 0) {
+    // Add any concepts of principle laws as keywords
+    const keywords = familyCase.concepts.filter((concept) => concept.type === "law");
+    jsonLd += `,
+    "keywords": [${keywords.map((keyword) => `"${keyword.preferred_label}"`).join(", ")}]`;
+
+    // Add legal entities as jurisdictions
+    const jurisdictions = familyCase.concepts.filter((concept) => concept.type === "legal_entity");
+    if (jurisdictions.length > 0) {
+      jsonLd += `,
+      "jurisdiction": [${jurisdictions
+        .map(
+          (jurisdiction) => `{
+        "@type": "AdministrativeArea",
+        "name": "${jurisdiction.preferred_label}"
+      }`
+        )
+        .join(", ")}]`;
+    }
+
+    // Add legal categories as about
+    const legalCategories = familyCase.concepts.filter((concept) => concept.type === "legal_category");
+    if (legalCategories.length > 0) {
+      jsonLd += `,
+      "about": [${legalCategories
+        .map(
+          (category) => `{
+        "@type": "Thing",
+        "name": "${category.preferred_label}"
+      }`
+        )
+        .join(", ")}]`;
+    }
+  }
+
+  // Documents as work examples
+  if (familyCase.documents && familyCase.documents.length > 0) {
+    jsonLd += `,
+    "workExample": [${familyCase.documents
+      .map(
+        (doc) => `{
+      "@type": "Legislation",
+      "@id": "${process.env.HOSTNAME}/documents/${doc.slug}",
+      "url": "${process.env.HOSTNAME}/documents/${doc.slug}",
+      "isAccessibleForFree": true,
+      "name": "${doc.title}",
+      "description": "${doc.events[0]?.metadata?.description || ""}",
+      "legislationDate": "${doc.events[0]?.date}"
+    }`
+      )
+      .join(", ")}]`;
+  }
+
+  return jsonLd;
+};


### PR DESCRIPTION
# What's changed
- Adding a JSON-LD schema to the litigation case page, driven from the data on the page

## Why?
- JSON-LD makes legislation data machine-readable, interoperable, and easily discoverable on the web

## Screenshots?
<img width="1360" height="1035" alt="Screenshot 2025-08-20 at 15 16 28" src="https://github.com/user-attachments/assets/41da283c-6325-4101-bf63-4b669be99406" />

Mapping notes:
 • ‎`@id` and ‎`mainEntityOfPage` use the case slug URL.
 • ‎`name`, ‎`description`, and ‎`legislationIdentifier` are direct mappings.
 • ‎`jurisdiction` uses AdministrativeArea for “Federal Courts” and “D.R.I.”
 • ‎`about` covers legal categories.
 • ‎`legislationPassedBy` is mapped to the organization “Sabin” (publisher/attribution).
 • ‎`legislationLegalForce` is set to “InForce” (case is active).
 • ‎`keywords` include principal laws.
 • ‎`spatialCoverage` uses geographies.
 • ‎`dateCreated` and ‎`dateModified` use published and last updated dates.
 • ‎`workExample` lists the main documents as Legislation objects, with th