### PR TITLE
fix: better canonical URL parsing

### DIFF
--- a/src/utils/getCanonicalUrl.test.ts
+++ b/src/utils/getCanonicalUrl.test.ts
@@ -50,6 +50,10 @@ describe("getCanonicalUrl", () => {
       attributionUrl: "app.climatepolicyradar.org",
       expected: "https://app.climatepolicyradar.org/documents/document-123",
     },
+
+    /** Pages with next router params in URL */
+    { route: "/geographies/us-tn?query=oil", theme: "cpr", expected: "https://app.climatepolicyradar.org/geographies/us-tn" },
+    { route: "/geographies/us-tn", theme: "cpr", expected: "https://app.climatepolicyradar.org/geographies/us-tn" },
   ] satisfies {
     route: string;
     theme: TTheme;

--- a/src/utils/getCanonicalUrl.ts
+++ b/src/utils/getCanonicalUrl.ts
@@ -8,12 +8,14 @@ import getThemeDomain from "./getThemeDomain";
 // This is used to tell search engines the preferred URL for the current page
 export const getCanonicalUrl = (router: NextRouter, theme: TTheme, attributionUrl = null): string => {
   const themeDomain = attributionUrl ? attributionUrl : getThemeDomain(theme);
+  /** We're only interested in the pathname so use an explicit placeholder url */
+  const url = new URL(router.asPath, "https://placeholder");
 
   let pathname: string;
   if (router.pathname === "/search") {
     pathname = router.asPath;
   } else {
-    pathname = router.pathname;
+    pathname = url.pathname;
   }
 
   const canonicalUrl = `https://${themeDomain}${pathname}`;


### PR DESCRIPTION
# What's changed
- uses the router.asPath in conjunction with the `URL` type to get the canonical URL
- adds those examples to the test

## Why?
- router.pathname is `/geographies/[id]` or similar on pages that use file paths as params