### PR TITLE
fix: || true = booboo

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -92,7 +92,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const vespaSearchOnGeographiesEnabled = isVespaSearchOnGeographiesEnabled(featureFlags, themeConfig);
   let vespaSearchResults: TSearch = null;
-  if (vespaSearchOnGeographiesEnabled || true) {
+  if (vespaSearchOnGeographiesEnabled) {
     const searchQuery = buildSearchQuery(
       {
         l: slug,


### PR DESCRIPTION
# What's changed
Removes the `|| true`.

## Why?
It should not always be `true`.
