### PR TITLE
APP-1182: Collection page navigation column (left side) cannot be scrolled separately from the table view

### DIFF
--- a/src/components/organisms/blocksLayout/BlocksLayout.tsx
+++ b/src/components/organisms/blocksLayout/BlocksLayout.tsx
@@ -51,7 +51,7 @@ export const BlocksLayout = <PageBlock extends string>({ blockDefinitions, block
 
   return (
     <Columns>
-      <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
+      <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] cols-3:max-h-[calc(100vh-72px)] pt-3 cols-2:pt-6 cols-3:pt-8" />
       <main className="flex flex-col py-3 gap-3 cols-2:py-6 cols-2:gap-6 cols-2:col-span-2 cols-3:py-8 cols-3:gap-8 cols-4:col-span-3">{blocks}</main>
     </Columns>
   );

--- a/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
+++ b/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
@@ -29,13 +29,13 @@ export const ContentsSideBar = ({ containerClasses, items, stickyClasses }: IPro
   };
 
   const allContainerClasses = joinTailwindClasses("relative select-none", containerClasses);
-  const allStickyClasses = joinTailwindClasses("sticky top-0", stickyClasses);
+  const allStickyClasses = joinTailwindClasses("sticky top-0 overflow-y-auto", stickyClasses);
 
   return (
     <aside className={allContainerClasses}>
       <div className={allStickyClasses}>
         <span className="block pb-2 text-xs text-text-primary font-[660] leading-none uppercase">On this page</span>
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1 pr-1">
           {items.map((item) => {
             const isActive = item.id === activeId;
 

--- a/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
+++ b/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
@@ -29,7 +29,10 @@ export const ContentsSideBar = ({ containerClasses, items, stickyClasses }: IPro
   };
 
   const allContainerClasses = joinTailwindClasses("relative select-none", containerClasses);
-  const allStickyClasses = joinTailwindClasses("sticky top-0 overflow-y-auto", stickyClasses);
+  const allStickyClasses = joinTailwindClasses(
+    "sticky top-0 overflow-y-auto scrollbar-thumb-scrollbar scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-scrollbar-darker",
+    stickyClasses
+  );
 
   return (
     <aside className={allContainerClasses}>

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -59,7 +59,7 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
       <Columns>
         {currentTab === "cases" && (
           <>
-            <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] pt-3 cols-2:pt-6 cols-3:pt-8" />
+            <ContentsSideBar items={sideBarItems} stickyClasses="!top-[72px] cols-3:max-h-[calc(100vh-72px)] pt-3 cols-2:pt-6 cols-3:pt-8" />
             <main className="flex flex-col py-3 gap-4 cols-2:py-6 cols-2:gap-8 cols-3:py-8 cols-3:gap-12 cols-3:col-span-2 cols-4:col-span-3">
               {families.map((family) => (
                 <FamilyBlock key={family.slug} family={family} />


### PR DESCRIPTION
# What's changed

`ContentsSideBar` implementations now set a max height on the internal sticky element. Paired with an overflow auto, this causes a scrollbar to show on the sidebar as needed.

## Why?

Satisfies [APP-1182](https://linear.app/climate-policy-radar/issue/APP-1182/collection-page-navigation-column-left-side-cannot-be-scrolled).

## Screenshots?

<img width="1393" height="953" alt="Screenshot 2025-10-02 at 13 38 47" src="https://github.com/user-attachments/assets/464e0a4b-2329-4fbb-b42a-9b7a437f5031" />