### PR TITLE
APP-1188: Burger menu does not appear on the landing page

### DIFF
--- a/themes/ccc/pages/homepage.tsx
+++ b/themes/ccc/pages/homepage.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 
 import { FeatureDiscover } from "@/ccc/components/FeatureDiscover";
 import { Footer } from "@/ccc/components/Footer";
+import Header from "@/ccc/components/Header";
 import { Hero } from "@/ccc/components/Hero";
 import { PoweredBy } from "@/ccc/components/PoweredBy";
 import Layout from "@/components/layouts/LandingPage";
@@ -27,8 +28,9 @@ interface IProps {
 const LandingPage = ({ handleSearchInput, searchInput, theme, themeConfig, exactMatch }: IProps) => {
   return (
     <Layout theme={theme} themeConfig={themeConfig} metadataKey="homepage">
+      <Header />
       <main id="main" className="md:h-screen">
-        <SiteWidth extraClasses="md:flex justify-between p-10 pb-14 h-full md:gap-10 lg:gap-16 md:h-[calc(100%-220px)] lg:h-[calc(100%-280px)] xl:h-[calc(100%-344px)]">
+        <SiteWidth extraClasses="md:flex justify-between p-10 pt-0 pb-14 h-full md:gap-10 lg:gap-16 md:h-[calc(100%-220px)] lg:h-[calc(100%-280px)] xl:h-[calc(100%-344px)]">
           <Hero handleSearchInput={handleSearchInput} searchInput={searchInput} exactMatch={exactMatch} />
         </SiteWidth>
         <FullWidth extraClasses="hidden md:block relative md:h-[220px] lg:h-[280px] xl:h-[344px]">


### PR DESCRIPTION
# What's changed

- Added `Header` to CCC home page.

## Why?

Satisfies [APP-1188](https://linear.app/climate-policy-radar/issue/APP-1188/burger-menu-does-not-appear-on-the-landing-page).

## Screenshots?

<img width="1642" height="1353" alt="Screenshot 2025-09-17 at 13 44 11" src="https://github.com/user-attachments/assets/d4bbea0d-9cd3-4d54-960c-3741d5c14705" />
