### PR TITLE
Revert language getter work for date format

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -20,10 +20,9 @@ interface IProps {
   matchesFamily?: TMatchedFamily; // The relevant search result family
   matchesStatus?: TLoadingStatus; // The status of the search
   showMatches?: boolean; // Whether to show matches from the search result
-  language: string;
 }
 
-export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatches = false, language }: IProps) => {
+export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatches = false }: IProps) => {
   const [view, setView] = useState("table");
 
   const isUSA = family.geographies.includes("USA");
@@ -31,8 +30,8 @@ export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatch
 
   const tableColumns = useMemo(() => getEventTableColumns({ isUSA, showMatches }), [isUSA, showMatches]);
   const tableRows = useMemo(
-    () => getEventTableRows({ families: [family], documentEventsOnly: true, matchesFamily, matchesStatus, language }),
-    [family, matchesFamily, matchesStatus, language]
+    () => getEventTableRows({ families: [family], documentEventsOnly: true, matchesFamily, matchesStatus }),
+    [family, matchesFamily, matchesStatus]
   );
 
   const cards: IEntityCardProps[] = useMemo(

--- a/src/components/blocks/eventsBlock/EventsBlock.tsx
+++ b/src/components/blocks/eventsBlock/EventsBlock.tsx
@@ -10,14 +10,13 @@ const MAX_ENTRIES_SHOWN = 8;
 
 interface IProps {
   families: TFamilyPublic[];
-  language: string;
 }
 
-export const EventsBlock = ({ families, language }: IProps) => {
+export const EventsBlock = ({ families }: IProps) => {
   const [showAllEntries, setShowAllEntries] = useState(false);
 
   const tableColumns = getEventTableColumns({ showFamilyColumns: true });
-  const tableRows = getEventTableRows({ families, language });
+  const tableRows = getEventTableRows({ families });
   const entriesToHide = tableRows.length > MAX_ENTRIES_SHOWN;
 
   const toggleShowAll = () => {

--- a/src/components/blocks/familyBlock/FamilyBlock.tsx
+++ b/src/components/blocks/familyBlock/FamilyBlock.tsx
@@ -13,15 +13,14 @@ const MAX_ENTRIES_SHOWN = 4;
 
 interface IProps {
   family: TFamilyPublic;
-  language: string;
 }
 
-export const FamilyBlock = ({ family, language }: IProps) => {
+export const FamilyBlock = ({ family }: IProps) => {
   const [showAllEntries, setShowAllEntries] = useState(false);
 
   const isUSA = family.geographies.includes("USA");
   const tableColumns = useMemo(() => getEventTableColumns({ isUSA }), [isUSA]);
-  const tableRows = useMemo(() => getEventTableRows({ families: [family], language }), [family, language]);
+  const tableRows = useMemo(() => getEventTableRows({ families: [family] }), [family]);
   const entriesToHide = tableRows.length > MAX_ENTRIES_SHOWN;
 
   const toggleShowAll = () => {

--- a/src/components/pages/familyLitigationPage.tsx
+++ b/src/components/pages/familyLitigationPage.tsx
@@ -28,7 +28,7 @@ import { convertDate } from "@/utils/timedate";
 
 import { IProps } from "./familyOriginalPage";
 
-export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, themeConfig, language }: IProps) => {
+export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, themeConfig }: IProps) => {
   /* Search matches */
 
   const router = useRouter();
@@ -143,17 +143,8 @@ export const FamilyLitigationPage = ({ countries, subdivisions, family, theme, t
     },
     documents: {
       render: useCallback(
-        () => (
-          <DocumentsBlock
-            key="documents"
-            family={family}
-            matchesFamily={matchesFamily}
-            matchesStatus={matchesStatus}
-            showMatches={hasSearch}
-            language={language}
-          />
-        ),
-        [family, hasSearch, matchesFamily, matchesStatus, language]
+        () => <DocumentsBlock key="documents" family={family} matchesFamily={matchesFamily} matchesStatus={matchesStatus} showMatches={hasSearch} />,
+        [family, hasSearch, matchesFamily, matchesStatus]
       ),
     },
     metadata: {

--- a/src/components/pages/familyOriginalPage.tsx
+++ b/src/components/pages/familyOriginalPage.tsx
@@ -64,7 +64,6 @@ export interface IProps {
   themeConfig: TThemeConfig;
   vespaFamilyData?: TSearchResponse;
   envConfig: TPublicEnvConfig;
-  language: string;
 }
 
 // Only published documents are returned in the family page call, so we can cross reference the import ID with those

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -26,13 +26,12 @@ interface IProps {
   collection: TCollectionPublicWithFamilies;
   theme: TTheme;
   themeConfig: TThemeConfig;
-  language: string;
 }
 
 type TCollectionTab = "about" | "cases" | "procedural history";
 const COLLECTION_TABS: IPageHeaderTab<TCollectionTab>[] = [{ tab: "cases" }, { tab: "procedural history" }, { tab: "about" }];
 
-const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ collection, theme, themeConfig, language }: IProps) => {
+const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ collection, theme, themeConfig }: IProps) => {
   const [currentTab, setCurrentTab] = useState<TCollectionTab>("cases");
   const { families } = collection;
 
@@ -63,7 +62,7 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
             <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
             <main className="flex flex-col py-3 gap-4 cols-2:py-6 cols-2:gap-8 cols-3:py-8 cols-3:gap-12 cols-3:col-span-2 cols-4:col-span-3">
               {families.map((family) => (
-                <FamilyBlock key={family.slug} family={family} language={language} />
+                <FamilyBlock key={family.slug} family={family} />
               ))}
             </main>
           </>
@@ -71,7 +70,7 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
 
         {currentTab === "procedural history" && (
           <main className="py-3 cols-2:py-6 cols-2:col-span-2 cols-3:py-8 cols-3:col-span-3 cols-4:col-span-4">
-            <EventsBlock families={families} language={language} />
+            <EventsBlock families={families} />
           </main>
         )}
 
@@ -98,8 +97,6 @@ export default CollectionPage;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
-
-  const language = getLanguage(context.req.headers["accept-language"]);
 
   const featureFlags = getFeatureFlags(context.req.cookies);
 
@@ -131,7 +128,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       collection: collectionData,
       theme,
       themeConfig,
-      language,
     }),
   };
 };

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -32,8 +32,6 @@ export default FamilyPage;
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader("Cache-Control", "public, max-age=3600, immutable");
 
-  const language = getLanguage(context.req.headers["accept-language"]);
-
   const featureFlags = getFeatureFlags(context.req.cookies);
 
   const theme = process.env.THEME;
@@ -110,7 +108,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       theme,
       themeConfig,
       vespaFamilyData: vespaFamilyData ?? null,
-      language,
     }),
   };
 };

--- a/src/utils/eventTable.test.tsx
+++ b/src/utils/eventTable.test.tsx
@@ -44,7 +44,7 @@ describe("getEventTableRows", () => {
       slug: "",
     };
 
-    const eventRows = getEventTableRows({ families: [familyWithoutDocuments], language });
+    const eventRows = getEventTableRows({ families: [familyWithoutDocuments] });
 
     expect(eventRows).toEqual([
       {
@@ -116,7 +116,7 @@ describe("getEventTableRows", () => {
       slug: "",
     };
 
-    const eventRows = getEventTableRows({ families: [familyWithoutEvents], language });
+    const eventRows = getEventTableRows({ families: [familyWithoutEvents] });
 
     expect(eventRows).toHaveLength(1);
     expect(eventRows[0].id).toBe("/0");
@@ -203,7 +203,7 @@ describe("getEventTableRows", () => {
       slug: "",
     };
 
-    const eventRows = getEventTableRows({ families: [familyWithoutEvents], language });
+    const eventRows = getEventTableRows({ families: [familyWithoutEvents] });
 
     expect(eventRows).toHaveLength(2);
 
@@ -311,7 +311,7 @@ describe("getEventTableRows", () => {
       slug: "",
     };
 
-    const eventRows = getEventTableRows({ families: [familyWithoutEvents], language });
+    const eventRows = getEventTableRows({ families: [familyWithoutEvents] });
 
     expect(eventRows).toHaveLength(1);
     expect(eventRows[0].id).toBe("/0");

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -77,13 +77,11 @@ export const getEventTableRows = ({
   documentEventsOnly = false,
   matchesFamily,
   matchesStatus = "success",
-  language,
 }: {
   families: TFamilyPublic[];
   documentEventsOnly?: boolean;
   matchesFamily?: TMatchedFamily;
   matchesStatus?: TLoadingStatus;
-  language: string;
 }): TEventTableRow[] => {
   const rows: TEventTableRow[] = [];
 
@@ -120,7 +118,7 @@ export const getEventTableRows = ({
           caseTitle: family.title,
           court: getCourts(family),
           date: {
-            label: formatDateShort(date, language),
+            label: formatDateShort(date),
             value: date.getTime(),
           },
           document: document

--- a/src/utils/timedate.test.ts
+++ b/src/utils/timedate.test.ts
@@ -1,21 +1,29 @@
 import { formatDateShort } from "./timedate";
 
 describe("formatDateShort", () => {
+  let languageGetter;
   const date = new Date("2021-09-16T00:00:00Z");
 
+  beforeEach(() => {
+    languageGetter = vi.spyOn(window.navigator, "language", "get");
+  });
+
   it("returns a GB short date", () => {
-    expect(formatDateShort(date, "en-GB")).toBe("16/09/2021");
+    languageGetter.mockReturnValue("en-GB");
+    expect(formatDateShort(date)).toBe("16/09/2021");
   });
 
   it("returns a US short date", () => {
-    expect(formatDateShort(date, "en-US")).toBe("09/16/2021");
+    languageGetter.mockReturnValue("en-US");
+    expect(formatDateShort(date)).toBe("09/16/2021");
   });
 
   it("returns a DE short date", () => {
-    expect(formatDateShort(date, "de-DE")).toBe("16.09.2021");
+    languageGetter.mockReturnValue("de-DE");
+    expect(formatDateShort(date)).toBe("16.09.2021");
   });
 
   it("returns an empty string for invalid dates", () => {
-    expect(formatDateShort(new Date("invalid"), "en")).toBe("");
+    expect(formatDateShort(new Date("invalid"))).toBe("");
   });
 });

--- a/src/utils/timedate.ts
+++ b/src/utils/timedate.ts
@@ -26,10 +26,10 @@ export const formatDate = (data: string) => {
   return [year, day, months[month]];
 };
 
-export const formatDateShort = (date: Date, language: string): string => {
+export const formatDateShort = (date: Date, language?: string): string => {
   if (isNaN(date.getTime())) return "";
 
-  return new Intl.DateTimeFormat(language, {
+  return new Intl.DateTimeFormat(language ?? navigator?.language ?? "en-GB", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",


### PR DESCRIPTION
# What's changed
- Reverting the other PR as it was inherently flawed due to caching
- It was resulting in the US date format showing for everyone, which is worse than the background hydration errors
