### PR TITLE
feat: use theme config to generate family lists on geo pages

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -96,7 +96,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const vespaSearchOnGeographiesEnabled = isVespaSearchOnGeographiesEnabled(featureFlags, themeConfig);
   let vespaSearchResults: TSearch = null;
-  if (vespaSearchOnGeographiesEnabled) {
+  if (vespaSearchOnGeographiesEnabled || true) {
     const searchQuery = buildSearchQuery(
       {
         l: slug,


### PR DESCRIPTION
# What's changed
Dependant on https://github.com/climatepolicyradar/navigator-frontend/pull/717

Uses the config files to generate the filters on the pages pages.

Part of: https://linear.app/climate-policy-radar/issue/APP-1066/use-document-type-as-the-grouped-lists-on-geography-pages

## Screenshots?

https://github.com/user-attachments/assets/f994db8c-1f10-4d84-af56-9cf333ad3ad6

