### PR TITLE
feat: sunset geography v1 on litigation geography page

### DIFF
--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -33,9 +33,9 @@ export const GeographyLitigationPage = ({ summary, targets, theme, themeConfig, 
             <MetadataBlock title="Statistics" metadata={getGeographyMetaData(geographyV2.statistics)} id="section-statistics" />
           )}
           <TargetsBlock targets={publishedTargets} theme={theme} />
-          {geographyV2?.statistics.legislative_process && (
+          {geographyV2.statistics?.legislative_process && (
             <TextBlock id="section-legislative-process" title="Legislative process">
-              <div className="text-content" dangerouslySetInnerHTML={{ __html: geographyV2?.statistics.legislative_process }} />
+              <div className="text-content" dangerouslySetInnerHTML={{ __html: geographyV2.statistics?.legislative_process }} />
             </TextBlock>
           )}
           <Section id="section-debug" title="Debug">

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -15,29 +15,30 @@ import { RecentFamiliesBlock } from "../blocks/recentFamiliesBlock/RecentFamilie
 import { TargetsBlock } from "../blocks/targetsBlock/TargetsBlock";
 import { TextBlock } from "../blocks/textBlock/TextBlock";
 
-export const GeographyLitigationPage = ({ geography, summary, targets, theme, themeConfig, geographyV2 }: IProps) => {
+export const GeographyLitigationPage = ({ summary, targets, theme, themeConfig, geographyV2 }: IProps) => {
   const categorySummaries = themeConfig.documentCategories.map((category) => getFamilyCategorySummary(summary, category));
   const publishedTargets = sortFilterTargets(targets);
 
-  const sidebarItems = getGeographyPageSidebarItems(geography, publishedTargets);
+  const sidebarItems = getGeographyPageSidebarItems(geographyV2, publishedTargets);
 
   return (
-    <Layout metadataKey="geography" theme={theme} themeConfig={themeConfig} title={geography.name} text={geography.name}>
-      <PageHeader coloured label="Geography" title={geography.name} metadata={[]} />
+    <Layout metadataKey="geography" theme={theme} themeConfig={themeConfig} title={geographyV2.name} text={geographyV2.name}>
+      <PageHeader coloured label="Geography" title={geographyV2.name} metadata={[]} />
       <Columns>
         <ContentsSideBar items={sidebarItems} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
         <main className="flex flex-col py-3 gap-3 cols-2:py-6 cols-2:gap-6 cols-3:py-8 cols-3:gap-8 cols-3:col-span-2 cols-4:col-span-3">
           <RecentFamiliesBlock categorySummaries={categorySummaries} />
           <SubDivisionBlock subdivisions={geographyV2.has_subconcept} />
-          <MetadataBlock title="Statistics" metadata={getGeographyMetaData(geography)} id="section-statistics" />
+          {geographyV2.statistics && (
+            <MetadataBlock title="Statistics" metadata={getGeographyMetaData(geographyV2.statistics)} id="section-statistics" />
+          )}
           <TargetsBlock targets={publishedTargets} theme={theme} />
-          {geography.legislative_process.length > 0 && (
+          {geographyV2?.statistics.legislative_process && (
             <TextBlock id="section-legislative-process" title="Legislative process">
-              <div className="text-content" dangerouslySetInnerHTML={{ __html: geography.legislative_process }} />
+              <div className="text-content" dangerouslySetInnerHTML={{ __html: geographyV2?.statistics.legislative_process }} />
             </TextBlock>
           )}
           <Section id="section-debug" title="Debug">
-            <pre className="w-full max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">{JSON.stringify(geography, null, 2)}</pre>
             <pre className="w-full max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">{JSON.stringify(summary, null, 2)}</pre>
             <pre className="w-full max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">
               {JSON.stringify(geographyV2.has_subconcept, null, 2)}

--- a/src/constants/sideBarItems.ts
+++ b/src/constants/sideBarItems.ts
@@ -52,7 +52,7 @@ export const getGeographyPageSidebarItems = (geography: GeographyV2, targets: TT
 
   const idsToRemove: string[] = [];
 
-  if (geography?.statistics.legislative_process) idsToRemove.push("section-legislative-process");
+  if (geography.statistics?.legislative_process) idsToRemove.push("section-legislative-process");
   if (targets.length === 0) idsToRemove.push("section-targets");
 
   return sidebarItems.filter((item) => !idsToRemove.includes(item.id));

--- a/src/constants/sideBarItems.ts
+++ b/src/constants/sideBarItems.ts
@@ -1,5 +1,5 @@
 import { ISideBarItem } from "@/components/organisms/contentsSideBar/ContentsSideBar";
-import { TGeographyStats, TTarget } from "@/types";
+import { GeographyV2, TTarget } from "@/types";
 
 export const FAMILY_PAGE_SIDE_BAR_ITEMS: ISideBarItem[] = [
   {
@@ -21,7 +21,7 @@ export const FAMILY_PAGE_SIDE_BAR_ITEMS: ISideBarItem[] = [
   },
 ];
 
-export const getGeographyPageSidebarItems = (geography: TGeographyStats, targets: TTarget[]): ISideBarItem[] => {
+export const getGeographyPageSidebarItems = (geography: GeographyV2, targets: TTarget[]): ISideBarItem[] => {
   const sidebarItems = [
     {
       id: "section-recents",
@@ -52,7 +52,7 @@ export const getGeographyPageSidebarItems = (geography: TGeographyStats, targets
 
   const idsToRemove: string[] = [];
 
-  if (geography.legislative_process.length === 0) idsToRemove.push("section-legislative-process");
+  if (geography?.statistics.legislative_process) idsToRemove.push("section-legislative-process");
   if (targets.length === 0) idsToRemove.push("section-targets");
 
   return sidebarItems.filter((item) => !idsToRemove.includes(item.id));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -67,7 +67,7 @@ export type GeographyV2 = {
   statistics?: {
     name: string;
     legislative_process: string;
-    federal: string;
+    federal: boolean;
     federal_details: string;
     political_groups: string;
     global_emissions_percent: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -64,6 +64,17 @@ export type GeographyV2 = {
   subconcept_of: GeographyV2[];
   has_subconcept: GeographyV2[];
   name: string;
+  statistics?: {
+    name: string;
+    legislative_process: string;
+    federal: string;
+    federal_details: string;
+    political_groups: string;
+    global_emissions_percent: string;
+    climate_risk_index: string;
+    worldbank_income_group: string;
+    visibility_status: string;
+  };
 };
 
 export type TGeography = {

--- a/src/utils/getGeographyMetadata.tsx
+++ b/src/utils/getGeographyMetadata.tsx
@@ -1,8 +1,8 @@
 import { ExternalLink } from "@/components/ExternalLink";
 import { Tooltip } from "@/components/atoms/tooltip/Tooltip";
-import { IMetadata, TGeographyStats } from "@/types";
+import { GeographyV2, IMetadata } from "@/types";
 
-export const getGeographyMetaData = (stats: TGeographyStats): IMetadata[] => {
+export const getGeographyMetaData = (stats: NonNullable<GeographyV2["statistics"]>): IMetadata[] => {
   const metadata = [];
 
   if (stats.federal && stats.federal_details) {


### PR DESCRIPTION
# What's changed

- sunsets the geography V1 on the litigation geo page

## Why?

[The Geographies API now returns statistics in a performant way, so we should use that.](https://api.climatepolicyradar.org/geographies/united-states) 


