### PR TITLE
APP-1168: Map: countries with 0 cases and countries with 1 case should have different colour

### DIFF
--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -68,11 +68,11 @@ const geoStyle = (isActive: boolean, count: number, max: number) => {
   const countLog = Math.log10(count || 1);
 
   const ratio = countLog / maxLog;
-  const fillLuminosity = count === 0 ? 80 : 60 - ratio * 25;
+  const fillLightness = count === 0 ? 80 : 60 - ratio * 25;
 
   return {
     default: {
-      fill: isActive ? "#002CA3" : `hsl(206, 14%, ${fillLuminosity}%)`,
+      fill: isActive ? "#002CA3" : `hsl(206, 14%, ${fillLightness}%)`,
       stroke: "#fff",
       strokeWidth: 0.25,
       outline: "none",


### PR DESCRIPTION
# What's changed

- Updated the formula for what colour to shade a world map country as:
  - Countries with no entries have a static HSL lightness value.
  - Lowered the darkness of the lowest count value and increased the contrast to the highest value country.

## Why?

Satisfies [APP-1168](https://linear.app/climate-policy-radar/issue/APP-1168/map-countries-with-0-cases-and-countries-with-1-case-should-have).

## Screenshots?

<img width="1191" height="713" alt="Screenshot 2025-10-07 at 15 37 44" src="https://github.com/user-attachments/assets/f0c818a6-e581-4c11-9586-ab66d3a45d2c" />