### PR TITLE
fix: add more root concepts

### DIFF
--- a/src/utils/processConcepts.ts
+++ b/src/utils/processConcepts.ts
@@ -11,6 +11,8 @@ export const ROOT_LEVEL_CONCEPTS = {
   Q1171: "Instruments",
   Q218: "Greenhouse gases",
   Q1367: "Public finance actors",
+  Q47: "Just transition",
+  Q567: "Renewable energy",
 };
 export const rootLevelConceptsIds = Object.keys(ROOT_LEVEL_CONCEPTS);
 


### PR DESCRIPTION
Adds more root concepts

<img width="470" height="1067" alt="Screenshot 2025-09-24 at 13 43 19" src="https://github.com/user-attachments/assets/d2347395-9e85-400f-ae45-1540d4955573" />

There is a bug that "Fossil fuels" isn't currently showing, we're looking into it.