### PR TITLE
APP-1068: Bug: Events table doesn't display Court properly

### DIFF
--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -93,7 +93,10 @@ export const getEventTableRows = ({
           action: event.status,
           caseNumber: family.metadata.case_number?.[0] || null,
           caseTitle: family.title,
-          court: getMostSpecificCourts(family.concepts).join(" / ") || null,
+          court:
+            getMostSpecificCourts(family.concepts)
+              .map((concept) => concept.preferred_label)
+              .join(" / ") || null,
           date: {
             display: formatDateShort(date),
             value: date.getTime(),


### PR DESCRIPTION
# What's changed

- Added a map to court concepts so that the entire object doesn't try displaying as text (`"[Object object]"`).

## Why?

Satisfies [APP-1068](https://linear.app/climate-policy-radar/issue/APP-1068/bug-events-table-doesnt-display-court-properly).

## Screenshots?

<img width="1606" height="954" alt="Screenshot 2025-08-27 at 10 48 23" src="https://github.com/user-attachments/assets/eee43c43-3bcd-4d23-9935-720da631badd" />