### PR TITLE
Treat empty string dates as empty strings, order missing dates last rather than first

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -12,7 +12,8 @@ import { TFamilyDocumentPublic, TFamilyPublic, TGeography, TLoadingStatus, TMatc
 import { getEventTableColumns, getEventTableRows, TEventTableColumnId } from "@/utils/eventTable";
 import { formatDate } from "@/utils/timedate";
 
-const getOldestEventDate = (document: TFamilyDocumentPublic) => document.events.map((event) => event.date).sort()[0];
+// If no date found for an event, use an empty string so it sorts to the bottom
+const getOldestEventDate = (document: TFamilyDocumentPublic) => document.events.map((event) => event.date).sort()[0] || "";
 
 interface IProps {
   family: TFamilyPublic;

--- a/src/utils/timedate.ts
+++ b/src/utils/timedate.ts
@@ -18,6 +18,7 @@ export const padNumber = (number) => {
 };
 
 export const formatDate = (data: string) => {
+  if (!data || data.length === 0) return ["", "", ""];
   const dateObj = new Date(data);
   const year = dateObj.getFullYear();
   const day = padNumber(dateObj.getDate());


### PR DESCRIPTION
# What's changed
- Not display `NaN` in the UI - show empty string instead
- Order documents with missing dates last in the descending list rather than first
