### PR TITLE
fix: SPAify vespaSearchResultson geography page

### DIFF
--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -64,6 +64,12 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
   const [searchResultsByCategory, setSearchResultsByCategory] = useState<{ [categorySlug: string]: TSearch }>({
     All: vespaSearchResults,
   });
+  // re-render when the page has changed
+  useEffect(() => {
+    setSearchResultsByCategory({
+      All: vespaSearchResults,
+    });
+  }, [vespaSearchResults]);
 
   const documentCategories = useMemo(
     () =>


### PR DESCRIPTION
When the page reloads we need to update the search values


https://github.com/user-attachments/assets/36ca724b-99d6-4b70-9a83-475d0aa3acc1

