### PR TITLE
refactor: disable this search on search page for litigation

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -448,20 +448,24 @@ const Search: InferGetServerSidePropsType<typeof getServerSideProps> = ({
               <div className="px-3 cols-2:px-6 cols-3:px-8">
                 <span className="text-sm mb-4 md:mb-0 text-right flex flex-wrap gap-x-2 md:justify-end">
                   <span>Download data (.csv): </span>
-                  <a
-                    href="#"
-                    className="flex gap-2 items-center justify-end text-blue-600 hover:underline hover:text-blue-800"
-                    data-cy="download-search-csv"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setShowCSVDownloadPopup(true);
-                    }}
-                  >
-                    {downloadCSVStatus === "loading" ? <Icon name="loading" /> : "this search"}
-                  </a>
+                  {!isLitigationEnabled(featureFlags, themeConfig) && (
+                    <>
+                      <a
+                        href="#"
+                        className="flex gap-2 items-center justify-end text-blue-600 hover:underline hover:text-blue-800"
+                        data-cy="download-search-csv"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setShowCSVDownloadPopup(true);
+                        }}
+                      >
+                        {downloadCSVStatus === "loading" ? <Icon name="loading" /> : "this search"}
+                      </a>
+                      <span>|</span>
+                    </>
+                  )}
                   {getThemeConfigLink(themeConfig, "download-database") && (
                     <>
-                      <span>|</span>
                       <ExternalLink
                         url={getThemeConfigLink(themeConfig, "download-database").url}
                         className="text-blue-600 hover:underline hover:text-blue-800"


### PR DESCRIPTION
This is whilst we fix the downloads but do not want to block launch at NY climate week

# What's changed
I thought the quickest way to get this in was to use is the litigation enabled feature

<img width="1410" height="181" alt="Screenshot 2025-09-25 at 11 59 53" src="https://github.com/user-attachments/assets/3e1fa6d6-810a-43aa-9d4b-e5c04481446c" />

CPR
<img width="1416" height="208" alt="Screenshot 2025-09-25 at 12 01 08" src="https://github.com/user-attachments/assets/c0b67313-14c2-431e-9e32-2077bb014db9" />

