### PR TITLE
APP-1131: Sort DocumentsBlock by filing date descending

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -56,7 +56,9 @@ export const DocumentsBlock = ({ countries, family }: IProps) => {
         )}
 
         {/* Table */}
-        {view === "table" && <InteractiveTable<TEventTableColumnId> columns={tableColumns} rows={tableRows} />}
+        {view === "table" && (
+          <InteractiveTable<TEventTableColumnId> columns={tableColumns} rows={tableRows} defaultSort={{ column: "date", ascending: false }} />
+        )}
       </Card>
     </Section>
   );


### PR DESCRIPTION
# What's changed

- `DocumentsBlock` now sorts its table by filing date descending by default.
  - Formerly just displayed documents in the order returned by the API.

## Why?

Satisfies [APP-1131](https://linear.app/climate-policy-radar/issue/APP-1131/sort-documentsblock-by-filing-date-descending).

## Screenshots?

<img width="2252" height="1351" alt="Screenshot 2025-09-09 at 12 44 47" src="https://github.com/user-attachments/assets/8c713ad5-8ecd-4e91-82a0-d5719a9095b7" />
