### PR TITLE
APP-1249: Add geos and sub-geos to the generated sitemap

### DIFF
--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -3,6 +3,7 @@ import { ComposableMap, Geographies, Geography, Graticule, Marker, Sphere, Zooma
 import { Tooltip, TooltipRefProps } from "react-tooltip";
 
 import { LinkWithQuery } from "@/components/LinkWithQuery";
+import { EXCLUDED_ISO_CODES } from "@/constants/geography";
 import { GEO_CENTER_POINTS } from "@/constants/mapCentres";
 import { GEO_EU_COUNTRIES } from "@/constants/mapEUCountries";
 import useConfig from "@/hooks/useConfig";
@@ -177,15 +178,17 @@ export default function MapChart({ showLitigation = false, showCategorySelect = 
       ? Math.max(...mapDataRaw.map((g) => (g.family_counts?.EXECUTIVE || 0) + (g.family_counts?.LEGISLATIVE || 0)))
       : 0;
     // Only take UNFCCC, Reports and MCF counts for countries that are not XAA or XAB (international, no geography)
-    const maxMcf = mapDataRaw.length ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.MCF || 0))) : 0;
+    const maxMcf = mapDataRaw.length
+      ? Math.max(...mapDataRaw.map((g) => (EXCLUDED_ISO_CODES.includes(g.iso_code) ? 0 : g.family_counts?.MCF || 0)))
+      : 0;
     const maxReports = mapDataRaw.length
-      ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.REPORTS || 0)))
+      ? Math.max(...mapDataRaw.map((g) => (EXCLUDED_ISO_CODES.includes(g.iso_code) ? 0 : g.family_counts?.REPORTS || 0)))
       : 0;
     const maxUnfccc = mapDataRaw.length
-      ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.UNFCCC || 0)))
+      ? Math.max(...mapDataRaw.map((g) => (EXCLUDED_ISO_CODES.includes(g.iso_code) ? 0 : g.family_counts?.UNFCCC || 0)))
       : 0;
     const maxLitigation = mapDataRaw.length
-      ? Math.max(...mapDataRaw.map((g) => (["XAA", "XAB"].includes(g.iso_code) ? 0 : g.family_counts?.LITIGATION || 0)))
+      ? Math.max(...mapDataRaw.map((g) => (EXCLUDED_ISO_CODES.includes(g.iso_code) ? 0 : g.family_counts?.LITIGATION || 0)))
       : 0;
 
     const mapDataConstructor: TMapData = {

--- a/src/constants/geography.ts
+++ b/src/constants/geography.ts
@@ -1,0 +1,2 @@
+export const EXCLUDED_ISO_CODES = ["XAA", "XAB"];
+export const INCLUDED_GEO_TYPES = ["ISO-3166", "ISO-3166-2"];

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -5,13 +5,13 @@ import React from "react";
 import { ApiClient } from "@/api/http-common";
 import { FamilyLitigationPage } from "@/components/pages/familyLitigationPage";
 import { FamilyOriginalPage, IProps } from "@/components/pages/familyOriginalPage";
+import { EXCLUDED_ISO_CODES } from "@/constants/geography";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { TCorpusTypeDictionary, TFamilyPublic, TGeography, TGeographySubdivision, TSearchResponse, TSlugResponse, TTarget } from "@/types";
 import { isCorpusIdAllowed } from "@/utils/checkCorpusAccess";
 import { extractNestedData } from "@/utils/extractNestedData";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { isKnowledgeGraphEnabled, isLitigationEnabled } from "@/utils/features";
-import { getLanguage } from "@/utils/getLanguage";
 import { readConfigFile } from "@/utils/readConfigFile";
 
 /*
@@ -73,7 +73,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   /** This is because our family.geographies field isn't hydrated but rather a string[] */
   const allSubdivisions = await Promise.all<TGeographySubdivision[]>(
     familyData.geographies
-      .filter((country) => country.length === 3 && !["XAA", "XAB"].includes(country))
+      .filter((country) => country.length === 3 && !EXCLUDED_ISO_CODES.includes(country))
       .map(async (country) => {
         try {
           const { data: subDivisionResponse } = await apiClient.get(`/geographies/subdivisions/${country}`);

--- a/src/pages/sitemap.txt.ts
+++ b/src/pages/sitemap.txt.ts
@@ -1,37 +1,39 @@
 import { ApiClient } from "@/api/http-common";
+import { EXCLUDED_ISO_CODES, INCLUDED_GEO_TYPES } from "@/constants/geography";
 import { TDataNode, TGeography } from "@/types";
 
-function Sitemap() {}
+// Determines which geographies to include/exclude
+const geographyFilter = (geography: TDataNode<TGeography>): boolean => {
+  if (EXCLUDED_ISO_CODES.includes(geography.node.value)) return false;
+  if (!INCLUDED_GEO_TYPES.includes(geography.node.type)) return false;
+  return true;
+};
 
-function extractGeographySlugs(config: TDataNode<TGeography>): string[] {
-  const children_slugs: string[] = config.children.flatMap((node): string[] => extractGeographySlugs(node));
-  return [config.node.slug].concat(children_slugs);
-}
-
-async function fetchGeographies(): Promise<TDataNode<TGeography>[]> {
-  const client = new ApiClient();
-  const { data: data } = await client.getConfig();
-  return data.geographies;
-}
-
-async function getGeographyIds(): Promise<string[]> {
-  const geographyData: TDataNode<TGeography>[] = await fetchGeographies();
-  return geographyData.flatMap((item: TDataNode<TGeography>) => extractGeographySlugs(item));
-}
-
-async function getGeographyPages(res: any, hostname: string): Promise<string[]> {
-  const slug_list: string[] = await getGeographyIds();
-  return slug_list.map((geo_slug: string) => `${hostname ?? ""}/geographies/${geo_slug}`);
-}
+// Recursively transform node structure into flat list of geo slugs
+const extractGeographySlugs = (config: TDataNode<TGeography>): string[] => {
+  const childrenSlugs: string[] = config.children.flatMap((node): string[] => extractGeographySlugs(node));
+  return (geographyFilter(config) ? [config.node.slug] : []).concat(childrenSlugs);
+};
 
 export async function getServerSideProps({ res }) {
-  res.setHeader("Content-Type", "text/plain");
-  res.write((await getGeographyPages(res, process.env.HOSTNAME)).join("\n"));
+  const client = new ApiClient();
+  const {
+    data: { geographies: geographiesData },
+  } = await client.getConfig();
+
+  const geographySlugs = geographiesData.flatMap((item) => extractGeographySlugs(item));
+  const urls = geographySlugs.map((slug) => `${process.env.HOSTNAME ?? ""}/geographies/${slug}`);
+
+  res.setHeader("Content-Type", "application/JSON");
+  res.write(urls.join("\n"));
   res.end();
 
   return {
     props: {},
   };
 }
+
+// Needed so Next.js recognises this as a page
+const Sitemap = () => {};
 
 export default Sitemap;


### PR DESCRIPTION
# What's changed

- Added constants for countries data and removed equivalent literal declarations.
- Refactored sitemap page:
  - Less individual functions for better readability.
  - Filtered out any geography node which we don't serve a geo page for (custom ISO codes, regions).

## Why?

Satisfies [APP-1249](https://linear.app/climate-policy-radar/issue/APP-1249/add-geos-and-sub-geos-to-the-generated-sitemap).