### PR TITLE
Fix: PostHog analytics attributes for search results in sidebar not working

### DIFF
--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -1,4 +1,3 @@
-import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 
 import { TPassage } from "@/types";
@@ -33,7 +32,10 @@ const PassageMatches = ({ passages, onClick, pageColour = "textDark", position, 
     }
   }, [hasCopied]);
 
-  const posthog = usePostHog();
+  const onButtonClick = (item: TPassage) => {
+    onClick(item.text_block_page);
+  };
+
   const hasPosition = typeof position === "number" && typeof positionOffset === "number";
 
   return (
@@ -45,20 +47,14 @@ const PassageMatches = ({ passages, onClick, pageColour = "textDark", position, 
       ) : (
         <ul className="my-5" id="passage-matches" aria-label="Passage matches">
           {passages.map((item, index: number) => (
-            <li
-              key={item.text_block_id}
-              data-analytics="document-passage-result"
-              id={`passage-${index}`}
-              className="mb-2 hide-in-percy"
-              onClick={() => posthog.capture("Passage matches click", { index })}
-              data-ph-capture-attribute-position-page={hasPosition ? position : undefined}
-              data-ph-capture-attribute-position-total={hasPosition ? positionOffset + position : undefined}
-            >
-              <div
+            <li key={item.text_block_id} data-analytics="document-passage-result" id={`passage-${index}`} className="mb-2 hide-in-percy">
+              <button
+                type="button"
                 className={`p-4 cursor-pointer border border-gray-300 rounded-md bg-white hover:border-gray-500`}
-                onClick={() => {
-                  onClick(item.text_block_page);
-                }}
+                onClick={() => onButtonClick(item)}
+                data-ph-capture-attribute-position-page={hasPosition ? position : undefined}
+                data-ph-capture-attribute-position-total={hasPosition ? positionOffset + position : undefined}
+                data-ph-capture-attribute-button-purpose="search-result-family-passage"
               >
                 <div className={`text-sm flex justify-between ${"text-" + pageColour}`}>
                   <span className="font-medium">{item.text_block_page !== null && <>Page {item.text_block_page}</>}</span>
@@ -66,8 +62,8 @@ const PassageMatches = ({ passages, onClick, pageColour = "textDark", position, 
                     {hasCopied === index ? "Copied" : <Icon name="copy" width="16" height="16" />}
                   </div>
                 </div>
-                <p className="mt-2 break-words">{item.text}</p>
-              </div>
+                <p className="mt-2 text-left wrap-break-word">{item.text}</p>
+              </button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
# What's changed

- Changed a `div` to a `button` so it is correctly captured as a click event.
- Moved the PostHog analytics attributes onto the button rather than them being on a list item.

## Why?

Should result in the correct capture of extra analytics info about the search result number.