### PR TITLE
feat: add error logging for missing search results on geography pages

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -97,7 +97,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         "Content-Type": "application/json",
       },
     })
-    .then((response) => response.data);
+    .then((response) => response.data)
+    /* eslint-disable-next-line no-console -- errors monitored and alerted on */
+    .catch((err) => console.error(`Could not find search results for geography ${geographyV2.slug}:`, err));
 
   if (!vespaSearchResults) {
     return { notFound: true };


### PR DESCRIPTION
# What's changed

- adds error reporting for missing search results on a geography page

## Why?

This will be alerted on in our #ops-sentry channel. The thinking is we 404 if we have a geography and no search results (or a search results error). I would like to know if this is happening and for what geographies.

This is partially predicated on https://ccc.production.climatepolicyradar.org/geographies/united-states-of-america not working and trying to debug why.