### PR TITLE
APP-1157: Sorting by Document on collection events table should be removed

### DIFF
--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -29,9 +29,11 @@ export const Generic: TStory<TWainwrightColumns> = {
       {
         id: "wainwright",
         fraction: 2,
+        sortable: true,
       },
       {
         id: "height",
+        sortable: true,
       },
       {
         id: "region",
@@ -41,15 +43,14 @@ export const Generic: TStory<TWainwrightColumns> = {
           </div>
         ),
         fraction: 2,
-        sortable: false,
       },
       {
         id: "link",
         name: "WalkLakes",
-        sortable: false,
       },
       {
         id: "summited",
+        sortable: true,
       },
     ],
     defaultSort: {

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -17,7 +17,7 @@ export interface IInteractiveTableColumn<ColumnKey extends string> {
   fraction?: number; // CSS grid fractional units - the column's relative width
   id: ColumnKey;
   name?: string; // defaults to first-cased id
-  sortable?: boolean; // defaults to true
+  sortable?: boolean; // defaults to false
   tooltip?: ReactNode;
 }
 
@@ -170,7 +170,7 @@ export const InteractiveTable = <ColumnKey extends string>({
                       <LucideInfo size={16} className="text-text-tertiary opacity-50 group-hover:opacity-100" />
                     </Tooltip>
                   )}
-                  {column.sortable !== false && renderSortControls(column)}
+                  {column.sortable === true && renderSortControls(column)}
                 </div>
               </div>
             );

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -22,11 +22,11 @@ export const getEventTableColumns = ({
   showMatches?: boolean;
 }) => {
   let columns: TEventTableColumn[] = [
-    { id: "date", name: "Filing Date", fraction: 2 },
-    { id: "type", fraction: 3 },
+    { id: "date", name: "Filing Date", sortable: true, fraction: 2 },
+    { id: "type", sortable: true, fraction: 3 },
     { id: "action", name: "Action Taken", fraction: 4 },
     { id: "document" },
-    { id: "summary", sortable: false, fraction: 6, classes: "min-w-75" },
+    { id: "summary", fraction: 6, classes: "min-w-75" },
   ];
 
   if (showFamilyColumns) {


### PR DESCRIPTION
# What's changed

- `InteractiveTable` columns' `sortable` key now defaults to false.
  - This better reflects the majority of columns _not_ being sortable, and shows intentionality when a column is marked as sortable rather than the opposite.
- Only "Filing Date" and "Type" columns are sortable on the event tables on the family and collection pages.

## Why?

Satisfies [APP-1157](https://linear.app/climate-policy-radar/issue/APP-1157/sorting-by-document-on-collection-events-table-should-be-removed).