### PR TITLE
APP-1152: Change the text on geo page to state the number of cases rather documents

### DIFF
--- a/src/components/blocks/familyBlock/FamilyBlock.tsx
+++ b/src/components/blocks/familyBlock/FamilyBlock.tsx
@@ -44,7 +44,7 @@ export const FamilyBlock = ({ family }: IProps) => {
             {caseNumbers && <span>{caseNumbers}</span>}
             {courts && <span>{courts}</span>}
             <span>
-              {tableRows.length} {pluralise(tableRows.length, "entry", "entries")}
+              {tableRows.length} {pluralise(tableRows.length, ["entry", "entries"])}
             </span>
           </div>
           <InteractiveTable<TEventTableColumnId>

--- a/src/components/blocks/recentFamiliesBlock/RecentFamiliesBlock.tsx
+++ b/src/components/blocks/recentFamiliesBlock/RecentFamiliesBlock.tsx
@@ -9,9 +9,10 @@ export interface IProps {
   categorySummaries: TCategorySummary[];
   onAccordionClick?: (id: string) => void;
   geography: GeographyV2;
+  title?: string;
 }
 
-export const RecentFamiliesBlock = ({ categorySummaries, onAccordionClick, geography }: IProps) => {
+export const RecentFamiliesBlock = ({ categorySummaries, onAccordionClick, geography, title = "Recent documents" }: IProps) => {
   const [expandedCategories, setExpandedCategories] = useState([categorySummaries[0].title]);
 
   const hideAccordion = categorySummaries.length === 1 && categorySummaries[0].title === "All";
@@ -27,7 +28,7 @@ export const RecentFamiliesBlock = ({ categorySummaries, onAccordionClick, geogr
   };
 
   return (
-    <Section block="recents" title="Recent documents">
+    <Section block="recents" title={title}>
       {categorySummaries.map((category) => (
         <RecentFamiliesCategory
           key={category.title}

--- a/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
+++ b/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
@@ -31,7 +31,7 @@ interface IProps {
 }
 
 export const RecentFamiliesCategory = ({
-  categorySummary: { count, families, title, unit },
+  categorySummary: { count, families, singularAndPlural, title },
   showAccordion = false,
   isExpanded = true,
   onAccordionClick,
@@ -105,7 +105,7 @@ export const RecentFamiliesCategory = ({
             </div>
           )}
           <p className="mt-4 mb-12 text-sm text-text-tertiary">
-            There {pluralise(count, "is", "are")} {count} {pluralise(count, ...unit)} in the database.
+            There {pluralise(count, ["is", "are"])} {count} {pluralise(count, singularAndPlural)} in the database.
           </p>
         </>
       )}

--- a/src/components/pages/familyOriginalPage.tsx
+++ b/src/components/pages/familyOriginalPage.tsx
@@ -257,7 +257,7 @@ export const FamilyOriginalPage = ({ corpus_types, countries = [], family: page,
 
             {mainDocuments.length > 0 && theme !== "mcf" && (
               <section className="mt-10">
-                <Heading level={2}>Main {pluralise(mainDocuments.length, "document", "documents")}</Heading>
+                <Heading level={2}>Main {pluralise(mainDocuments.length, ["document", "documents"])}</Heading>
                 <div data-cy="main-documents">
                   {mainDocuments.map((doc) => (
                     <FamilyDocument

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -57,6 +57,8 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
 
   /* Blocks */
 
+  const recentFamiliesTitle = theme === "ccc" ? "Recent cases" : "Recent families";
+
   const blocksToRender = themeConfig.pageBlocks.geography;
   const blockDefinitions: TBlockDefinitions<TGeographyPageBlock> = {
     debug: {
@@ -130,17 +132,18 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
                 title: categorySummary.title,
                 families: searchResultsByCategory[categorySummary.slug]?.families || [],
                 count: searchResultsByCategory[categorySummary.slug]?.total_family_hits,
-                unit: ["document", "documents"],
+                singularAndPlural: theme === "ccc" ? ["case", "cases"] : ["document", "documents"],
               };
             })}
             onAccordionClick={(id) => {
               fetchFamiliesByCategory(id);
             }}
             geography={geographyV2}
+            title={recentFamiliesTitle}
           />
         );
-      }, [envConfig, geographyV2, searchResultsByCategory, themeConfig]),
-      sideBarItem: { display: "Recent documents" },
+      }, [envConfig, geographyV2, recentFamiliesTitle, searchResultsByCategory, theme, themeConfig]),
+      sideBarItem: { display: recentFamiliesTitle },
     },
     statistics: {
       render: useCallback(() => {

--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -57,6 +57,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
 
   /* Blocks */
 
+  // TODO better app-specific family taxonomy
   const recentFamiliesTitle = theme === "ccc" ? "Recent cases" : "Recent families";
 
   const blocksToRender = themeConfig.pageBlocks.geography;
@@ -133,6 +134,7 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
                 title: categorySummary.title,
                 families: searchResultsByCategory[categorySummary.slug]?.families || [],
                 count: searchResultsByCategory[categorySummary.slug]?.total_family_hits,
+                // TODO better app-specific family taxonomy
                 singularAndPlural: theme === "ccc" ? ["case", "cases"] : ["document", "documents"],
               };
             })}

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -6,6 +6,7 @@ import { MAX_RESULTS } from "@/constants/paging";
 import { ThemeContext } from "@/context/ThemeContext";
 import { TMatchedFamily } from "@/types";
 import { isSearchFamilySummaryEnabled } from "@/utils/features";
+import { pluralise } from "@/utils/pluralise";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
 interface IProps {
@@ -21,7 +22,7 @@ const SearchResult = ({ family, active, onClick }: IProps) => {
   const hasFamilyDocuments = family_documents.length > 0;
 
   const matchesNumber = total_passage_hits >= MAX_RESULTS ? `${MAX_RESULTS}+` : `${total_passage_hits}`;
-  const matchesText = `View ${matchesNumber} text ${total_passage_hits === 1 ? "passage" : "passages"} matching your search`;
+  const matchesText = `View ${matchesNumber} text ${pluralise(total_passage_hits, ["passage", "passages"])} matching your search`;
 
   const titleClasses = joinTailwindClasses(
     hasFamilyDocuments ? "text-text-primary" : "text-[#0041A3]",

--- a/src/stubs/categorySummarytStub.tsx
+++ b/src/stubs/categorySummarytStub.tsx
@@ -5,7 +5,7 @@ export const CATEGORY_SUMMARY_STUB: TCategorySummary[] = [
     id: "Executive",
     count: 74,
     title: "Executive",
-    unit: ["Policy", "Policies"],
+    singularAndPlural: ["Policy", "Policies"],
     families: [
       {
         family_slug: "clean-power-2030-action-plan_c2c5",
@@ -113,7 +113,7 @@ export const CATEGORY_SUMMARY_STUB: TCategorySummary[] = [
     id: "Legislative",
     title: "Legislative",
     count: 33,
-    unit: ["Law", "Laws"],
+    singularAndPlural: ["Law", "Laws"],
     families: [
       {
         family_slug: "the-climate-change-targeted-greenhouse-gases-order-2023_d2ab",
@@ -221,7 +221,7 @@ export const CATEGORY_SUMMARY_STUB: TCategorySummary[] = [
     id: "UNFCCC",
     title: "UNFCCC",
     count: 19,
-    unit: ["Document", "Documents"],
+    singularAndPlural: ["Document", "Documents"],
     families: [
       {
         family_slug: "united-kingdom-national-inventory-report-nir-2025_3a70",
@@ -324,7 +324,7 @@ export const CATEGORY_SUMMARY_STUB: TCategorySummary[] = [
     id: "Reports",
     title: "Reports",
     count: 73,
-    unit: ["Report", "Reports"],
+    singularAndPlural: ["Report", "Reports"],
     families: [
       {
         family_slug: "aviva-plc-corporate-transition-plan-2021-2024_2e00",
@@ -427,14 +427,14 @@ export const CATEGORY_SUMMARY_STUB: TCategorySummary[] = [
     id: "MCF",
     title: "MCF",
     count: 0,
-    unit: ["Document", "Documents"],
+    singularAndPlural: ["Document", "Documents"],
     families: [],
   },
   {
     id: "Litigation",
     title: "Litigation",
     count: 0,
-    unit: ["Document", "Documents"],
+    singularAndPlural: ["Document", "Documents"],
     families: [],
   },
 ];

--- a/src/types/display.ts
+++ b/src/types/display.ts
@@ -4,3 +4,5 @@ export interface IMetadata {
   label: ReactNode;
   value: ReactNode;
 }
+
+export type TSingularAndPlural = [string, string];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,3 +1,5 @@
+import { TSingularAndPlural } from "./display";
+
 export type TTheme = "cpr" | "cclw" | "mcf" | "ccc";
 
 export type TSearchKeywordFilters = {
@@ -488,5 +490,5 @@ export type TCategorySummary = {
   count: number;
   families: TFamily[];
   title: string;
-  unit: [string, string];
+  singularAndPlural: TSingularAndPlural;
 };

--- a/src/utils/getPassageResultsContext.tsx
+++ b/src/utils/getPassageResultsContext.tsx
@@ -4,6 +4,8 @@ import { ConceptLink } from "@/components/molecules/conceptLink/ConceptLink";
 import { MAX_PASSAGES } from "@/constants/paging";
 import { TConcept } from "@/types";
 
+import { pluralise } from "./pluralise";
+
 interface IArgs {
   isExactSearch?: boolean;
   passageMatches: number;
@@ -37,13 +39,12 @@ export const getPassageResultsContext = ({ isExactSearch, passageMatches, queryT
     ) : (
       <span className="font-bold">{passageMatches}</span>
     );
-  const matchesPlural = passageMatches === 1 ? "match" : "matches";
 
   const phrase = queryString ? `${isExactSearch ? "" : "phrases related to "}${queryString}` : null;
 
   return (
     <div>
-      {passages} {matchesPlural} for <ResultsTopicsContext phrase={phrase} selectedTopics={selectedTopics} />
+      {passages} {pluralise(passageMatches, ["match", "matches"])} for <ResultsTopicsContext phrase={phrase} selectedTopics={selectedTopics} />
     </div>
   );
 };

--- a/src/utils/pluralise.ts
+++ b/src/utils/pluralise.ts
@@ -1,3 +1,5 @@
-export const pluralise = (count: number, singular: string, plural: string) => {
+import { TSingularAndPlural } from "@/types";
+
+export const pluralise = (count: number, [singular, plural]: TSingularAndPlural) => {
   return count === 1 ? singular : plural;
 };


### PR DESCRIPTION
# What's changed

- Updates to the `pluralise` utility function:
  - Typed the singular/plural tuple so it's a bit more obvious what is happening elsewhere in the codebase.
  - Refactored the arguments so the tuple is passed in directly.
  - Renamed `unit` keys to `singularAndPlural`.
  - Spotted a few singular/plural instances not yet using `pluralise` and refactored them.
- `RecentFamiliesBlock`:
  - `title` prop so "Recent documents" can be named differently per app.
  - `singularAndPlural` tuple provided per category is now different on CCC.

## Why?

Satisfies [APP-1152](https://linear.app/climate-policy-radar/issue/APP-1152/change-the-text-on-geo-page-to-state-the-number-of-cases-rather).

## Screenshots?

<img width="1451" height="875" alt="Screenshot 2025-09-15 at 16 52 26" src="https://github.com/user-attachments/assets/f9b1eeaa-ca7b-4e14-af71-378a33b9d8c8" />
