### PR TITLE
APP-1136: Bug: some families render no documents on the family page

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.stories.tsx
@@ -44,3 +44,18 @@ export const WithMatches: TStory = {
     showMatches: true,
   },
 };
+
+export const WithAPlaceholderDocument: TStory = {
+  args: {
+    ...WithoutMatches.args,
+    family: {
+      ...FAMILY_NEW_STUB,
+      documents: [
+        {
+          ...FAMILY_NEW_STUB.documents[0],
+          events: [],
+        },
+      ],
+    },
+  },
+};

--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -45,6 +45,7 @@ export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatch
     [category, family]
   );
 
+  // If the case is new, there can be one placeholder document with no events. Handle this interim state
   const hasDocumentsToDisplay = tableRows.length > 0;
 
   const onToggleChange = (toggleValue: string[]) => {


### PR DESCRIPTION
# What's changed

We have cases that don't yet have documents, in situations where a case has been created in Sabin's database but no documents have been added yet. `DocumentsBlock` currently doesn't handle this well.

When there are no events to render in `DocumentsBlock`'s table, only render placeholder text that explains there are no documents yet. I expect this placeholder to be interim, but it's a lot better than the current table with no rows and singular card with no title that links to a document that can't be viewed.

## Why?

Satisfies [APP-1136](https://linear.app/climate-policy-radar/issue/APP-1136/bug-some-families-render-no-documents-on-the-family-page).

## Screenshots?

<img width="2235" height="1273" alt="Screenshot 2025-09-11 at 15 09 07" src="https://github.com/user-attachments/assets/147acbbb-2ffa-42d0-80e7-626be9891216" />
