### PR TITLE
Re-hydrate the table rows in the client to display dates in local format

### DIFF
--- a/src/components/blocks/documentsBlock/DocumentsBlock.tsx
+++ b/src/components/blocks/documentsBlock/DocumentsBlock.tsx
@@ -1,5 +1,5 @@
 import orderBy from "lodash/orderBy";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Card } from "@/components/atoms/card/Card";
 import { EntityCard, IProps as IEntityCardProps } from "@/components/molecules/entityCard/EntityCard";
@@ -9,7 +9,7 @@ import { ToggleGroup } from "@/components/molecules/toggleGroup/ToggleGroup";
 import { InteractiveTable } from "@/components/organisms/interactiveTable/InteractiveTable";
 import { getCategoryName } from "@/helpers/getCategoryName";
 import { TFamilyDocumentPublic, TFamilyPublic, TLoadingStatus, TMatchedFamily } from "@/types";
-import { getEventTableColumns, getEventTableRows, TEventTableColumnId } from "@/utils/eventTable";
+import { getEventTableColumns, getEventTableRows, TEventTableColumnId, TEventTableRow } from "@/utils/eventTable";
 import { formatDate } from "@/utils/timedate";
 
 // If no date found for an event, use an empty string so it sorts to the bottom
@@ -24,6 +24,7 @@ interface IProps {
 
 export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatches = false }: IProps) => {
   const [view, setView] = useState("table");
+  const [updatedRowsWithLocalisedDates, setUpdatedRowsWithLocalisedDates] = useState<TEventTableRow[]>(null);
 
   const isUSA = family.geographies.includes("USA");
   const category = getCategoryName(family.category, family.corpus_type_name, family.organisation);
@@ -53,6 +54,12 @@ export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatch
     setView(toggleValue[0]);
   };
 
+  useEffect(() => {
+    const language = navigator?.language;
+
+    setUpdatedRowsWithLocalisedDates(getEventTableRows({ families: [family], language }));
+  }, [family]);
+
   return (
     <Section block="documents" title="Documents">
       {hasDocumentsToDisplay && (
@@ -76,7 +83,11 @@ export const DocumentsBlock = ({ family, matchesFamily, matchesStatus, showMatch
 
           {/* Table */}
           {view === "table" && (
-            <InteractiveTable<TEventTableColumnId> columns={tableColumns} rows={tableRows} defaultSort={{ column: "date", order: "desc" }} />
+            <InteractiveTable<TEventTableColumnId>
+              columns={tableColumns}
+              rows={updatedRowsWithLocalisedDates || tableRows}
+              defaultSort={{ column: "date", order: "desc" }}
+            />
           )}
         </Card>
       )}

--- a/src/components/blocks/eventsBlock/EventsBlock.tsx
+++ b/src/components/blocks/eventsBlock/EventsBlock.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/atoms/button/Button";
 import { Card } from "@/components/atoms/card/Card";
 import { InteractiveTable } from "@/components/organisms/interactiveTable/InteractiveTable";
 import { TFamilyPublic } from "@/types";
-import { getEventTableColumns, getEventTableRows, TEventTableColumnId } from "@/utils/eventTable";
+import { getEventTableColumns, getEventTableRows, TEventTableColumnId, TEventTableRow } from "@/utils/eventTable";
 
 const MAX_ENTRIES_SHOWN = 8;
 
@@ -14,6 +14,7 @@ interface IProps {
 
 export const EventsBlock = ({ families }: IProps) => {
   const [showAllEntries, setShowAllEntries] = useState(false);
+  const [updatedRowsWithLocalisedDates, setUpdatedRowsWithLocalisedDates] = useState<TEventTableRow[]>(null);
 
   const tableColumns = getEventTableColumns({ showFamilyColumns: true });
   const tableRows = getEventTableRows({ families });
@@ -23,6 +24,12 @@ export const EventsBlock = ({ families }: IProps) => {
     setShowAllEntries((current) => !current);
   };
 
+  useEffect(() => {
+    const language = navigator?.language;
+
+    setUpdatedRowsWithLocalisedDates(getEventTableRows({ families, language }));
+  }, [families]);
+
   return (
     <div className="relative">
       <Card variant="outlined" className="rounded-lg !p-5">
@@ -30,7 +37,7 @@ export const EventsBlock = ({ families }: IProps) => {
         <InteractiveTable<TEventTableColumnId>
           columns={tableColumns}
           defaultSort={{ column: "date", order: "desc" }}
-          rows={tableRows}
+          rows={updatedRowsWithLocalisedDates || tableRows}
           maxRows={showAllEntries ? 0 : MAX_ENTRIES_SHOWN}
           tableClasses="pt-8"
         />

--- a/src/components/blocks/familyBlock/FamilyBlock.tsx
+++ b/src/components/blocks/familyBlock/FamilyBlock.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
 import { Button } from "@/components/atoms/button/Button";
@@ -6,7 +6,7 @@ import { Card } from "@/components/atoms/card/Card";
 import { Section } from "@/components/molecules/section/Section";
 import { InteractiveTable } from "@/components/organisms/interactiveTable/InteractiveTable";
 import { TFamilyPublic } from "@/types";
-import { getCaseNumbers, getCourts, getEventTableColumns, getEventTableRows, TEventTableColumnId } from "@/utils/eventTable";
+import { getCaseNumbers, getCourts, getEventTableColumns, getEventTableRows, TEventTableColumnId, TEventTableRow } from "@/utils/eventTable";
 import { pluralise } from "@/utils/pluralise";
 
 const MAX_ENTRIES_SHOWN = 4;
@@ -17,6 +17,7 @@ interface IProps {
 
 export const FamilyBlock = ({ family }: IProps) => {
   const [showAllEntries, setShowAllEntries] = useState(false);
+  const [updatedRowsWithLocalisedDates, setUpdatedRowsWithLocalisedDates] = useState<TEventTableRow[]>(null);
 
   const isUSA = family.geographies.includes("USA");
   const tableColumns = useMemo(() => getEventTableColumns({ isUSA }), [isUSA]);
@@ -29,6 +30,12 @@ export const FamilyBlock = ({ family }: IProps) => {
 
   const caseNumbers = getCaseNumbers(family);
   const courts = getCourts(family);
+
+  useEffect(() => {
+    const language = navigator?.language;
+
+    setUpdatedRowsWithLocalisedDates(getEventTableRows({ families: [family], language }));
+  }, [family]);
 
   return (
     <Section id={`section-${family.slug}`}>
@@ -50,7 +57,7 @@ export const FamilyBlock = ({ family }: IProps) => {
           <InteractiveTable<TEventTableColumnId>
             columns={tableColumns}
             defaultSort={{ column: "date", order: "desc" }}
-            rows={tableRows}
+            rows={updatedRowsWithLocalisedDates || tableRows}
             maxRows={showAllEntries ? 0 : MAX_ENTRIES_SHOWN}
             tableClasses="pt-8"
           />

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -77,11 +77,13 @@ export const getEventTableRows = ({
   documentEventsOnly = false,
   matchesFamily,
   matchesStatus = "success",
+  language,
 }: {
   families: TFamilyPublic[];
   documentEventsOnly?: boolean;
   matchesFamily?: TMatchedFamily;
   matchesStatus?: TLoadingStatus;
+  language?: string;
 }): TEventTableRow[] => {
   const rows: TEventTableRow[] = [];
 
@@ -118,7 +120,7 @@ export const getEventTableRows = ({
           caseTitle: family.title,
           court: getCourts(family),
           date: {
-            label: formatDateShort(date),
+            label: formatDateShort(date, language),
             value: date.getTime(),
           },
           document: document

--- a/src/utils/timedate.test.ts
+++ b/src/utils/timedate.test.ts
@@ -1,26 +1,22 @@
 import { formatDateShort } from "./timedate";
 
 describe("formatDateShort", () => {
-  let languageGetter;
   const date = new Date("2021-09-16T00:00:00Z");
 
-  beforeEach(() => {
-    languageGetter = vi.spyOn(window.navigator, "language", "get");
-  });
-
-  it("returns a GB short date", () => {
-    languageGetter.mockReturnValue("en-GB");
-    expect(formatDateShort(date)).toBe("16/09/2021");
-  });
-
-  it("returns a US short date", () => {
-    languageGetter.mockReturnValue("en-US");
+  it("by default returns a US short date", () => {
     expect(formatDateShort(date)).toBe("09/16/2021");
   });
 
+  it("returns a GB short date", () => {
+    expect(formatDateShort(date, "en-GB")).toBe("16/09/2021");
+  });
+
+  it("returns a US short date", () => {
+    expect(formatDateShort(date, "en-US")).toBe("09/16/2021");
+  });
+
   it("returns a DE short date", () => {
-    languageGetter.mockReturnValue("de-DE");
-    expect(formatDateShort(date)).toBe("16.09.2021");
+    expect(formatDateShort(date, "de-DE")).toBe("16.09.2021");
   });
 
   it("returns an empty string for invalid dates", () => {

--- a/src/utils/timedate.ts
+++ b/src/utils/timedate.ts
@@ -29,7 +29,7 @@ export const formatDate = (data: string) => {
 export const formatDateShort = (date: Date, language?: string): string => {
   if (isNaN(date.getTime())) return "";
 
-  return new Intl.DateTimeFormat(language ?? navigator?.language ?? "en-GB", {
+  return new Intl.DateTimeFormat(language || "en-US", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",


### PR DESCRIPTION
# What's changed
- Wait for page to load before updating the table rows to display dates in the client's language format

## Why?
- Prevents console errors caused by hydration errors cause by the client and server differing
- Displays dates in client's preferred format
