### PR TITLE
Feature/app 1246 Remove links to international and no geo 

### DIFF
--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -5,6 +5,7 @@ import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Icon } from "@/components/atoms/icon/Icon";
 import { ThemeContext } from "@/context/ThemeContext";
 import { TTheme } from "@/types";
+import { isSystemGeo } from "@/utils/isSystemGeo";
 
 const BREADCRUMB_MAXLENGTH = 50;
 
@@ -81,8 +82,8 @@ export const BreadCrumbs = ({ geography = null, parentGeography = null, isSubdiv
   const isCollectionPage = !isSearchPage && !category && !family && !geography;
 
   if (isGeographyPage) {
-    const breadcrumbGeography = isSubdivision && parentGeography ? parentGeography : null;
-    const finalGeography = geography;
+    const breadcrumbGeography = isSubdivision && parentGeography && !isSystemGeo(String(parentGeography.label)) ? parentGeography : null;
+    const finalGeography = geography && !isSystemGeo(String(geography.label)) ? geography : null;
 
     return (
       <ul className="flex items-baseline flex-wrap gap-2 text-sm px-3 cols-2:px-6 cols-3:px-8 py-4 border-b border-gray-200" data-cy="breadcrumbs">
@@ -104,8 +105,13 @@ export const BreadCrumbs = ({ geography = null, parentGeography = null, isSubdiv
     );
   }
 
-  const breadcrumbGeography = isSubdivision && parentGeography ? parentGeography : geography;
-  const breadcrumbSubGeography = isSubdivision ? geography : null;
+  const breadcrumbGeography =
+    isSubdivision && parentGeography && !isSystemGeo(String(parentGeography.label))
+      ? parentGeography
+      : geography && !isSystemGeo(String(geography.label))
+        ? geography
+        : null;
+  const breadcrumbSubGeography = isSubdivision && geography && !isSystemGeo(String(geography.label)) ? geography : null;
 
   return (
     <ul

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -21,6 +21,7 @@ import useSearch from "@/hooks/useSearch";
 import { TMatchedFamily, TFamilyPageBlock } from "@/types";
 import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
 import { getFamilyMetadata } from "@/utils/getFamilyMetadata";
+import { isSystemGeo } from "@/utils/isSystemGeo";
 import { getLitigationJSONLD } from "@/utils/json-ld/getLitigationCaseJSONLD";
 import { joinNodes } from "@/utils/reactNode";
 import { convertDate } from "@/utils/timedate";
@@ -71,7 +72,7 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
     // Is a country not a subdivision.
     const geographySlug = getCountrySlug(firstGeography, countries);
     const geographyName = getCountryName(firstGeography, countries);
-    breadcrumbGeography = { label: geographyName, href: `/geographies/${geographySlug}` };
+    breadcrumbGeography = !isSystemGeo(geographyName) ? { label: geographyName, href: `/geographies/${geographySlug}` } : null;
   } else {
     // Is a subdivision.
     const subdivisionData = subdivisions.find((sub) => sub.code === firstGeography);
@@ -83,16 +84,16 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
       const countrySlug = getCountrySlug(subdivisionData.country_alpha_3, countries);
       const countryName = getCountryName(subdivisionData.country_alpha_3, countries);
 
-      breadcrumbGeography = { label: countryName, href: `/geographies/${countrySlug}` };
-      breadcrumbSubGeography = { label: subdivisionName, href: `/geographies/${subdivisionSlug}` };
+      breadcrumbGeography = !isSystemGeo(countryName) ? { label: countryName, href: `/geographies/${countrySlug}` } : null;
+      breadcrumbSubGeography = !isSystemGeo(subdivisionName) ? { label: subdivisionName, href: `/geographies/${subdivisionSlug}` } : null;
     } else {
       // Fallback to country if subdivision data lookup is not found.
       const countryCode = firstGeography.split("-")[0];
       const countrySlug = getCountrySlug(countryCode, countries);
       const countryName = getCountryName(countryCode, countries);
 
-      breadcrumbGeography = { label: countryName, href: `/geographies/${countrySlug}` };
-      breadcrumbSubGeography = { label: subdivisionName, href: `/geographies/${subdivisionSlug}` };
+      breadcrumbGeography = !isSystemGeo(countryName) ? { label: countryName, href: `/geographies/${countrySlug}` } : null;
+      breadcrumbSubGeography = !isSystemGeo(subdivisionName) ? { label: subdivisionName, href: `/geographies/${subdivisionSlug}` } : null;
     }
   }
 
@@ -101,17 +102,21 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
     {
       label: "Geography",
       value: joinNodes(
-        geographiesToDisplay.map((code) => {
-          const isCountry = !code.includes("-");
-          const slug = isCountry ? getCountrySlug(code, countries) : code.toLowerCase();
-          const name = isCountry ? getCountryName(code, countries) : getSubdivisionName(code, subdivisions);
+        geographiesToDisplay
+          .map((code) => {
+            const isCountry = !code.includes("-");
+            const slug = isCountry ? getCountrySlug(code, countries) : code.toLowerCase();
+            const name = isCountry ? getCountryName(code, countries) : getSubdivisionName(code, subdivisions);
 
-          return (
-            <LinkWithQuery key={code} href={`/geographies/${slug}`} className="underline">
-              {name}
-            </LinkWithQuery>
-          );
-        }),
+            return !isSystemGeo(name) ? (
+              <LinkWithQuery key={code} href={`/geographies/${slug}`} className="underline">
+                {name}
+              </LinkWithQuery>
+            ) : (
+              <span key={code}>{name}</span>
+            );
+          })
+          .filter(Boolean),
         ", "
       ),
     },

--- a/src/utils/getFamilyMetadata.tsx
+++ b/src/utils/getFamilyMetadata.tsx
@@ -8,6 +8,7 @@ import { getCountryName, getCountrySlug } from "@/helpers/getCountryFields";
 import { getSubdivisionName } from "@/helpers/getSubdivision";
 import { IMetadata, TFamilyPublic, TGeography, TGeographySubdivision } from "@/types";
 import { buildConceptHierarchy } from "@/utils/buildConceptHierarchy";
+import { isSystemGeo } from "@/utils/isSystemGeo";
 
 const hierarchyArrow = ` ${ARROW_RIGHT} `;
 
@@ -53,14 +54,15 @@ function getLitigationMetaData(family: TFamilyPublic, countries: TGeography[], s
       label: "Geography",
       value: geosOrdered.map((geo, index) => {
         const geoSlug = getCountrySlug(geo, countries);
+        const geoName = geoSlug ? getCountryName(geo, countries) : getSubdivisionName(geo, subdivisions);
         return (
           <Fragment key={geo}>
-            {geoSlug ? (
-              <LinkWithQuery key={geo} href={`/geographies/${geoSlug}`} className="underline">
-                {getCountryName(geo, countries)}
+            {geoSlug && !isSystemGeo(geoName) ? (
+              <LinkWithQuery href={`/geographies/${geoSlug}`} className="underline">
+                {geoName}
               </LinkWithQuery>
             ) : (
-              <>{getSubdivisionName(geo, subdivisions)}</>
+              <span>{geoName}</span>
             )}
             {index + 1 < geosOrdered.length && hierarchyArrow}
           </Fragment>


### PR DESCRIPTION
# What's changed

Removed links to international and no geo:
- In breadcrumbs
- On family page metadata block
- On family page header

## Why?

Because we don't have geo pages for these, so we get 404 errors.


