### PR TITLE
fix: move slug hack to the edge of the app

### DIFF
--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -15,7 +15,6 @@ import { getGeographyPageSidebarItems } from "@/constants/sideBarItems";
 import { GeographiesContext } from "@/context/GeographiesContext";
 import { TSearch } from "@/types";
 import buildSearchQuery from "@/utils/buildSearchQuery";
-import { v2GeoSlugToV1 } from "@/utils/geography";
 import { getGeographyMetaData } from "@/utils/getGeographyMetadata";
 
 import { IProps } from "./geographyOriginalPage";
@@ -46,7 +45,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
     pageHeaderMetadata.push({
       label: "Part of",
       value: (
-        <LinkWithQuery href={`/geographies/${v2GeoSlugToV1(parentGeographyV2.slug)}`} className="underline">
+        <LinkWithQuery href={`/geographies/${parentGeographyV2.slug}`} className="underline">
           {parentGeographyV2.name}
         </LinkWithQuery>
       ),

--- a/src/utils/geography.ts
+++ b/src/utils/geography.ts
@@ -7,6 +7,3 @@ export const getCountryFromId = (id: number, geos): string => {
   const match = geos.find((geo) => id === geo.geography_id);
   return match.english_shortname;
 };
-
-export const v1GeoSlugToV2 = (slug: string): string => (slug === "united-states-of-america" ? "united-states" : slug);
-export const v2GeoSlugToV1 = (slug: string): string => (slug === "united-states" ? "united-states-of-america" : slug);


### PR DESCRIPTION
Moves the slug hack and contains it in the try statement, stopping it from
- leaking out elsewhere
- not being implemented (this fixes a bug on litigation counts)