### PR TITLE
fix typo in CCC tutorial text

### DIFF
--- a/src/constants/tutorials.tsx
+++ b/src/constants/tutorials.tsx
@@ -82,7 +82,7 @@ export const TUTORIALS: TTutorials = {
       title: "Welcome to our new site",
       content: (
         <p>
-          The Climate Litigation Database is the most comprehensive resource tracking climate change litigation worldwide. Please bare with us while
+          The Climate Litigation Database is the most comprehensive resource tracking climate change litigation worldwide. Please bear with us while
           we make some exciting new updates.
         </p>
       ),


### PR DESCRIPTION
# What's changed

Fix for typo

## Why?

> “Bare with me” translates to “uncover with me” and is an incorrect way to spell this phrase. 

😆 https://www.grammarly.com/blog/grammar/bear-with-me/

## Screenshots?
