### PR TITLE
APP-974 search results cases

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -12,9 +12,10 @@ interface IProps {
   family: TFamily;
   showSummary?: boolean;
   titleClasses?: string;
+  className?: string;
 }
 
-export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = true, titleClasses = "hover:underline" }) => {
+export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = true, titleClasses = "hover:underline", className }) => {
   const {
     corpus_type_name,
     family_slug,
@@ -33,8 +34,8 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
   const summaryText = family_category === "Litigation" ? (family_metadata?.core_object?.[0] ?? family_description) : family_description;
 
   return (
-    <li className="family-list-item relative">
-      <div className="flex flex-wrap text-sm gap-1 my-2 items-center middot-between">
+    <li className={`family-list-item relative flex flex-col gap-2 ${className}`}>
+      <div className="flex flex-wrap text-sm gap-4 items-center">
         <FamilyMeta
           category={family_category}
           corpus_type_name={corpus_type_name}
@@ -49,14 +50,14 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
       </LinkWithQuery>
       {showSummary && (
         <p
-          className="my-3 text-content"
+          className="text-content text-sm"
           data-cy="family-description"
           dangerouslySetInnerHTML={{
             __html: truncateString(summaryText.replace(/(<([^>]+)>)/gi, ""), 375),
           }}
         />
       )}
-      {family_metadata?.status.length > 0 && <p className="my-3">Status: {family_metadata?.status.join(", ")}</p>}
+      {family_metadata?.status.length > 0 && <p className="text-sm">Status: {family_metadata?.status.join(", ")}</p>}
       {children}
     </li>
   );

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -57,7 +57,7 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
           }}
         />
       )}
-      {family_metadata?.status.length > 0 && <p className="text-sm">Status: {family_metadata?.status.join(", ")}</p>}
+      {family_metadata?.status?.length > 0 && <p className="text-sm">Status: {family_metadata?.status.join(", ")}</p>}
       {children}
     </li>
   );

--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -29,6 +29,9 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
 
   const allTitleClasses = joinTailwindClasses("result-title text-left font-medium text-lg duration-300 flex items-start", titleClasses);
 
+  // If the case is litigation and we have a core object, use that as the summary text
+  const summaryText = family_category === "Litigation" ? (family_metadata?.core_object?.[0] ?? family_description) : family_description;
+
   return (
     <li className="family-list-item relative">
       <div className="flex flex-wrap text-sm gap-1 my-2 items-center middot-between">
@@ -49,10 +52,11 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
           className="my-3 text-content"
           data-cy="family-description"
           dangerouslySetInnerHTML={{
-            __html: truncateString(family_description.replace(/(<([^>]+)>)/gi, ""), 375),
+            __html: truncateString(summaryText.replace(/(<([^>]+)>)/gi, ""), 375),
           }}
         />
       )}
+      {family_metadata?.status.length > 0 && <p className="my-3">Status: {family_metadata?.status.join(", ")}</p>}
       {children}
     </li>
   );

--- a/src/components/pages/familyOriginalPage.tsx
+++ b/src/components/pages/familyOriginalPage.tsx
@@ -423,12 +423,14 @@ export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page,
                       }}
                     />
                     <Heading level={4}>Other documents in the {collection.title}</Heading>
-                    <div className="divide-solid divide-y">
+                    <div className="divide-y flex flex-col gap-4">
                       {collection.families.map((collFamily, i) => (
-                        <div key={collFamily.slug} className="pt-4 pb-4">
-                          <LinkWithQuery href={`/document/${collFamily.slug}`}>{collFamily.title}</LinkWithQuery>
+                        <div key={collFamily.slug} className="border-border-light">
+                          <LinkWithQuery href={`/document/${collFamily.slug}`} className="text-[#0041A3] text-left font-medium text-lg underline">
+                            {collFamily.title}
+                          </LinkWithQuery>
                           <div
-                            className="text-content"
+                            className="text-content text-sm"
                             dangerouslySetInnerHTML={{
                               __html: collFamily.description,
                             }}

--- a/src/components/pages/geographyOriginalPage.tsx
+++ b/src/components/pages/geographyOriginalPage.tsx
@@ -118,7 +118,9 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
     router.push({ pathname: "/search", query: { ...newQuery } });
   };
 
-  const renderEmpty = (documentType: string = "") => <li className="mt-4">{`There are no ${documentType} documents for ${geographyV2.name}.`}</li>;
+  const renderEmpty = (documentType: string = "") => (
+    <li className="mb-4 text-sm">{`There are no ${documentType} documents for ${geographyV2.name}.`}</li>
+  );
 
   const renderDocuments = () => {
     // All docs || All MCF docs if theme is MCF

--- a/src/components/pages/geographyOriginalPage.tsx
+++ b/src/components/pages/geographyOriginalPage.tsx
@@ -118,7 +118,7 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
     router.push({ pathname: "/search", query: { ...newQuery } });
   };
 
-  const renderEmpty = (documentType: string = "") => <p className="mt-4">{`There are no ${documentType} documents for ${geographyV2.name}.`}</p>;
+  const renderEmpty = (documentType: string = "") => <li className="mt-4">{`There are no ${documentType} documents for ${geographyV2.name}.`}</li>;
 
   const renderDocuments = () => {
     // All docs || All MCF docs if theme is MCF
@@ -136,9 +136,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return allFamilies.map((family) => {
         if (family)
           return (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              titleClasses="text-[#0041A3] hover:underline"
+              family={family}
+              className={`pb-8 border-border-light`}
+            />
           );
       });
     }
@@ -147,9 +150,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return summary.top_families.Legislative.length === 0
         ? renderEmpty("Legislative")
         : summary.top_families.Legislative.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              titleClasses="text-[#0041A3] hover:underline"
+              family={family}
+              className={`pb-8 border-border-light`}
+            />
           ));
     }
     // Executive
@@ -157,9 +163,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return summary.top_families.Executive.length === 0
         ? renderEmpty("Executive")
         : summary.top_families.Executive.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              titleClasses="text-[#0041A3] hover:underline"
+              family={family}
+              className={`pb-8 border-border-light`}
+            />
           ));
     }
     // UNFCCC
@@ -167,9 +176,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return summary.top_families.UNFCCC.length === 0
         ? renderEmpty("UNFCCC")
         : summary.top_families.UNFCCC.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              titleClasses="text-[#0041A3] hover:underline"
+              family={family}
+              className={`pb-8 border-border-light`}
+            />
           ));
     }
     // Litigation
@@ -189,9 +201,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return summary.top_families.MCF.length === 0
         ? renderEmpty("multilateral climate funds")
         : summary.top_families.MCF.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              family={family}
+              titleClasses="text-[#0041A3] hover:underline"
+              className={`pb-8 border-border-light`}
+            />
           ));
     }
     // Reports
@@ -199,9 +214,12 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
       return summary.top_families.Reports.length === 0
         ? renderEmpty("reports")
         : summary.top_families.Reports.slice(0, MAX_NUMBER_OF_FAMILIES).map((family) => (
-            <ol key={family.family_slug} className="mb-10">
-              <FamilyListItem family={family} />
-            </ol>
+            <FamilyListItem
+              key={family.family_slug}
+              family={family}
+              titleClasses="text-[#0041A3] hover:underline"
+              className={`pb-8 border-border-light`}
+            />
           ));
     }
   };
@@ -296,15 +314,17 @@ export const GeographyOriginalPage = ({ geographyV2, summary, targets, theme, th
                       <TabbedNav activeItem={selectedCategory} items={documentCategories} handleTabClick={handleDocumentCategoryClick} />
                     </div>
                   </div>
-                  {renderDocuments()}
+                  <ol className="mt-8 divide-y flex flex-col gap-6">{renderDocuments()}</ol>
                 </section>
                 {selectedCategory !== "Litigation" && (
-                  <div data-cy="see-more-button">
-                    <Button rounded variant="outlined" className="my-5" onClick={handleDocumentSeeMoreClick}>
-                      View more documents
-                    </Button>
+                  <>
+                    <div data-cy="see-more-button" className="mb-4">
+                      <Button rounded variant="outlined" onClick={handleDocumentSeeMoreClick}>
+                        View more documents
+                      </Button>
+                    </div>
                     <Divider />
-                  </div>
+                  </>
                 )}
               </>
             )}

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -12,9 +12,10 @@ interface IProps {
   family: TMatchedFamily;
   active: boolean;
   onClick?: () => void;
+  className?: string;
 }
 
-const SearchResult = ({ family, active, onClick }: IProps) => {
+const SearchResult = ({ family, active, onClick, className }: IProps) => {
   const { themeConfig } = useContext(ThemeContext);
   const { family_documents, total_passage_hits, family_slug } = family;
 
@@ -29,25 +30,21 @@ const SearchResult = ({ family, active, onClick }: IProps) => {
   );
 
   return (
-    <FamilyListItem family={family} showSummary={isSearchFamilySummaryEnabled(themeConfig)} titleClasses={titleClasses}>
+    <FamilyListItem family={family} showSummary={isSearchFamilySummaryEnabled(themeConfig)} titleClasses={titleClasses} className={className}>
       {hasFamilyDocuments && (
-        <>
-          <div>
-            <div className="inline-block">
-              <button
-                type="button"
-                onClick={onClick}
-                className="mt-1 text-text-brand"
-                aria-label={matchesText}
-                data-analytics="search-result-matches-button"
-                data-slug={family_slug}
-              >
-                <TextSearch size={16} className="inline mr-1.5" />
-                <span className="text-sm font-semibold underline">{matchesText}</span>
-              </button>
-            </div>
-          </div>
-        </>
+        <div className="flex">
+          <button
+            type="button"
+            onClick={onClick}
+            className="text-text-brand flex items-center"
+            aria-label={matchesText}
+            data-analytics="search-result-matches-button"
+            data-slug={family_slug}
+          >
+            <TextSearch size={16} className="inline mr-1.5" />
+            <span className="text-sm font-semibold underline">{matchesText}</span>
+          </button>
+        </div>
       )}
     </FamilyListItem>
   );

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -60,7 +60,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: IP
   }
   return (
     <>
-      <ol className={`divide-y flex flex-col gap-6`} data-cy="search-result">
+      <ol className="divide-y flex flex-col gap-6" data-cy="search-result">
         {families?.map((family, index: number) => (
           <SearchResult
             key={index}

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -60,11 +60,17 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: IP
   }
   return (
     <>
-      {families?.map((family, index: number) => (
-        <ol key={index} className={`my-10 ${index === 0 && "md:mt-8"}`} data-cy="search-result">
-          <SearchResult family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
-        </ol>
-      ))}
+      <ol className={`divide-y flex flex-col gap-6`} data-cy="search-result">
+        {families?.map((family, index: number) => (
+          <SearchResult
+            key={index}
+            family={family}
+            onClick={() => onClick(index)}
+            active={activeFamilyIndex === index}
+            className={`pb-8 border-border-light`}
+          />
+        ))}
+      </ol>
     </>
   );
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -180,7 +180,7 @@ export type TFamily = {
   family_documents: TFamilyDocument[];
   family_geographies: string[];
   family_last_updated_date: string;
-  family_metadata: {}; // TODO: type this
+  family_metadata: { [key: string]: string[] }; // TODO: type this better
   family_name: string;
   family_slug: string;
   family_source: string;


### PR DESCRIPTION
# What's changed
- Update search result to match designs
- Display the "status" in search results with label
- Display "at issue" or "description" field - depending on what we have in the data

Important drive-by fixes / improvements for:
- Fixing a bug introduced in an earlier PR that wrapped each search result in its own ordered list, rather than list item
- Fix display of families in other contexts such as: geo page, on family page under collection 
- Slightly better typing of family metadata

## Why?

## Screen
<img width="816" height="806" alt="Screenshot 2025-09-08 at 16 05 56" src="https://github.com/user-attachments/assets/6f4080d8-db1c-4be2-a867-283fa728dc30" />
shots?
