### PR TITLE
APP-1129: Old search results overrides current results

### DIFF
--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import React from "react";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
@@ -27,6 +28,8 @@ const BreadCrumb = ({ last = false, label = null, href = null, cy = "", isHome =
     return null;
   }
 
+  const LinkComponent = isHome ? Link : LinkWithQuery;
+
   const labelShort =
     typeof label === "string" && label.toString().length > BREADCRUMB_MAXLENGTH ? `${label.toString().substring(0, BREADCRUMB_MAXLENGTH)}...` : label;
 
@@ -34,14 +37,14 @@ const BreadCrumb = ({ last = false, label = null, href = null, cy = "", isHome =
     <>
       <li data-cy={`breadcrumb ${cy}`} className={`${last && "text-textDark font-medium"}`}>
         {href ? (
-          <LinkWithQuery className="underline hover:text-blue-800 text-textNormal flex items-baseline" href={href}>
+          <LinkComponent className="underline hover:text-blue-800 text-textNormal flex items-baseline" href={href}>
             {isHome && (
               <span className="mr-1 translate-y-0.5">
                 <Icon name="house" />
               </span>
             )}
             {labelShort}
-          </LinkWithQuery>
+          </LinkComponent>
         ) : (
           <span className="flex items-baseline">
             {isHome && (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -29,7 +29,6 @@ import Pagination from "@/components/pagination";
 import { MultiCol } from "@/components/panels/MultiCol";
 import { SideCol } from "@/components/panels/SideCol";
 import { SingleCol } from "@/components/panels/SingleCol";
-import { SiteWidth } from "@/components/panels/SiteWidth";
 import SearchResultList from "@/components/search/SearchResultList";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { SEARCH_SETTINGS } from "@/constants/searchSettings";

--- a/themes/ccc/components/Footer.tsx
+++ b/themes/ccc/components/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { ExternalLink } from "@/components/ExternalLink";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Columns } from "@/components/atoms/columns/Columns";
@@ -15,19 +17,19 @@ export const Footer = () => {
 
       <Columns>
         <aside className="flex flex-col items-start cols-2:col-span-2 cols-3:col-span-1">
-          <LinkWithQuery href="/" className="max-w-70">
+          <Link href="/" className="max-w-70">
             {/* trunk-ignore(eslint/@next/next/no-img-element) */}
             <img src="/images/ccc/sabin-logo-large.png" alt="Sabin Center for Climate Change logo" className="w-full mb-2" />
-          </LinkWithQuery>
+          </Link>
         </aside>
 
         <main className="cols-2:col-span-2 cols-4:col-span-3 grid grid-cols-subgrid gap-6">
           <div className="flex flex-col items-start gap-2">
             <ul className="space-y-1">
               <li>
-                <LinkWithQuery href="/" className={`${link} ${strong}`}>
+                <Link href="/" className={`${link} ${strong}`}>
                   Home
-                </LinkWithQuery>
+                </Link>
               </li>
               <li>
                 <LinkWithQuery href="/search" className={`${link} ${strong}`}>

--- a/themes/ccc/components/Header.tsx
+++ b/themes/ccc/components/Header.tsx
@@ -1,14 +1,14 @@
+import Link from "next/link";
 import { useRouter } from "next/router";
 
 import { Menu } from "@/ccc/components/Menu";
-import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { NavBar } from "@/components/organisms/navBar/NavBar";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
 export const CCLWLogo = (
-  <LinkWithQuery href={`/`} cypress="cclw-logo">
+  <Link href="/" data-cy="cclw-logo">
     <span className="text-text-primary text-2xl font-medium">Climate Case Chart</span>
-  </LinkWithQuery>
+  </Link>
 );
 
 const Header = () => {

--- a/themes/ccc/components/Menu.tsx
+++ b/themes/ccc/components/Menu.tsx
@@ -25,7 +25,15 @@ export const Menu = () => {
         <div className="absolute right-0 top-[100%] z-50">
           <DropdownMenuWrapper>
             {MENU_LINKS.map((link, index) => (
-              <DropdownMenuItem key={index} {...link} title={link.text} setShowMenu={setShowMenu} first={index === 0} cy={`navigation-${link.cy}`} />
+              <DropdownMenuItem
+                key={index}
+                {...link}
+                title={link.text}
+                external={link.href === "/"}
+                setShowMenu={setShowMenu}
+                first={index === 0}
+                cy={`navigation-${link.cy}`}
+              />
             ))}
           </DropdownMenuWrapper>
         </div>


### PR DESCRIPTION
# What's changed

- `useSearch` adds an `AbortController` `AbortSignal` to the Axios request, and calls the abort if the `useEffect` iteration is unmounted.
  - Effectively kills an in-flight Axios request if a new request is started.
  - Handles the `Promise.then` situation where `undefined` is returned from an aborted request.
- Drive-by on links to the CCC homepage not preserving the active search params.
  - `LinkWithQuery` changed to `Link`.

## Why?

Satisfies both [APP-1129](https://linear.app/climate-policy-radar/issue/APP-1129/old-search-results-overrides-current-results) and [APP-1142](https://linear.app/climate-policy-radar/issue/APP-1142/going-back-to-homepage-search-should-remove-any-previous-keywords-or).