### PR TITLE
Feature/app 1085 world map hide show aggregated eu data checkbox

### DIFF
--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -137,10 +137,11 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
 interface IProps {
   showLitigation?: boolean;
   showCategorySelect?: boolean;
+  showEUCheckbox?: boolean;
   theme: TTheme;
 }
 
-export default function MapChart({ showLitigation = false, showCategorySelect = true, theme }: IProps) {
+export default function MapChart({ showLitigation = false, showCategorySelect = true, showEUCheckbox = false, theme }: IProps) {
   const configQuery = useConfig();
   const geographiesQuery = useGeographies();
   const { data: { countries: configCountries = [] } = {} } = configQuery;
@@ -412,23 +413,25 @@ export default function MapChart({ showLitigation = false, showCategorySelect = 
           handleZoomOut={() => setMapZoom(mapZoom - 1)}
           handleReset={handleResetMapClick}
         />
-        <div className="absolute top-0 right-0 p-4">
-          <label
-            className="checkbox-input flex items-center p-2 px-4 rounded-full cursor-pointer border border-gray-300 bg-white"
-            htmlFor="show_eu_aggregated"
-          >
-            <input
-              className="border-gray-300 cursor-pointer"
-              id="show_eu_aggregated"
-              type="checkbox"
-              name="exact_match"
-              value={0}
-              checked={showUnifiedEU}
-              onChange={() => setShowUnifiedEU(!showUnifiedEU)}
-            />
-            <span className="px-2 text-sm">Show aggregated EU data</span>
-          </label>
-        </div>
+        {showEUCheckbox && (
+          <div className="absolute top-0 right-0 p-4">
+            <label
+              className="checkbox-input flex items-center p-2 px-4 rounded-full cursor-pointer border border-gray-300 bg-white"
+              htmlFor="show_eu_aggregated"
+            >
+              <input
+                className="border-gray-300 cursor-pointer"
+                id="show_eu_aggregated"
+                type="checkbox"
+                name="exact_match"
+                value={0}
+                checked={showUnifiedEU}
+                onChange={() => setShowUnifiedEU(!showUnifiedEU)}
+              />
+              <span className="px-2 text-sm">Show aggregated EU data</span>
+            </label>
+          </div>
+        )}
       </div>
       <Legend max={getMaxValue()} showMcf={showMcf} showLitigation={showLitigation} theme={theme} />
     </>

--- a/tests/ccc/WorldMap.test.tsx
+++ b/tests/ccc/WorldMap.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { vi } from "vitest";
+
+import WorldMap from "@/components/map/WorldMap";
+import { ThemeContext } from "@/context/ThemeContext";
+import { TTheme } from "@/types";
+
+// Mock the hooks
+vi.mock("@/hooks/useConfig", () => ({
+  default: () => ({
+    data: {
+      countries: [
+        {
+          value: "GBR",
+          slug: "united-kingdom",
+          display_value: "United Kingdom",
+        },
+        {
+          value: "FRA",
+          slug: "france",
+          display_value: "France",
+        },
+        {
+          value: "DEU",
+          slug: "germany",
+          display_value: "Germany",
+        },
+        {
+          value: "EUR",
+          slug: "european-union",
+          display_value: "European Union",
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useGeographies", () => ({
+  default: () => ({
+    data: [
+      {
+        slug: "united-kingdom",
+        iso_code: "GBR",
+        family_counts: {
+          EXECUTIVE: 5,
+          LEGISLATIVE: 3,
+          UNFCCC: 2,
+          MCF: 1,
+          REPORTS: 4,
+          LITIGATION: 0,
+        },
+      },
+      {
+        slug: "france",
+        iso_code: "FRA",
+        family_counts: {
+          EXECUTIVE: 4,
+          LEGISLATIVE: 2,
+          UNFCCC: 1,
+          MCF: 0,
+          REPORTS: 3,
+          LITIGATION: 1,
+        },
+      },
+      {
+        slug: "germany",
+        iso_code: "DEU",
+        family_counts: {
+          EXECUTIVE: 6,
+          LEGISLATIVE: 4,
+          UNFCCC: 3,
+          MCF: 2,
+          REPORTS: 5,
+          LITIGATION: 2,
+        },
+      },
+      {
+        slug: "european-union",
+        iso_code: "EUR",
+        family_counts: {
+          EXECUTIVE: 15,
+          LEGISLATIVE: 9,
+          UNFCCC: 6,
+          MCF: 3,
+          REPORTS: 12,
+          LITIGATION: 3,
+        },
+      },
+    ],
+    status: "success",
+  }),
+}));
+
+vi.mock("@/hooks/useMcfData", () => ({
+  useMcfData: () => false,
+}));
+
+vi.mock("@/constants/mapEUCountries", () => ({
+  GEO_EU_COUNTRIES: ["FRA", "DEU"],
+}));
+
+vi.mock("@/constants/mapCentres", () => ({
+  GEO_CENTER_POINTS: {
+    GBR: [0, 55],
+    FRA: [2, 46],
+    DEU: [10, 51],
+    EUR: [10, 50],
+  },
+}));
+
+const theme: TTheme = "ccc";
+
+const renderWorldMap = (props: { showLitigation?: boolean; showCategorySelect?: boolean; showEUCheckbox?: boolean; theme: TTheme }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeContext.Provider value={{ theme: props.theme, themeConfig: {} as any }}>
+        <WorldMap {...props} />
+      </ThemeContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("WorldMap", () => {
+  describe("EU Checkbox visibility", () => {
+    it("should hide EU checkbox when showEUCheckbox is false", () => {
+      renderWorldMap({
+        showLitigation: false,
+        showCategorySelect: true,
+        showEUCheckbox: false,
+        theme: theme,
+      });
+
+      const euCheckbox = screen.queryByLabelText("Show aggregated EU data");
+      expect(euCheckbox).not.toBeInTheDocument();
+    });
+
+    it("should show EU checkbox when showEUCheckbox is true", () => {
+      renderWorldMap({
+        showLitigation: false,
+        showCategorySelect: true,
+        showEUCheckbox: true,
+        theme: theme,
+      });
+
+      const euCheckbox = screen.getByLabelText("Show aggregated EU data");
+      expect(euCheckbox).toBeInTheDocument();
+    });
+
+    it("should hide EU checkbox by default when showEUCheckbox is not specified", () => {
+      renderWorldMap({
+        showLitigation: false,
+        showCategorySelect: true,
+        theme: theme,
+      });
+
+      const euCheckbox = screen.queryByLabelText("Show aggregated EU data");
+      expect(euCheckbox).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/ccc/WorldMap.test.tsx
+++ b/tests/ccc/WorldMap.test.tsx
@@ -96,19 +96,6 @@ vi.mock("@/hooks/useMcfData", () => ({
   useMcfData: () => false,
 }));
 
-vi.mock("@/constants/mapEUCountries", () => ({
-  GEO_EU_COUNTRIES: ["FRA", "DEU"],
-}));
-
-vi.mock("@/constants/mapCentres", () => ({
-  GEO_CENTER_POINTS: {
-    GBR: [0, 55],
-    FRA: [2, 46],
-    DEU: [10, 51],
-    EUR: [10, 50],
-  },
-}));
-
 const theme: TTheme = "ccc";
 
 const renderWorldMap = (props: { showLitigation?: boolean; showCategorySelect?: boolean; showEUCheckbox?: boolean; theme: TTheme }) => {


### PR DESCRIPTION
# What's changed

Hide show aggregated EU checkbox in World Map by default

## Why?

There is a bug that means that the counts of families is not aggregated for EU member states.

## Screenshots?

<img width="1431" height="770" alt="image" src="https://github.com/user-attachments/assets/d16bada9-38e6-4477-8309-fbfca684cfb8" />
