### PR TITLE
feat: add search params to search only in canonical URL

### DIFF
--- a/src/utils/getCanonicalUrl.test.ts
+++ b/src/utils/getCanonicalUrl.test.ts
@@ -1,0 +1,65 @@
+import router from "next-router-mock";
+
+import { TTheme } from "@/types";
+
+import { getCanonicalUrl } from "./getCanonicalUrl";
+
+describe("getCanonicalUrl", () => {
+  const testCases = [
+    /** maintains search params, but not params for other pages */
+    { route: "/search", theme: "cpr", expected: "https://app.climatepolicyradar.org/search" },
+    {
+      route: "/search?cpl=principal_law%2Fcolorado+air+pollution+prevention+and+control+act",
+      theme: "cpr",
+      expected: "https://app.climatepolicyradar.org/search?cpl=principal_law%2Fcolorado+air+pollution+prevention+and+control+act",
+    },
+    {
+      route: "/privacy-policy?cpl=principal_law%2Fcolorado+air+pollution+prevention+and+control+act",
+      theme: "cpr",
+      expected: "https://app.climatepolicyradar.org/privacy-policy",
+    },
+
+    /** Themes */
+    { route: "/", theme: "cpr", expected: "https://app.climatepolicyradar.org" },
+    { route: "/", theme: "cclw", expected: "https://climate-laws.org" },
+    { route: "/", theme: "mcf", expected: "https://climateprojectexplorer.org" },
+    { route: "/", theme: "ccc", expected: "https://www.climatecasechart.com" },
+
+    /** Attribution overrides themes */
+    {
+      route: "/documents/document-123",
+      theme: "cpr",
+      attributionUrl: "www.climate-laws.org",
+      expected: "https://www.climate-laws.org/documents/document-123",
+    },
+    {
+      route: "/documents/document-123",
+      theme: "cclw",
+      attributionUrl: "app.climatepolicyradar.org",
+      expected: "https://app.climatepolicyradar.org/documents/document-123",
+    },
+    {
+      route: "/documents/document-123",
+      theme: "mcf",
+      attributionUrl: "app.climatepolicyradar.org",
+      expected: "https://app.climatepolicyradar.org/documents/document-123",
+    },
+    {
+      route: "/documents/document-123",
+      theme: "ccc",
+      attributionUrl: "app.climatepolicyradar.org",
+      expected: "https://app.climatepolicyradar.org/documents/document-123",
+    },
+  ] satisfies {
+    route: string;
+    theme: TTheme;
+    attributionUrl?: string;
+    expected: string;
+  }[];
+
+  test.each(testCases)("$route => $expected", ({ route, theme, attributionUrl, expected }) => {
+    router.push(route);
+    const canonicalUrl = getCanonicalUrl(router, theme, attributionUrl);
+    expect(canonicalUrl).toBe(expected);
+  });
+});

--- a/src/utils/getCanonicalUrl.ts
+++ b/src/utils/getCanonicalUrl.ts
@@ -6,18 +6,17 @@ import getThemeDomain from "./getThemeDomain";
 
 // Get the canonical URL for the current page
 // This is used to tell search engines the preferred URL for the current page
-export const getCanonicalUrl = (router: NextRouter, theme: TTheme, attribution_url = null): string => {
-  const themeDomain = attribution_url ? attribution_url : getThemeDomain(theme);
+export const getCanonicalUrl = (router: NextRouter, theme: TTheme, attributionUrl = null): string => {
+  const themeDomain = attributionUrl ? attributionUrl : getThemeDomain(theme);
 
-  // Get the length of the path slice to remove query params and hash
-  // We specifically do not want to include query params or hash in the canonical URL
-  // for example: https://example.com/page?query=1#hash -> https://example.com/page
-  const _pathSliceLength = Math.min.apply(Math, [
-    router.asPath.indexOf("?") > 0 ? router.asPath.indexOf("?") : router.asPath.length,
-    router.asPath.indexOf("#") > 0 ? router.asPath.indexOf("#") : router.asPath.length,
-  ]);
+  let pathname: string;
+  if (router.pathname === "/search") {
+    pathname = router.asPath;
+  } else {
+    pathname = router.pathname;
+  }
 
-  const canonicalUrl = `https://${themeDomain}${router.asPath.substring(0, _pathSliceLength)}`;
+  const canonicalUrl = `https://${themeDomain}${pathname}`;
 
   // Remove trailing slash to avoid duplicate content being indexed
   if (canonicalUrl.endsWith("/")) {


### PR DESCRIPTION
# What's changed
- add tests for `getCanonicalUrl`
- simplification refactor of the `getCanonicalUrl` method
- make sure we maintain the search params on the search URL as they're relevant

## Why?
- search results can be index by search engines. Currently we flatten all search results to `/search`

## Screenshots?

<img width="1422" height="72" alt="Screenshot 2025-09-29 at 09 05 41" src="https://github.com/user-attachments/assets/b7c23092-7580-4693-b525-44900fe7b544" />

