### PR TITLE
APP-1154: Change 'Case' into 'Case Number' in the collection timeline table

### DIFF
--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -136,7 +136,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
   const blockDefinitions: TBlockDefinitions<TFamilyPageBlock> = {
     debug: {
       render: () => (
-        <Section block="debug" title="Debug">
+        <Section key="debug" block="debug" title="Debug">
           <Debug data={family} title="Family" />
           <Debug data={countries} title="Countries" />
           <Debug data={subdivisions} title="Subdivisions" />
@@ -145,7 +145,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
     },
     documents: {
       render: useCallback(
-        () => <DocumentsBlock family={family} matchesFamily={matchesFamily} matchesStatus={matchesStatus} showMatches={hasSearch} />,
+        () => <DocumentsBlock key="documents" family={family} matchesFamily={matchesFamily} matchesStatus={matchesStatus} showMatches={hasSearch} />,
         [family, hasSearch, matchesFamily, matchesStatus]
       ),
     },
@@ -154,7 +154,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
         const metadata = getFamilyMetadata(family, countries, subdivisions);
         if (metadata.length === 0) return null;
 
-        return <MetadataBlock block="metadata" title="About this case" metadata={metadata} />;
+        return <MetadataBlock key="metadata" block="metadata" title="About this case" metadata={metadata} />;
       }, [countries, family, subdivisions]),
       sideBarItem: { display: "About" },
     },
@@ -163,7 +163,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
         if (!family.summary) return null;
 
         return (
-          <TextBlock block="summary" title="Summary">
+          <TextBlock key="summary" block="summary" title="Summary">
             <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
           </TextBlock>
         );

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -61,7 +61,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
   const blockDefinitions: TBlockDefinitions<TGeographyPageBlock> = {
     debug: {
       render: () => (
-        <Section block="debug" title="Debug">
+        <Section key="debug" block="debug" title="Debug">
           <Debug data={geographyV2} title="Geography V2" />
           <Debug data={parentGeographyV2} title="Parent geography V2" />
           <Debug data={targets} title="Targets" />
@@ -74,7 +74,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
         if (legislativeProcess.length === 0) return null;
 
         return (
-          <TextBlock block="legislative-process" title="Legislative process">
+          <TextBlock key="legislative-process" block="legislative-process" title="Legislative process">
             <div className="text-content" dangerouslySetInnerHTML={{ __html: legislativeProcess }} />
           </TextBlock>
         );
@@ -124,6 +124,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
 
         return (
           <RecentFamiliesBlock
+            key="recents"
             categorySummaries={documentCategories.map((categorySummary) => {
               return {
                 id: categorySummary.slug,
@@ -147,7 +148,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
         const geographyMetaData = geographyV2.statistics ? getGeographyMetaData(geographyV2.statistics) : [];
         if (geographyMetaData.length === 0) return null;
 
-        return <MetadataBlock block="statistics" title="Statistics" metadata={geographyMetaData} />;
+        return <MetadataBlock key="statistics" block="statistics" title="Statistics" metadata={geographyMetaData} />;
       }, [geographyV2]),
     },
     subdivisions: {
@@ -159,14 +160,14 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
             : (parentGeographyV2?.has_subconcept || []).filter((subdivision) => subdivision.id !== geographyV2.id)
         );
 
-        return <SubDivisionBlock subdivisions={subdivisions} title={subdivisionsTitle} />;
+        return <SubDivisionBlock key="subdivisions" subdivisions={subdivisions} title={subdivisionsTitle} />;
       }, [geographyV2, isCountry, parentGeographyV2, subdivisionsTitle]),
       sideBarItem: { display: subdivisionsTitle },
     },
     targets: {
       render: useCallback(() => {
         const publishedTargets = sortFilterTargets(targets);
-        return <TargetsBlock targets={publishedTargets} theme={theme} />;
+        return <TargetsBlock key="targets" targets={publishedTargets} theme={theme} />;
       }, [targets, theme]),
     },
   };

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -24,13 +24,13 @@ export const getEventTableColumns = ({
   let columns: TEventTableColumn[] = [
     { id: "date", name: "Filing Date", fraction: 2 },
     { id: "type", fraction: 3 },
-    { id: "action", name: "Action taken", fraction: 4 },
+    { id: "action", name: "Action Taken", fraction: 4 },
     { id: "document" },
     { id: "summary", sortable: false, fraction: 6, classes: "min-w-75" },
   ];
 
   if (showFamilyColumns) {
-    columns = [...columns, { id: "caseNumber", name: "Case", fraction: 2 }, { id: "court" }, { id: "caseTitle", name: "Case", fraction: 2 }];
+    columns = [...columns, { id: "caseNumber", name: "Case Number", fraction: 2 }, { id: "court" }, { id: "caseTitle", name: "Case", fraction: 2 }];
   }
 
   if (!isUSA) columns.splice(2, 1);


### PR DESCRIPTION
# What's changed

- Renamed "Case" to "Case Number".
- Capitalised "Action taken" to "Action Taken" for consistency.
- Driveby on missing React keys on `BlocksLayout` render function return values which was throwing warnings to the console.

## Why?

Satisfies [APP-1154](https://linear.app/climate-policy-radar/issue/APP-1154/change-case-into-case-number-in-the-collection-timeline-table).

## Screenshots?

<img width="2234" height="711" alt="Screenshot 2025-09-15 at 16 20 17" src="https://github.com/user-attachments/assets/42a95809-d128-4fbc-9ee4-87afeceb8b01" />
