### PR TITLE
fix: use families-api for litigation family pages

### DIFF
--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -6,7 +6,16 @@ import { ApiClient } from "@/api/http-common";
 import { FamilyLitigationPage } from "@/components/pages/familyLitigationPage";
 import { FamilyOriginalPage, IProps } from "@/components/pages/familyOriginalPage";
 import { withEnvConfig } from "@/context/EnvConfig";
-import { TCorpusTypeDictionary, TFamilyPage, TFamilyPublic, TGeography, TGeographySubdivision, TSearchResponse, TTarget } from "@/types";
+import {
+  TCorpusTypeDictionary,
+  TFamilyPage,
+  TFamilyPublic,
+  TGeography,
+  TGeographySubdivision,
+  TSearchResponse,
+  TSlugResponse,
+  TTarget,
+} from "@/types";
 import { extractNestedData } from "@/utils/extractNestedData";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { isKnowledgeGraphEnabled, isLitigationEnabled } from "@/utils/features";
@@ -47,27 +56,36 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   let corpus_types: TCorpusTypeDictionary;
   let subdivisionsData: TGeographySubdivision[] = [];
 
-  try {
-    const { data: returnedData } = await backendApiClient.get(`/documents/${id}`);
-    familyData = returnedData;
-
-    if (knowledgeGraphEnabled) {
-      // fetch the families
-      const { data: vespaFamilyDataResponse } = await backendApiClient.get(`/families/${familyData.import_id}`);
-      vespaFamilyData = vespaFamilyDataResponse;
-    }
-  } catch (error) {
-    // TODO: handle error more elegantly
-  }
-
-  // We're using the new families-api for litigation work
-  // This is slightly inefficient as we're making 2 API calls but we'll deprecate ☝️ once this becomes universal
   const litigationEnabled = isLitigationEnabled(featureFlags, themeConfig);
+  /** We're using the new families-api for litigation work */
   if (litigationEnabled) {
     try {
-      const { data: familyResponse } = await apiClient.get(`/families/${familyData.import_id}`);
+      let slug: TSlugResponse;
+      try {
+        const { data: slugData } = await apiClient.get(`/families/slugs/${id}`);
+        slug = slugData.data;
+      } catch (error) {
+        return {
+          notFound: true,
+        };
+      }
+      const { data: familyResponse } = await apiClient.get(`/families/${slug.family_import_id}`);
       familyData = familyResponse.data;
     } catch (error) {}
+  } else {
+    /** TODO: move over to exclusively using the families-api */
+    try {
+      const { data: returnedData } = await backendApiClient.get(`/documents/${id}`);
+      familyData = returnedData;
+
+      if (knowledgeGraphEnabled) {
+        // fetch the families
+        const { data: vespaFamilyDataResponse } = await backendApiClient.get(`/families/${familyData.import_id}`);
+        vespaFamilyData = vespaFamilyDataResponse;
+      }
+    } catch (error) {
+      // TODO: handle error more elegantly
+    }
   }
 
   if (familyData) {


### PR DESCRIPTION
# What's changed
- when on litigation - use the families API endpoint

This fixes the litigation homepage "Latest" families from erroring.