### PR TITLE
APP-1161 litigation filters rework

### DIFF
--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -11,7 +11,7 @@ interface IProps {
 }
 
 const CheckBox = ({ checked, onChange, name }: IProps) => {
-  return <input type="checkbox" checked={checked || false} onChange={onChange} className="w-[24px] h-[24px]" name={name} />;
+  return <input type="checkbox" checked={checked || false} onChange={onChange} className="w-[16px] h-[16px]" name={name} />;
 };
 
 export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal }: IProps) => {

--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -7,17 +7,18 @@ interface IProps {
   additionalInfo?: string;
   learnMoreUrl?: string;
   learnMoreExternal?: boolean;
+  className?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const CheckBox = ({ checked, onChange, name }: IProps) => {
-  return <input type="checkbox" checked={checked || false} onChange={onChange} className="w-[16px] h-[16px]" name={name} />;
+  return <input type="checkbox" checked={checked || false} onChange={onChange} className="w-[20px] h-[20px]" name={name} />;
 };
 
-export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal }: IProps) => {
+export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal, className }: IProps) => {
   return (
     <>
-      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""}`}>
+      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""} ${className}`}>
         <CheckBox checked={checked} onChange={onChange} name={name} />
         <span className="flex items-center">{label}</span>
       </label>

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -120,31 +120,34 @@ export const FamilyConceptPicker = ({ concepts, containerClasses = "", showBadge
   }, [concepts]);
 
   return (
-    <div className={`relative flex flex-col gap-5 max-h-full pb-5 ${containerClasses}`} ref={ref}>
+    <div className={`relative flex flex-col max-h-full pb-4 ${containerClasses}`} ref={ref}>
       {/* HEADER */}
-      <span className="text-base font-semibold text-text-primary">
+      <span className="text-base font-semibold text-text-primary pb-4">
         <TextSearch size={20} className="inline mr-2 text-text-brand align-text-bottom" />
         {title}
         {showBadge && <Badge className="ml-2">Beta</Badge>}
       </span>
+      <div className="flex gap-2 items-center justify-between pb-5 border-b border-border-light">
+        {showSearch && (
+          <input
+            type="text"
+            placeholder="Quick search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="py-1 text-xs h-[30px]"
+          />
+        )}
+      </div>
 
       {/* SCROLL AREA */}
       <div className="flex-1 flex flex-col gap-5 overflow-y-auto scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker">
-        <div className="flex gap-2 items-center justify-between">
-          {showSearch && (
-            <input
-              type="text"
-              placeholder="Quick search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="py-1 text-xs h-[30px]"
-            />
-          )}
-        </div>
-        <div className={`flex flex-col text-sm border-t border-border-light`}>
+        <div className={`flex flex-col text-sm gap-2 pt-4`}>
           {rootConcepts.map((rootConcept) => {
             const filteredConcepts = filterConcepts(conceptsGrouped[rootConcept.wikibase_id] || [], search);
             if (filteredConcepts.length === 0) return null;
+            const childConcepts = filteredConcepts
+              .filter((concept) => concept.wikibase_id !== rootConcept.wikibase_id)
+              .sort((a, b) => conceptsSorter(a, b, "A-Z"));
             return (
               <div key={rootConcept.wikibase_id}>
                 <InputCheck
@@ -156,11 +159,9 @@ export const FamilyConceptPicker = ({ concepts, containerClasses = "", showBadge
                   }}
                   name={rootConcept.preferred_label}
                 />
-                <div className="pl-4">
-                  {filteredConcepts
-                    .filter((concept) => concept.wikibase_id !== rootConcept.wikibase_id)
-                    .sort((a, b) => conceptsSorter(a, b, "A-Z"))
-                    .map((concept, i) => (
+                {childConcepts.length > 0 && (
+                  <div className="pl-8 flex flex-col gap-2 mt-2">
+                    {childConcepts.map((concept, i) => (
                       <InputCheck
                         key={concept.wikibase_id + i}
                         label={firstCase(concept.preferred_label)}
@@ -171,7 +172,8 @@ export const FamilyConceptPicker = ({ concepts, containerClasses = "", showBadge
                         name={concept.preferred_label}
                       />
                     ))}
-                </div>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -73,11 +73,19 @@ const onConceptChange = (router: NextRouter, concept: TConcept, relatedConcepts:
       selectedConcepts = selectedConcepts.filter((c) => !relatedConcepts.map((rc) => rc.wikibase_id).includes(c));
     }
     // case 1b: child concept selected, previously selected
-    if (rootConcept) selectedConcepts = selectedConcepts.filter((c) => c !== selectedConceptLabel);
+    // - check the root concept, if not selected, remove all concepts and reselect root and concept
+    if (rootConcept) {
+      if (!selectedConcepts.includes(rootConcept.wikibase_id)) {
+        selectedConcepts = [rootConcept.wikibase_id, selectedConceptLabel];
+      } else {
+        selectedConcepts = selectedConcepts.filter((c) => c !== selectedConceptLabel);
+      }
+    }
   } else {
     // selections
     // case 1a: root concept selected, not previously selected
-    if (!rootConcept) selectedConcepts = [...selectedConcepts, selectedConceptLabel];
+    // - remove all other concepts
+    if (!rootConcept) selectedConcepts = [selectedConceptLabel];
     if (rootConcept) {
       const rootConceptLabel = rootConcept?.wikibase_id;
       // case 1b: child concept selected, not previously selected & root concept was selected
@@ -85,7 +93,8 @@ const onConceptChange = (router: NextRouter, concept: TConcept, relatedConcepts:
         selectedConcepts = [...selectedConcepts, selectedConceptLabel];
       } else {
         // case 1c: child concept selected, not previously selected & root concept not selected
-        selectedConcepts = [...selectedConcepts, selectedConceptLabel, rootConceptLabel];
+        // - remove all other concepts
+        selectedConcepts = [selectedConceptLabel, rootConceptLabel];
       }
     }
   }
@@ -95,14 +104,7 @@ const onConceptChange = (router: NextRouter, concept: TConcept, relatedConcepts:
   router.push({ query: query }, undefined, { shallow: true });
 };
 
-export const FamilyConceptPicker = ({
-  concepts,
-  containerClasses = "",
-  startingSort = "Grouped",
-  showBadge = false,
-  showSearch = true,
-  title,
-}: IProps) => {
+export const FamilyConceptPicker = ({ concepts, containerClasses = "", showBadge = false, showSearch = true, title }: IProps) => {
   const router = useRouter();
   const ref = useRef(null);
   const [search, setSearch] = useState("");
@@ -116,8 +118,6 @@ export const FamilyConceptPicker = ({
     setRootConcepts(rootConcepts);
     setConceptsGrouped(groupByRootConcept(concepts, rootConcepts));
   }, [concepts]);
-
-  // console.log(rootConcepts, conceptsGrouped);
 
   return (
     <div className={`relative flex flex-col gap-5 max-h-full pb-5 ${containerClasses}`} ref={ref}>

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -158,6 +158,12 @@ export const FamilyConceptPicker = ({ concepts, containerClasses = "", showBadge
                     onConceptChange(router, rootConcept, filteredConcepts);
                   }}
                   name={rootConcept.preferred_label}
+                  className={
+                    childConcepts.some((child) => isSelected(router.query[QUERY_PARAMS.concept_preferred_label], child.wikibase_id)) &&
+                    !childConcepts.every((child) => isSelected(router.query[QUERY_PARAMS.concept_preferred_label], child.wikibase_id))
+                      ? "semi-checked"
+                      : ""
+                  }
                 />
                 {childConcepts.length > 0 && (
                   <div className="pl-8 flex flex-col gap-2 mt-2">

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from "react";
 
 import { Accordion } from "@/components/accordion/Accordion";
 import { Badge } from "@/components/atoms/label/Badge";
-import { Select } from "@/components/atoms/select/Select";
 import { InputCheck } from "@/components/forms/Checkbox";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TConcept } from "@/types";
@@ -84,22 +83,14 @@ export const FamilyConceptPicker = ({
   const router = useRouter();
   const ref = useRef(null);
   const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<TSort>(startingSort);
   const [rootConcepts, setRootConcepts] = useState<TConcept[]>([]);
   const [conceptsGrouped, setConceptsGrouped] = useState<{
     [rootConceptId: string]: TConcept[];
   }>({});
-  const [filteredConcepts, setFilteredConcepts] = useState<TConcept[]>([]);
-
-  const selectOptions = SORT_OPTIONS.map((option) => ({
-    value: option,
-    label: option,
-  }));
 
   useEffect(() => {
     const rootConcepts = concepts.filter((concept) => concept.recursive_subconcept_of.length === 0);
     setRootConcepts(rootConcepts);
-    setFilteredConcepts(concepts);
     setConceptsGrouped(groupByRootConcept(concepts, rootConcepts));
   }, [concepts]);
 
@@ -124,66 +115,38 @@ export const FamilyConceptPicker = ({
               className="py-1 text-xs h-[30px]"
             />
           )}
-          <div className="basis-3/10 shrink-0 relative flex items-center">
-            <label className="text-sm text-text-tertiary">Sort:</label>
-            <Select
-              defaultValue="A-Z"
-              value={sort}
-              onValueChange={(value) => setSort(value as TSort)}
-              options={selectOptions}
-              container={ref.current}
-            />
-          </div>
         </div>
-        <div className={`flex flex-col text-sm border-t border-border-light ${sort === "A-Z" ? "gap-2 border-t-0" : ""}`}>
-          {/* GROUPED SORT */}
-          {sort === "Grouped" &&
-            rootConcepts.map((rootConcept, rootConceptIndex) => {
-              const filteredConcepts = filterConcepts(conceptsGrouped[rootConcept.wikibase_id] || [], search);
-              if (filteredConcepts.length === 0) return null;
-              return (
-                <Accordion
-                  title={firstCase(rootConcept.preferred_label)}
-                  key={rootConcept.wikibase_id + rootConceptIndex}
-                  fixedHeight="100%"
-                  startOpen={true}
-                  open={search === "" ? undefined : true}
-                  className="py-3 border-b border-border-lighter"
-                >
-                  <div className="flex flex-col gap-2 pb-2">
-                    {filteredConcepts
-                      .sort((a, b) => conceptsSorter(a, b, "A-Z"))
-                      .map((concept, i) => (
-                        <InputCheck
-                          key={concept.wikibase_id + i}
-                          label={firstCase(concept.preferred_label)}
-                          checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.wikibase_id)}
-                          onChange={() => {
-                            onConceptChange(router, concept);
-                          }}
-                          name={concept.preferred_label}
-                        />
-                      ))}
-                  </div>
-                </Accordion>
-              );
-            })}
-
-          {/* A-Z SORT */}
-          {sort === "A-Z" &&
-            filterConcepts(filteredConcepts, search)
-              .sort((a, b) => conceptsSorter(a, b, sort))
-              .map((concept) => (
-                <InputCheck
-                  key={concept.wikibase_id}
-                  label={firstCase(concept.preferred_label)}
-                  checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.preferred_label)}
-                  onChange={() => {
-                    onConceptChange(router, concept);
-                  }}
-                  name={concept.preferred_label}
-                />
-              ))}
+        <div className={`flex flex-col text-sm border-t border-border-light`}>
+          {rootConcepts.map((rootConcept, rootConceptIndex) => {
+            const filteredConcepts = filterConcepts(conceptsGrouped[rootConcept.wikibase_id] || [], search);
+            if (filteredConcepts.length === 0) return null;
+            return (
+              <Accordion
+                title={firstCase(rootConcept.preferred_label)}
+                key={rootConcept.wikibase_id + rootConceptIndex}
+                fixedHeight="100%"
+                startOpen={true}
+                open={search === "" ? undefined : true}
+                className="py-3 border-b border-border-lighter"
+              >
+                <div className="flex flex-col gap-2 pb-2">
+                  {filteredConcepts
+                    .sort((a, b) => conceptsSorter(a, b, "A-Z"))
+                    .map((concept, i) => (
+                      <InputCheck
+                        key={concept.wikibase_id + i}
+                        label={firstCase(concept.preferred_label)}
+                        checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.wikibase_id)}
+                        onChange={() => {
+                          onConceptChange(router, concept);
+                        }}
+                        name={concept.preferred_label}
+                      />
+                    ))}
+                </div>
+              </Accordion>
+            );
+          })}
 
           <div className="h-[34px] sticky block bottom-0 w-full bg-gradient-to-b from-transparent to-white">&nbsp;</div>
         </div>

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -2,7 +2,6 @@ import { TextSearch } from "lucide-react";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
-import { Accordion } from "@/components/accordion/Accordion";
 import { Badge } from "@/components/atoms/label/Badge";
 import { InputCheck } from "@/components/forms/Checkbox";
 import { QUERY_PARAMS } from "@/constants/queryParams";
@@ -24,14 +23,19 @@ const SORT_OPTIONS = ["A-Z", "Grouped"] as const;
 
 type TSort = (typeof SORT_OPTIONS)[number];
 
-const isSelected = (queryValue: string | string[] | undefined, option: string) => {
+const isSelected = (queryValue: string | string[] | undefined, option: string, parent: string = undefined) => {
   if (!queryValue) {
     return false;
   }
   if (typeof queryValue === "string") {
     return queryValue === option;
   } else {
-    return queryValue.includes(option);
+    // if parent is provided, check if both parent and option are in the query
+    if (parent) {
+      return queryValue.includes(option) && queryValue.includes(parent);
+    } else {
+      return queryValue.includes(option);
+    }
   }
 };
 
@@ -138,7 +142,7 @@ export const FamilyConceptPicker = ({
           )}
         </div>
         <div className={`flex flex-col text-sm border-t border-border-light`}>
-          {rootConcepts.map((rootConcept, rootConceptIndex) => {
+          {rootConcepts.map((rootConcept) => {
             const filteredConcepts = filterConcepts(conceptsGrouped[rootConcept.wikibase_id] || [], search);
             if (filteredConcepts.length === 0) return null;
             return (
@@ -160,7 +164,7 @@ export const FamilyConceptPicker = ({
                       <InputCheck
                         key={concept.wikibase_id + i}
                         label={firstCase(concept.preferred_label)}
-                        checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.wikibase_id)}
+                        checked={isSelected(router.query[QUERY_PARAMS.concept_preferred_label], concept.wikibase_id, rootConcept.wikibase_id)}
                         onChange={() => {
                           onConceptChange(router, concept, filteredConcepts, rootConcept);
                         }}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -121,7 +121,13 @@ const getSelectedConcepts = (selectedConcepts: string | string[], allConcepts: T
 
 const getSelectedFamilyConcepts = (selectedConcepts: string | string[], allConcepts: TConcept[] = []): TConcept[] => {
   const selectedConceptsAsArray = Array.isArray(selectedConcepts) ? selectedConcepts : [selectedConcepts];
-  return allConcepts?.filter((concept) => selectedConceptsAsArray.includes(concept.wikibase_id)) || [];
+  return (
+    allConcepts?.filter(
+      (concept) =>
+        selectedConceptsAsArray.includes(concept.wikibase_id) &&
+        (concept.recursive_subconcept_of.length === 0 || concept.recursive_subconcept_of.some((sub) => selectedConceptsAsArray.includes(sub)))
+    ) || []
+  );
 };
 
 const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -100,6 +100,13 @@
     background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
     @apply border-black bg-transparent;
   }
+
+  .semi-checked [type="checkbox"]:checked,
+  .semi-checked [type="checkbox"]:checked:focus {
+    background: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3e%3cpath d='M3.33331 8H12.6666' stroke='white' stroke-width='2'/%3e%3c/svg%3e");
+    @apply bg-inputSelected;
+  }
 }
 
 /* Necessary for Base UI overlays (tooltip, popover etc.) */


### PR DESCRIPTION
# What's changed
- Adding hierarchical display of filters
- Making sure not more than one root concept can be selected at once

## Why?
- Hierarchies were not displaying in an intuitive way

## Screenshots?
<img width="887" height="718" alt="Screenshot 2025-09-16 at 17 29 21" src="https://github.com/user-attachments/assets/5bec3928-9f65-4fdc-83df-0e8a20525afb" />
