### PR TITLE
feat: add vespa-search-on-geographies feature flag

### DIFF
--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -2,6 +2,6 @@ export const featureFlagKeys = ["concepts-v1", "litigation", "unfccc-filters"] a
 export type TFeatureFlag = (typeof featureFlagKeys)[number];
 export type TFeatureFlags = Record<TFeatureFlag, boolean>;
 
-export const configFeatureKeys = ["familyConceptsSearch", "knowledgeGraph", "litigation", "searchFamilySummary"] as const;
+export const configFeatureKeys = ["familyConceptsSearch", "knowledgeGraph", "litigation", "searchFamilySummary", "vespaSearchOnGeographies"] as const;
 export type TConfigFeature = (typeof configFeatureKeys)[number];
 export type TConfigFeatures = Record<TConfigFeature, boolean>;

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -41,3 +41,9 @@ export const isSearchFamilySummaryEnabled = (themeConfig: TThemeConfig) =>
   isFeatureEnabled({
     configFeature: themeConfig.features.searchFamilySummary,
   });
+
+export const isVespaSearchOnGeographiesEnabled = (featureFlags: TFeatureFlags, themeConfig: TThemeConfig) =>
+  isFeatureEnabled({
+    configFeature: themeConfig.features.vespaSearchOnGeographies,
+    featureFlag: featureFlags["vespa-search-on-geographies"],
+  });


### PR DESCRIPTION
# What's changed
Adds the `vespa-search-on-geographies` switch

## Why?
This will enable us to move towards using the vespa search endpoint on our geos pages removing complexity in our code and UI.

Towards https://linear.app/climate-policy-radar/issue/APP-1066/use-document-type-as-the-grouped-lists-on-geography-pages
