### PR TITLE
fix: use ccc canonical for non document pages

### DIFF
--- a/src/utils/getThemeDomain.ts
+++ b/src/utils/getThemeDomain.ts
@@ -3,6 +3,7 @@ import { TTheme } from "@/types";
 const CPR_DOMAIN = "app.climatepolicyradar.org";
 const CCLW_DOMAIN = "climate-laws.org";
 const MCF_DOMAIN = "climateprojectexplorer.org";
+const CCC_DOMAIN = "www.climatecasechart.com";
 
 export default function getThemeDomain(site: TTheme): string {
   let domain = CPR_DOMAIN;
@@ -12,6 +13,9 @@ export default function getThemeDomain(site: TTheme): string {
       break;
     case "mcf":
       domain = MCF_DOMAIN;
+      break;
+    case "ccc":
+      domain = CCC_DOMAIN;
       break;
   }
   return domain;


### PR DESCRIPTION
# What's changed
- add the `www.climatecasechart.com` url to use on non-document pages

This uses the `canonical_url` on other pages.

This might better live in the `ThemeConfig`?

## Why?

it's the canonical URL

## Screenshots?
