### PR TITLE
fix: add theme to Layout

### DIFF
--- a/themes/ccc/pages/about.tsx
+++ b/themes/ccc/pages/about.tsx
@@ -8,7 +8,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const About = () => {
   return (
-    <Layout title="About" description="Find out more about the Sabin Center for Climate Change Law's Climate Litigation Database.">
+    <Layout title="About" description="Find out more about the Sabin Center for Climate Change Law's Climate Litigation Database." theme="ccc">
       <BreadCrumbs label={"About us"} />
       <section className="pt-8 color-text-primary">
         <SiteWidth>

--- a/themes/ccc/pages/contact.tsx
+++ b/themes/ccc/pages/contact.tsx
@@ -11,6 +11,7 @@ const Contact = () => {
     <Layout
       title="Contact"
       description="If you have questions or comments about the content of the database, use this page to get in touch with our team."
+      theme="ccc"
     >
       <BreadCrumbs label={"Contact"} />
       <section>

--- a/themes/ccc/pages/cookie-policy.tsx
+++ b/themes/ccc/pages/cookie-policy.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const CookiePolicy = () => {
   return (
-    <Layout title="Cookie policy">
+    <Layout title="Cookie policy" theme="ccc">
       <BreadCrumbs label={"Cookie policy"} />
       <section>
         <SiteWidth>

--- a/themes/ccc/pages/faq.tsx
+++ b/themes/ccc/pages/faq.tsx
@@ -18,6 +18,7 @@ const FAQ: React.FC = () => {
     <Layout
       title="FAQ"
       description="Find quick tips for how you can use this resource to explore national-level climate change projects from across the world."
+      theme="ccc"
     >
       <BreadCrumbs label={"Frequently asked questions"} />
       <section className="pt-8">

--- a/themes/ccc/pages/methodology.tsx
+++ b/themes/ccc/pages/methodology.tsx
@@ -16,6 +16,7 @@ const Methodology = () => {
     <Layout
       title="Methodology"
       description="Find the definitions, scope and principles we use to collect and categorise the climate litigation cases."
+      theme="ccc"
     >
       <BreadCrumbs label={"Methodology"} />
       <section className="pt-8">

--- a/themes/ccc/pages/privacy-policy.tsx
+++ b/themes/ccc/pages/privacy-policy.tsx
@@ -8,7 +8,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const PrivacyPolicy = () => {
   return (
-    <Layout title="Privacy policy">
+    <Layout title="Privacy policy" theme="ccc">
       <BreadCrumbs label={"Privacy policy"} />
       <section>
         <SiteWidth>

--- a/themes/ccc/pages/terms-of-use.tsx
+++ b/themes/ccc/pages/terms-of-use.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (
-    <Layout title="Terms of use">
+    <Layout title="Terms of use" theme="ccc">
       <BreadCrumbs label={"Terms of use"} />
       <section>
         <SiteWidth>

--- a/themes/cclw/pages/about.tsx
+++ b/themes/cclw/pages/about.tsx
@@ -14,6 +14,7 @@ const About = () => {
     <Layout
       title="About"
       description="Climate Change Laws of the World is a database of national-level climate change legislation and policies globally, led by the Grantham Research Institute at LSE."
+      theme="cclw"
     >
       <BreadCrumbs label={"About"} />
       <section>

--- a/themes/cclw/pages/contact.tsx
+++ b/themes/cclw/pages/contact.tsx
@@ -10,6 +10,7 @@ const Contact = () => {
     <Layout
       title="Contact"
       description="If you have questions or comments about the content of the database, use this page to get in touch with our team."
+      theme="cclw"
     >
       <BreadCrumbs label={"Contact"} />
       <section>

--- a/themes/cclw/pages/faq.tsx
+++ b/themes/cclw/pages/faq.tsx
@@ -21,6 +21,7 @@ const FAQ: React.FC = () => {
     <Layout
       title="FAQ"
       description="Find quick tips for how you can use this resource to explore national-level climate change laws and policies from across the world."
+      theme="cclw"
     >
       <BreadCrumbs label={"Frequently asked questions"} />
       <section>

--- a/themes/cclw/pages/framework-laws.tsx
+++ b/themes/cclw/pages/framework-laws.tsx
@@ -13,6 +13,7 @@ const FrameworkLaws = () => {
     <Layout
       title="Climate Change Framework Laws"
       description="We assign a number of classifications and categories to laws and policies in the Climate Change Laws of the World database to enhance the usability and searchability of the data."
+      theme="cclw"
     >
       <BreadCrumbs label="Climate Change Framework Laws" />
       <section>

--- a/themes/cclw/pages/methodology.tsx
+++ b/themes/cclw/pages/methodology.tsx
@@ -15,6 +15,7 @@ const Methodology = () => {
     <Layout
       title="Methodology"
       description="Find the definitions, scope and principles we use to collect and categorise the laws and policies contained in the Climate Change Laws of the World dataset."
+      theme="cclw"
     >
       <BreadCrumbs label={"Methodology"} />
       <section>

--- a/themes/cclw/pages/terms-of-use.tsx
+++ b/themes/cclw/pages/terms-of-use.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (
-    <Layout title="Terms of use">
+    <Layout title="Terms of use" theme="cclw">
       <BreadCrumbs label={"Terms of use"} />
       <section>
         <SiteWidth>

--- a/themes/cpr/pages/faq.tsx
+++ b/themes/cpr/pages/faq.tsx
@@ -18,6 +18,7 @@ const FAQ: React.FC = () => {
     <Layout
       title="FAQ"
       description="Find quick tips for how you can use Climate Policy Radar to explore climate laws, policies, and projects from across the world."
+      theme="cpr"
     >
       <BreadCrumbs label={"Frequently asked questions"} />
       <section className="pt-8">

--- a/themes/cpr/pages/oep.tsx
+++ b/themes/cpr/pages/oep.tsx
@@ -18,7 +18,7 @@ const OceanEnergyPathwayPage = () => {
         {/* eslint-disable-next-line @next/next/no-css-tags */}
         <link rel="stylesheet" href="/css/oep/oep.css" />
       </Head>
-      <Layout title="Ocean Energy Pathway" description="Helping the offshore wind sector design effective strategies">
+      <Layout title="Ocean Energy Pathway" description="Helping the offshore wind sector design effective strategies" theme="cpr">
         <Header />
         <main id="oep" className="relative">
           <Hero />

--- a/themes/cpr/pages/terms-of-use.tsx
+++ b/themes/cpr/pages/terms-of-use.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (
-    <Layout title="Terms of use">
+    <Layout title="Terms of use" theme="cpr">
       <BreadCrumbs label={"Terms of use"} />
       <section>
         <SiteWidth>

--- a/themes/mcf/pages/about.tsx
+++ b/themes/mcf/pages/about.tsx
@@ -10,6 +10,7 @@ const About = () => {
     <Layout
       title="About"
       description="Discover how the MCFs collaboratively developed this platform as a central hub for accessing documents, enhancing transparency, and raising awareness of their value and impact in addressing climate change."
+      theme="mcf"
     >
       <BreadCrumbs label={"About us"} />
       <section className="pt-8">

--- a/themes/mcf/pages/contact.tsx
+++ b/themes/mcf/pages/contact.tsx
@@ -10,6 +10,7 @@ const Contact = () => {
     <Layout
       title="Contact"
       description="Get in touch with us for inquiries, support, or feedback regarding our climate change resources and initiatives."
+      theme="mcf"
     >
       <BreadCrumbs label={"Contact us"} />
       <section className="pt-8">

--- a/themes/mcf/pages/faq.tsx
+++ b/themes/mcf/pages/faq.tsx
@@ -18,6 +18,7 @@ const FAQ: React.FC = () => {
     <Layout
       title="FAQ"
       description="Find quick tips for how you can use this resource to explore national-level climate change projects from across the world."
+      theme="mcf"
     >
       <BreadCrumbs label={"Frequently asked questions"} />
       <section className="pt-8">

--- a/themes/mcf/pages/methodology.tsx
+++ b/themes/mcf/pages/methodology.tsx
@@ -6,7 +6,11 @@ import { Heading } from "@/components/typography/Heading";
 
 const Methodology = () => {
   return (
-    <Layout title="Methodology" description="Find the definitions, scope and principles we use to collect and categorise the laws and policies.">
+    <Layout
+      title="Methodology"
+      description="Find the definitions, scope and principles we use to collect and categorise the laws and policies."
+      theme="mcf"
+    >
       <BreadCrumbs label={"Methodology"} />
       <section className="pt-8">
         <SiteWidth>

--- a/themes/mcf/pages/terms-of-use.tsx
+++ b/themes/mcf/pages/terms-of-use.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@/components/typography/Heading";
 
 const TermsOfUse = () => {
   return (
-    <Layout title="Terms of use">
+    <Layout title="Terms of use" theme="mcf">
       <BreadCrumbs label={"Terms of use"} />
       <section>
         <SiteWidth>


### PR DESCRIPTION
# What's changed
- adds the theme parameter to pages in that theme

## Why?
- the `canonical` link was showing up as e.g. https://app.climatepolicyradar.org/contact on different themes. This make it e.g. https://climatecasechart.com/contact

Noticed in Google search console.

<img width="1527" height="220" alt="Screenshot 2025-09-30 at 07 36 35" src="https://github.com/user-attachments/assets/9f69e910-dfd6-44b9-8198-da250d400ad8" />

## Screenshots

<img width="595" height="20" alt="Screenshot 2025-09-30 at 07 35 23" src="https://github.com/user-attachments/assets/d8139b36-5cc0-40ca-86b9-4c2392faefdf" />
