### PR TITLE
Add gold standard corpus to cclw config

### DIFF
--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -13,6 +13,7 @@ const config: TThemeConfig = {
           "CPR.corpus.i00000591.n0000",
           "CPR.corpus.i00000592.n0000",
           "UNFCCC.corpus.i00000001.n0000",
+          "CPR.corpus.Goldstandard.n0000",
         ],
       },
       {
@@ -24,14 +25,14 @@ const config: TThemeConfig = {
       {
         label: "Laws",
         slug: "laws",
-        value: ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000", "CPR.corpus.i00000001.n0000"],
+        value: ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000", "CPR.corpus.i00000001.n0000, CPR.corpus.Goldstandard.n0000"],
         category: ["Legislative"],
         alias: "LAWS",
       },
       {
         label: "Policies",
         slug: "policies",
-        value: ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000", "CPR.corpus.i00000001.n0000"],
+        value: ["CCLW.corpus.i00000001.n0000", "CPR.corpus.i00000592.n0000", "CPR.corpus.i00000001.n0000, CPR.corpus.Goldstandard.n0000"],
         category: ["Executive"],
       },
     ],


### PR DESCRIPTION
# What's changed

- update cclw config to include the Gold Standard corpus for 'All', 'Laws' and 'Policies' category filters

