### PR TITLE
Comment out all instances of the debug component and remove from sidebar

### DIFF
--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -89,11 +89,11 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
             <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
           </TextBlock>
           <MetadataBlock title="About this case" metadata={getFamilyMetadata(family, countries, subdivisions)} id="section-metadata" />
-          <Section id="section-debug" title="Debug">
+          {/* <Section id="section-debug" title="Debug">
             <Debug data={family} title="Family" />
             <Debug data={countries} title="Countries" />
             <Debug data={subdivisions} title="Subdivisions" />
-          </Section>
+          </Section> */}
         </main>
       </Columns>
       <Head>

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -141,11 +141,11 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
                   <div className="text-content" dangerouslySetInnerHTML={{ __html: legislativeProcess }} />
                 </TextBlock>
             )} */}
-            <Section id="section-debug" title="Debug">
+            {/* <Section id="section-debug" title="Debug">
               <Debug data={geographyV2} title="Geography V2" />
               <Debug data={parentGeographyV2} title="Parent geography V2" />
               <Debug data={targets} title="Targets" />
-            </Section>
+            </Section> */}
           </main>
         </Columns>
       </Layout>

--- a/src/constants/sideBarItems.ts
+++ b/src/constants/sideBarItems.ts
@@ -13,10 +13,10 @@ export const FAMILY_PAGE_SIDE_BAR_ITEMS: ISideBarItem[] = [
     id: "section-metadata",
     display: "About",
   },
-  {
-    id: "section-debug",
-    display: "Debug",
-  },
+  // {
+  //   id: "section-debug",
+  //   display: "Debug",
+  // },
 ];
 
 type TProps = Record<"isCountry" | "legislativeProcess" | "metadata" | "subdivisions" | "targets", boolean>;
@@ -43,11 +43,11 @@ export const getGeographyPageSidebarItems = (settings: TProps): ISideBarItem[] =
       id: "section-legislative-process",
       display: "Legislative process",
     },
-    {
-      id: "section-debug",
-      display: "Debug",
-      badge: "Developer",
-    },
+    // {
+    //   id: "section-debug",
+    //   display: "Debug",
+    //   badge: "Developer",
+    // },
   ];
 
   const idsToRemove: string[] = [];

--- a/src/pages/collection/[id].tsx
+++ b/src/pages/collection/[id].tsx
@@ -79,9 +79,9 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
                 <div className="text-content" dangerouslySetInnerHTML={{ __html: collection.description }} />
               </TextBlock>
               <MetadataBlock metadata={getCollectionMetadata(collection)} id="section-collection-metadata" />
-              <Section id="section-debug" title="Debug">
+              {/* <Section id="section-debug" title="Debug">
                 <Debug data={collection} title="Collection" />
-              </Section>
+              </Section> */}
             </main>
           </>
         )}


### PR DESCRIPTION
# What's changed
- Commenting out instances of the debug component that we were using for debugging

## Why?
- Don't want to confuse any external users
- Didn't have time to incorporate a feature-flagged solution and will reinstate after any immediate demos
