### PR TITLE
fix: move to collections and slugs

### DIFF
--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -121,7 +121,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
       label: "Part of",
       value: joinNodes(
         family.collections.map((collection) => (
-          <LinkWithQuery key={collection.import_id} href={`/collection/${collection.import_id}`} className="underline">
+          <LinkWithQuery key={collection.import_id} href={`/collections/${collection.slug}`} className="underline">
             {collection.title}
           </LinkWithQuery>
         )),

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -105,13 +105,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return { notFound: true };
   }
 
-  const import_id = context.params.id;
-  const apiClient = new ApiClient(process.env.CONCEPTS_API_URL);
-
   let collectionData: TCollectionPublicWithFamilies;
 
   try {
-    const { data: collectionResponse } = await apiClient.get(`/families/collections/${import_id}`);
+    const apiClient = new ApiClient(process.env.CONCEPTS_API_URL);
+    const id = context.params.id;
+    const { data: slugData } = await apiClient.get(`/families/slugs/${id}`);
+    const collection_import_id = slugData.data.collection_import_id;
+
+    const { data: collectionResponse } = await apiClient.get(`/families/collections/${collection_import_id}`);
     collectionData = collectionResponse.data;
   } catch (error) {}
 


### PR DESCRIPTION
# What's changed
- moves collection => collections to sync with APIs
- uses slugs to sync with other pages

## Why?

Consistency is key. If we make a change, this will make it easier to do universally.