### PR TITLE
APP-1119 - Show some help text for litigation searches

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -73,6 +73,12 @@ const showResultInformation = (query: ParsedUrlQuery) => {
   return showKnowledgeGraphInformation(query) || showCorporateDisclosuresInformation(query);
 };
 
+// We want to show information when using specific litigation filters
+const showLitigationInformation = (query: ParsedUrlQuery) => {
+  if (Array.isArray(query[QUERY_PARAMS.concept_preferred_label]) && query[QUERY_PARAMS.concept_preferred_label].length >= 2) return true;
+  return false;
+};
+
 // We want to show the KG information under certain rules
 const showKnowledgeGraphInformation = (query: ParsedUrlQuery) => {
   let show = false;
@@ -111,6 +117,11 @@ const showSearchOnboarding = (query: ParsedUrlQuery) => {
 const getSelectedConcepts = (selectedConcepts: string | string[], allConcepts: TConcept[] = []): TConcept[] => {
   const selectedConceptsAsArray = Array.isArray(selectedConcepts) ? selectedConcepts : [selectedConcepts];
   return allConcepts?.filter((concept) => selectedConceptsAsArray.includes(concept.preferred_label.toLowerCase())) || [];
+};
+
+const getSelectedFamilyConcepts = (selectedConcepts: string | string[], allConcepts: TConcept[] = []): TConcept[] => {
+  const selectedConceptsAsArray = Array.isArray(selectedConcepts) ? selectedConcepts : [selectedConcepts];
+  return allConcepts?.filter((concept) => selectedConceptsAsArray.includes(concept.wikibase_id)) || [];
 };
 
 const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
@@ -617,6 +628,16 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                       </div>
                       <section data-cy="search-results">
                         <h2 className="sr-only">Search results</h2>
+                        {showLitigationInformation(router.query) && (
+                          <Warning variant="info">
+                            <p>
+                              You are viewing a list of litigation cases filtered by{" "}
+                              {getSelectedFamilyConcepts(router.query[QUERY_PARAMS.concept_preferred_label], familyConceptsData)
+                                .map((c) => c.preferred_label)
+                                .join(" AND ")}
+                            </p>
+                          </Warning>
+                        )}
                         {showCorporateDisclosuresInformation(router.query) && (
                           <Warning variant="info">
                             <p className="font-semibold">New data</p>


### PR DESCRIPTION
# What's changed
- Adding some help text to the top of search when 2 or more of the litigation filters: Case categories, Principal laws, Jurisdictions are selected

## Why?
- To explain to users why they are seeing the results.

## Screenshots?
<img width="865" height="378" alt="Screenshot 2025-09-08 at 17 26 54" src="https://github.com/user-attachments/assets/584dc91e-d466-4b74-9da2-b4f1a382ac8a" />
