### PR TITLE
APP-1224 - timezone affecting date display

### DIFF
--- a/src/constants/timedate.ts
+++ b/src/constants/timedate.ts
@@ -3,12 +3,12 @@ export const months = ["January", "February", "March", "April", "May", "June", "
 export const minYear = 1947;
 export const currentYear = (): number => {
   const now = new Date();
-  return now.getUTCFullYear();
+  return now.getFullYear();
 };
 
 export const yearRange = () => {
   const min = minYear;
-  const max = new Date().getUTCFullYear();
+  const max = new Date().getFullYear();
   const arr = [];
   for (let i = min; i <= max; i++) {
     arr.push(i);
@@ -20,5 +20,5 @@ export const yearRange = () => {
 
 export const daysInMonth = (month, year) => {
   // Use 1 for January, 2 for February, etc.
-  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return new Date(year, month, 0).getDate();
 };

--- a/src/constants/timedate.ts
+++ b/src/constants/timedate.ts
@@ -3,12 +3,12 @@ export const months = ["January", "February", "March", "April", "May", "June", "
 export const minYear = 1947;
 export const currentYear = (): number => {
   const now = new Date();
-  return now.getFullYear();
+  return now.getUTCFullYear();
 };
 
 export const yearRange = () => {
   const min = minYear;
-  const max = new Date().getFullYear();
+  const max = new Date().getUTCFullYear();
   const arr = [];
   for (let i = min; i <= max; i++) {
     arr.push(i);
@@ -20,5 +20,5 @@ export const yearRange = () => {
 
 export const daysInMonth = (month, year) => {
   // Use 1 for January, 2 for February, etc.
-  return new Date(year, month, 0).getDate();
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
 };

--- a/src/helpers/getApprovedYearFromEvents.ts
+++ b/src/helpers/getApprovedYearFromEvents.ts
@@ -3,7 +3,7 @@ export const getApprovedYearFromEvents = (events) => {
 
   if (approvalEvent) {
     const date = new Date(approvalEvent.date);
-    return String(date.getFullYear());
+    return String(date.getUTCFullYear());
   }
 
   return null;

--- a/src/utils/getCollectionMetadata.tsx
+++ b/src/utils/getCollectionMetadata.tsx
@@ -18,7 +18,7 @@ export const getCollectionMetadata = (collection: TCollectionPublicWithFamilies)
     const earliestFilingDate = new Date(Math.min(...filingDates.map((date) => date.getTime())));
     collectionMetadata.push({
       label: "Filing date",
-      value: earliestFilingDate && !isNaN(earliestFilingDate.getFullYear()) ? earliestFilingDate.getFullYear() : EN_DASH,
+      value: earliestFilingDate && !isNaN(earliestFilingDate.getUTCFullYear()) ? earliestFilingDate.getUTCFullYear() : EN_DASH,
     });
   } else {
     collectionMetadata.push({

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -39,7 +39,7 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
 
   metadata.push({
     label: "Filing year",
-    value: filingTimestamp ? new Date(filingTimestamp).getFullYear() : EN_DASH,
+    value: filingTimestamp ? new Date(filingTimestamp).getUTCFullYear() : EN_DASH,
   });
 
   /* Status */

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -33,7 +33,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   const isUSA = geosOrdered.includes("USA");
 
   /* Filing year */
-
   let filingTimestamp = family.events.find((event) => event.event_type === "Filing Year For Action")?.date;
   if (isUSA && family.published_date) filingTimestamp = family.published_date;
 
@@ -43,14 +42,12 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   });
 
   /* Status */
-
   metadata.push({
     label: "Status",
     value: family.metadata.status ?? EN_DASH,
   });
 
   /* Geography */
-
   if (geosOrdered.length > 0) {
     metadata.push({
       label: "Geography",
@@ -73,7 +70,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   }
 
   /* Docket number */
-
   if (isUSA) {
     metadata.push({
       label: "Docket number",
@@ -86,7 +82,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   }
 
   /* Court/admin entity */
-
   const legalEntities = hierarchy.filter((concept) => concept.type === "legal_entity");
   metadata.push({
     label: "Court/admin entity",
@@ -98,7 +93,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   });
 
   /* Case category */
-
   const caseCategories = hierarchy.filter((concept) => concept.type === "legal_category");
   metadata.push({
     label: "Case category",
@@ -110,7 +104,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   });
 
   /* Principal law */
-
   const principalLaws = hierarchy.filter((concept) => concept.type === "law");
   metadata.push({
     label: "Principal law",
@@ -120,7 +113,6 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
   });
 
   /* At issue */
-
   let atIssueValue: ReactNode = null;
 
   if (isUSA && family.collections[0]) {

--- a/src/utils/timedate.ts
+++ b/src/utils/timedate.ts
@@ -33,5 +33,6 @@ export const formatDateShort = (date: Date): string => {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
+    timeZone: "UTC",
   }).format(date);
 };

--- a/src/utils/timedate.ts
+++ b/src/utils/timedate.ts
@@ -7,9 +7,9 @@ export const convertDate = (data: string): [number, string, string] => {
     const [day, month, year] = data.split("/");
     dateObj = new Date(`${month}-${day}-${year}`);
   }
-  const year = dateObj.getFullYear();
-  const day = padNumber(dateObj.getDate());
-  const month = dateObj.getMonth();
+  const year = dateObj.getUTCFullYear();
+  const day = padNumber(dateObj.getUTCDate());
+  const month = dateObj.getUTCMonth();
   return [year, day, months[month]?.substring(0, 3)];
 };
 
@@ -20,9 +20,9 @@ export const padNumber = (number) => {
 export const formatDate = (data: string) => {
   if (!data || data.length === 0) return ["", "", ""];
   const dateObj = new Date(data);
-  const year = dateObj.getFullYear();
-  const day = padNumber(dateObj.getDate());
-  const month = dateObj.getMonth();
+  const year = dateObj.getUTCFullYear();
+  const day = padNumber(dateObj.getUTCDate());
+  const month = dateObj.getUTCMonth();
   return [year, day, months[month]];
 };
 


### PR DESCRIPTION
# What's changed
- Instances where we access an entity's date, we were modifying it to the client's timezone as opposed to keeping it an a universal time - which means depending on your location you would see a different value (in most cases a date, or year) for an entity which should never be different regardless of where you are viewing it from

## Why?
- Confusing and incorrect data is presented to the user
