### PR TITLE
APP-1199 Add control to clear other values when interacting with AppliedFilters

### DIFF
--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -13,7 +13,7 @@ import useSubdivisions from "@/hooks/useSubdivisions";
 import useGetThemeConfig from "@/hooks/useThemeConfig";
 import { TConcept, TGeography, TGeographySubdivision, TThemeConfig, TGeographyWithDocumentCounts } from "@/types";
 
-type TFilterChange = (type: string, value: string) => void;
+type TFilterChange = (type: string, value: string, clearOthersOfType?: boolean, otherValuesToClear?: string[]) => void;
 
 interface IProps {
   filterChange: TFilterChange;
@@ -67,6 +67,7 @@ const handleFilterDisplay = (
 ) => {
   let filterLabel: string | null | undefined = null;
   let filterValue = value;
+  let otherValuesToClear: string[] = [];
   switch (key) {
     case "category":
       const configCategory = themeConfig?.categories?.options.find((c) => c.slug === value);
@@ -86,6 +87,8 @@ const handleFilterDisplay = (
       break;
     case "concept_preferred_label":
       filterLabel = handleConceptName(value, familyConcepts);
+      // If we are removing a root concept, we should also remove all child concepts
+      otherValuesToClear = familyConcepts?.filter((c) => c.recursive_subconcept_of.includes(value)).map((c) => c.wikibase_id) || [];
       break;
     case "exact_match":
       filterLabel = value === "true" ? "Exact phrases only" : "Related phrases";
@@ -129,7 +132,7 @@ const handleFilterDisplay = (
   }
 
   return (
-    <Pill key={value} onClick={() => filterChange(QUERY_PARAMS[key], filterValue)}>
+    <Pill key={value} onClick={() => filterChange(QUERY_PARAMS[key], filterValue, false, otherValuesToClear)}>
       {filterLabel}
     </Pill>
   );

--- a/src/components/filters/SearchFilters.tsx
+++ b/src/components/filters/SearchFilters.tsx
@@ -41,7 +41,7 @@ interface IProps {
   corpus_types: TCorpusTypeDictionary;
   conceptsData?: TConcept[];
   familyConceptsData?: TConcept[];
-  handleFilterChange(type: string, value: string, clearOthersOfType?: boolean): void;
+  handleFilterChange(type: string, value: string, clearOthersOfType?: boolean, otherValuesToClear?: string[]): void;
   handleYearChange(values: string[], reset?: boolean): void;
   handleClearSearch(): void;
   handleDocumentCategoryClick(value: string): void;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -215,7 +215,7 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
     resetCSVStatus();
   };
 
-  const handleFilterChange = (type: string, value: string, clearOthersOfType: boolean = false) => {
+  const handleFilterChange = (type: string, value: string, clearOthersOfType: boolean = false, otherValuesToClear: string[] = []) => {
     // Clear pagination controls and continuation tokens
     delete router.query[QUERY_PARAMS.offset];
     delete router.query[QUERY_PARAMS.active_continuation_token];
@@ -244,6 +244,11 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
       // If we are removing a year range, we should also remove the other year range
       if (type === QUERY_PARAMS.year_range) {
         queryCollection = [];
+      }
+
+      // In some scenarios we want to clear other values of the same type
+      if (otherValuesToClear.length > 0) {
+        queryCollection = queryCollection.filter((item) => !otherValuesToClear.includes(item));
       }
     } else {
       // If we want the filter to be exclusive, we clear all other filters of the same type


### PR DESCRIPTION
# What's changed
- When a user selects to remove a root concept from the list of `AppliedFilters` we now clear all the child filters, to prevent unwanted behaviour

## Why?
- Bug that allowed root concepts to be removed but leaving the child concepts, which is invalid in the new structure

## Screenshots?
https://github.com/user-attachments/assets/4f3bd89b-1230-4019-82ca-beeca1f1f21f

