### PR TITLE
fix: move FamilyListItem classes to itself away from parent component

### DIFF
--- a/src/components/document/FamilyListItem.tsx
+++ b/src/components/document/FamilyListItem.tsx
@@ -34,7 +34,7 @@ export const FamilyListItem: FC<IProps> = ({ children, family, showSummary = tru
   const summaryText = family_category === "Litigation" ? (family_metadata?.core_object?.[0] ?? family_description) : family_description;
 
   return (
-    <li className={`family-list-item relative flex flex-col gap-2 ${className}`}>
+    <li className={`family-list-item relative flex flex-col gap-2 pb-8 border-border-light ${className}`}>
       <div className="flex flex-wrap text-sm gap-4 items-center">
         <FamilyMeta
           category={family_category}

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -12,10 +12,9 @@ interface IProps {
   family: TMatchedFamily;
   active: boolean;
   onClick?: () => void;
-  className?: string;
 }
 
-const SearchResult = ({ family, active, onClick, className }: IProps) => {
+const SearchResult = ({ family, active, onClick }: IProps) => {
   const { themeConfig } = useContext(ThemeContext);
   const { family_documents, total_passage_hits, family_slug } = family;
 
@@ -30,7 +29,7 @@ const SearchResult = ({ family, active, onClick, className }: IProps) => {
   );
 
   return (
-    <FamilyListItem family={family} showSummary={isSearchFamilySummaryEnabled(themeConfig)} titleClasses={titleClasses} className={className}>
+    <FamilyListItem family={family} showSummary={isSearchFamilySummaryEnabled(themeConfig)} titleClasses={titleClasses}>
       {hasFamilyDocuments && (
         <div className="flex">
           <button

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -62,13 +62,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick }: IP
     <>
       <ol className="divide-y flex flex-col gap-6" data-cy="search-result">
         {families?.map((family, index: number) => (
-          <SearchResult
-            key={index}
-            family={family}
-            onClick={() => onClick(index)}
-            active={activeFamilyIndex === index}
-            className={`pb-8 border-border-light`}
-          />
+          <SearchResult key={index} family={family} onClick={() => onClick(index)} active={activeFamilyIndex === index} />
         ))}
       </ol>
     </>


### PR DESCRIPTION
# What's changed

Instead of drilling down these classes, we just apply them to the component.
This is cleaner, and also avoid styles drifting if we use this component elsewhere, like we do on geography pages.

## 👀 

| before | after |
|---|---|
| ![before][before] | ![after][after] |

[before]: https://github.com/user-attachments/assets/a3289b16-8477-44cc-8086-825f39fe50da
[after]: https://github.com/user-attachments/assets/d9d75f78-f9ca-4947-b6ce-1192bc0acc27