### PR TITLE
Change filter label from 'First published'

### DIFF
--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -6,7 +6,7 @@ const config: TThemeConfig = {
   labelVariations: [
     {
       key: "date",
-      label: "First published",
+      label: "Filing Year",
       category: [],
     },
   ],


### PR DESCRIPTION
# What's changed

Change search filter label from 'First published' on CCC

## Why?

Dominyka asked nicely

## Screenshots?

<img width="1147" height="913" alt="image" src="https://github.com/user-attachments/assets/48786727-e106-45ff-baf2-d79dbc7647c5" />
