### PR TITLE
Feature/app 1190 Clarify the count on search results

### DIFF
--- a/src/components/pages/geographyLitigationPage.tsx
+++ b/src/components/pages/geographyLitigationPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ApiClient } from "@/api/http-common";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Debug } from "@/components/atoms/debug/Debug";
+import { MetadataBlock } from "@/components/blocks/metadataBlock/MetadataBlock";
 import { RecentFamiliesBlock } from "@/components/blocks/recentFamiliesBlock/RecentFamiliesBlock";
 import { SubDivisionBlock } from "@/components/blocks/subDivisionBlock/SubDivisionBlock";
 import { TargetsBlock } from "@/components/blocks/targetsBlock/TargetsBlock";
@@ -16,6 +17,7 @@ import { IPageHeaderMetadata, PageHeader } from "@/components/organisms/pageHead
 import { GeographiesContext } from "@/context/GeographiesContext";
 import { TSearch, TGeographyPageBlock } from "@/types";
 import buildSearchQuery from "@/utils/buildSearchQuery";
+import { getGeographyMetaData } from "@/utils/getGeographyMetadata";
 import { sortFilterTargets } from "@/utils/sortFilterTargets";
 
 import { IProps } from "./geographyOriginalPage";
@@ -82,7 +84,6 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
       }, [geographyV2]),
       sideBarItem: { display: "Legislative Process" },
     },
-    statistics: null,
     recents: {
       render: useCallback(() => {
         const backendApiClient = new ApiClient(envConfig.BACKEND_API_URL, envConfig.BACKEND_API_TOKEN);
@@ -146,6 +147,14 @@ export const GeographyLitigationPage = ({ geographyV2, parentGeographyV2, target
         );
       }, [envConfig, geographyV2, recentFamiliesTitle, searchResultsByCategory, theme, themeConfig]),
       sideBarItem: { display: recentFamiliesTitle },
+    },
+    statistics: {
+      render: useCallback(() => {
+        const geographyMetaData = geographyV2.statistics ? getGeographyMetaData(geographyV2.statistics) : [];
+        if (geographyMetaData.length === 0) return null;
+
+        return <MetadataBlock key="statistics" block="statistics" title="Statistics" metadata={geographyMetaData} />;
+      }, [geographyV2]),
     },
     subdivisions: {
       render: useCallback(() => {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -557,7 +557,11 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
                         <div className="flex flex-wrap gap-4 justify-between items-start">
                           <div className="flex items-center gap-2">
                             <p className="text-sm text-text-primary font-normal">
-                              Results <span className="text-text-secondary">{hits || 0}</span>
+                              Results{" "}
+                              <span className="text-text-secondary">
+                                {hits || 0}
+                                {themeConfig.searchResultCountLabel ? ` ${themeConfig.searchResultCountLabel}` : ""}
+                              </span>
                             </p>
                             <Info
                               title="Showing the top 500 results"

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -96,4 +96,5 @@ export type TThemeConfig = {
   defaultDocumentCategory: TDocumentCategory;
   pageBlocks: TThemePageBlocks;
   features: TConfigFeatures;
+  searchResultCountLabel: string;
 };

--- a/themes/ccc/config.ts
+++ b/themes/ccc/config.ts
@@ -52,6 +52,7 @@ const config: TThemeConfig = {
     litigation: true,
     searchFamilySummary: true,
   },
+  searchResultCountLabel: "cases",
 };
 
 export default config;

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -184,6 +184,7 @@ const config: TThemeConfig = {
     litigation: false,
     searchFamilySummary: true,
   },
+  searchResultCountLabel: "",
 };
 
 export default config;

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -369,6 +369,7 @@ const config: TThemeConfig = {
     litigation: false,
     searchFamilySummary: false,
   },
+  searchResultCountLabel: "",
 };
 
 export default config;

--- a/themes/mcf/config.ts
+++ b/themes/mcf/config.ts
@@ -148,6 +148,7 @@ const config: TThemeConfig = {
     litigation: false,
     searchFamilySummary: true,
   },
+  searchResultCountLabel: "",
 };
 
 export default config;


### PR DESCRIPTION
# What's changed

- Add search result count label for litigation app (configurable in theme config)
- Driveby fix by reverting the change to the stats block in the geo page rendering

## Screenshots?

Note the 151 cases at the top 

<img width="1627" height="958" alt="image" src="https://github.com/user-attachments/assets/59e7a264-9159-4d4c-a702-70646947505a" />
