### PR TITLE
feat: start using Vespa search results on geo pages

### DIFF
--- a/src/components/pages/geographyOriginalPage.tsx
+++ b/src/components/pages/geographyOriginalPage.tsx
@@ -217,10 +217,6 @@ export const GeographyOriginalPage = ({ geography, summary, targets, theme, them
     }
   };
 
-  const renderVespaSearchResults = (vespaSearchResults: TSearch) => {
-    vespaSearchResults;
-  };
-
   return (
     <Layout theme={theme} themeConfig={themeConfig} metadataKey="geography" text={geography.name}>
       {!geography ? (

--- a/src/components/pages/geographyOriginalPage.tsx
+++ b/src/components/pages/geographyOriginalPage.tsx
@@ -28,6 +28,7 @@ import {
   TGeographySubdivision,
   TGeographySubDivisionNew,
   TGeographySummary,
+  TSearch,
   TTarget,
   TTheme,
   TThemeConfig,
@@ -42,6 +43,7 @@ export interface IProps {
   targets: TTarget[];
   theme: TTheme;
   themeConfig: TThemeConfig;
+  vespaSearchResults?: TSearch;
 }
 
 const categories: { title: TDocumentCategory; slug: string }[] = [
@@ -56,7 +58,7 @@ const categories: { title: TDocumentCategory; slug: string }[] = [
 
 const MAX_NUMBER_OF_FAMILIES = 3;
 
-export const GeographyOriginalPage = ({ geography, summary, targets, theme, themeConfig }: IProps) => {
+export const GeographyOriginalPage = ({ geography, summary, targets, theme, themeConfig, vespaSearchResults }: IProps) => {
   const router = useRouter();
   const startingNumberOfTargetsToDisplay = 5;
   const [numberOfTargetsToDisplay, setNumberOfTargetsToDisplay] = useState(startingNumberOfTargetsToDisplay);
@@ -215,6 +217,10 @@ export const GeographyOriginalPage = ({ geography, summary, targets, theme, them
     }
   };
 
+  const renderVespaSearchResults = (vespaSearchResults: TSearch) => {
+    vespaSearchResults;
+  };
+
   return (
     <Layout theme={theme} themeConfig={themeConfig} metadataKey="geography" text={geography.name}>
       {!geography ? (
@@ -263,7 +269,7 @@ export const GeographyOriginalPage = ({ geography, summary, targets, theme, them
               <section className="mt-8">
                 <Heading level={2}>Documents</Heading>
               </section>
-              {hasFamilies && (
+              {!vespaSearchResults && hasFamilies && (
                 <>
                   <section className="" data-cy="top-documents">
                     <div className="my-4 md:flex">
@@ -283,6 +289,31 @@ export const GeographyOriginalPage = ({ geography, summary, targets, theme, them
                   )}
                 </>
               )}
+              {vespaSearchResults && (
+                <>
+                  <section className="" data-cy="top-documents">
+                    <div className="my-4 md:flex">
+                      <div className="flex-grow">
+                        <TabbedNav activeItem={selectedCategory} items={documentCategories} handleTabClick={handleDocumentCategoryClick} />
+                      </div>
+                    </div>
+                    <ol className="mb-10">
+                      {vespaSearchResults.families.map((family) => (
+                        <FamilyListItem family={family} key={family.family_slug} />
+                      ))}
+                    </ol>
+                  </section>
+                  {selectedCategory !== "Litigation" && (
+                    <div data-cy="see-more-button">
+                      <Button rounded variant="outlined" className="my-5" onClick={handleDocumentSeeMoreClick}>
+                        View more documents
+                      </Button>
+                      <Divider />
+                    </div>
+                  )}
+                </>
+              )}
+
               {hasTargets && (
                 <>
                   <section className="mt-10" id="targets">

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -7,21 +7,13 @@ import { GeographyOriginalPage, IProps } from "@/components/pages/geographyOrigi
 import { systemGeoNames } from "@/constants/systemGeos";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { getCountryCode } from "@/helpers/getCountryFields";
-import {
-  TGeographyNewParent,
-  TGeographyStats,
-  TGeographySubdivision,
-  TGeographySubDivisionNew,
-  TGeographySummary,
-  TSearch,
-  TSearchResponse,
-} from "@/types";
+import { TGeographyNewParent, TGeographyStats, TGeographySubdivision, TGeographySubDivisionNew, TGeographySummary, TSearch } from "@/types";
 import { TTarget, TGeography, TDocumentCategory } from "@/types";
+import buildSearchQuery from "@/utils/buildSearchQuery";
 import { extractNestedData } from "@/utils/extractNestedData";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { isLitigationEnabled, isVespaSearchOnGeographiesEnabled } from "@/utils/features";
 import { readConfigFile } from "@/utils/readConfigFile";
-import buildSearchQuery from "@/utils/buildSearchQuery";
 
 const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags, themeConfig, ...props }: IProps) => {
   const litigationIsEnabled = isLitigationEnabled(featureFlags, themeConfig);

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -7,12 +7,21 @@ import { GeographyOriginalPage, IProps } from "@/components/pages/geographyOrigi
 import { systemGeoNames } from "@/constants/systemGeos";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { getCountryCode } from "@/helpers/getCountryFields";
-import { TGeographyNewParent, TGeographyStats, TGeographySubdivision, TGeographySubDivisionNew, TGeographySummary } from "@/types";
+import {
+  TGeographyNewParent,
+  TGeographyStats,
+  TGeographySubdivision,
+  TGeographySubDivisionNew,
+  TGeographySummary,
+  TSearch,
+  TSearchResponse,
+} from "@/types";
 import { TTarget, TGeography, TDocumentCategory } from "@/types";
 import { extractNestedData } from "@/utils/extractNestedData";
 import { getFeatureFlags } from "@/utils/featureFlags";
-import { isLitigationEnabled } from "@/utils/features";
+import { isLitigationEnabled, isVespaSearchOnGeographiesEnabled } from "@/utils/features";
 import { readConfigFile } from "@/utils/readConfigFile";
+import buildSearchQuery from "@/utils/buildSearchQuery";
 
 const CountryPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({ featureFlags, themeConfig, ...props }: IProps) => {
   const litigationIsEnabled = isLitigationEnabled(featureFlags, themeConfig);
@@ -30,6 +39,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const themeConfig = await readConfigFile(theme);
 
   const id = context.params.id;
+  // TODO: remove the workaround for the US
+  const slug = id === "united-states-of-america" ? "united-states" : id;
 
   if (systemGeoNames.includes(id as string)) {
     return {
@@ -72,8 +83,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   // TODO: make this not less double nested
   try {
-    // TODO: remove the workaround for the US
-    const slug = id === "united-states-of-america" ? "united-states" : id;
     const {
       data: { data: returnedData },
     }: { data: { data: TGeographyNewParent } } = await apiClient.get(`/geographies/${slug}`);
@@ -93,6 +102,25 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
+  const vespaSearchOnGeographiesEnabled = isVespaSearchOnGeographiesEnabled(featureFlags, themeConfig);
+  let vespaSearchResults: TSearch = null;
+  if (vespaSearchOnGeographiesEnabled) {
+    const searchQuery = buildSearchQuery(
+      {
+        l: slug,
+      },
+      themeConfig
+    );
+    vespaSearchResults = await backendApiClient
+      .post<TSearch>("/searches", searchQuery, {
+        headers: {
+          accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => response.data);
+  }
+
   return {
     props: withEnvConfig({
       featureFlags,
@@ -102,6 +130,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       targets: theme === "mcf" ? [] : targetsData,
       theme,
       themeConfig,
+      vespaSearchResults: vespaSearchResults,
     }),
   };
 };

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -364,7 +364,7 @@ const config: TThemeConfig = {
     knowledgeGraph: true,
     litigation: false,
     searchFamilySummary: false,
-    vespaSearchOnGeographies: false,
+    vespaSearchOnGeographies: true,
   },
 };
 

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -364,7 +364,7 @@ const config: TThemeConfig = {
     knowledgeGraph: true,
     litigation: false,
     searchFamilySummary: false,
-    vespaSearchOnGeographies: true,
+    vespaSearchOnGeographies: false,
   },
 };
 


### PR DESCRIPTION
# What's changed
Starts rendering search results from Vespa on the geographies page

## Why?
In aid of https://linear.app/climate-policy-radar/issue/APP-1066/use-document-type-as-the-grouped-lists-on-geography-pages

This is definitely a v0.1 - but trying to keep the PRs small (and hence the feature switch)
