### PR TITLE
fix: comment out debug

### DIFF
--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -83,9 +83,9 @@ const CollectionPage: InferGetStaticPropsType<typeof getServerSideProps> = ({ co
                 <div className="text-content" dangerouslySetInnerHTML={{ __html: collection.description }} />
               </TextBlock>
               <MetadataBlock block="metadata" metadata={getCollectionMetadata(collection)} />
-              <Section block="debug" title="Debug">
+              {/* <Section block="debug" title="Debug">
                 <Debug data={collection} title="Collection" />
-              </Section>
+              </Section> */}
             </main>
           </>
         )}


### PR DESCRIPTION
[There there might have been a misunderstanding here](https://github.com/climatepolicyradar/navigator-frontend/pull/888/files/4eb932276b940ba249c56630f4e720418e7843f6#r2410098964).


fixes: https://linear.app/climate-policy-radar/issue/APP-1286/remove-debug-from-about-tab-on-collection-pages-on-climatecasechart