### PR TITLE
fix: use labels.value.value for filter

### DIFF
--- a/src/components/_experiment/queryBuilder/QueryBuilder.tsx
+++ b/src/components/_experiment/queryBuilder/QueryBuilder.tsx
@@ -17,7 +17,7 @@ type TQueryGroup = {
 };
 
 type TQueryRule = {
-  field: "labels.value.id";
+  field: "labels.value.value";
   op: "contains" | "not_contains";
   value: string;
 };
@@ -52,7 +52,7 @@ function nodeId(node: TQueryGroup | TQueryRule): number {
 // ---------------------------------------------------------------------------
 
 function createRule(): TQueryRule {
-  return { field: "labels.value.id", op: "contains", value: "" };
+  return { field: "labels.value.value", op: "contains", value: "" };
 }
 
 export function createGroup(): TQueryGroup {

--- a/src/schemas/filters.ts
+++ b/src/schemas/filters.ts
@@ -3,7 +3,7 @@ import * as v from "valibot";
 import { TQueryGroup } from "@/components/_experiment/queryBuilder/QueryBuilder";
 
 export const FilterSchema = v.object({
-  field: v.literal("labels.value.id"),
+  field: v.literal("labels.value.value"),
   op: v.picklist(["contains", "not_contains"]),
   value: v.string(),
 });

--- a/src/utils/filters/advancedFilters.ts
+++ b/src/utils/filters/advancedFilters.ts
@@ -21,7 +21,7 @@ function groupIsEmpty(group: TQueryGroup | null): boolean {
 
 /** Add a label as a new "contains" rule to the root filter group. */
 export function addLabelRule(group: TQueryGroup | null, label: string): TQueryGroup {
-  const rule: TQueryRule = { field: "labels.value.id", op: "contains", value: label };
+  const rule: TQueryRule = { field: "labels.value.value", op: "contains", value: label };
   if (groupIsEmpty(group)) return { op: "and", filters: [rule] };
   return { ...group, filters: [...group.filters, rule] };
 }


### PR DESCRIPTION
# What's changed
- uses `labels.value.value` for the filter value, based on [this PR](https://github.com/climatepolicyradar/search/pull/239)

## Why?

- so that we can reimplement the `labels.value.id` filter properly, and then move the FE over
- this will avoid selecting a filter value across type e.g. `Law` will select `entity_type::Law` and `category::Law`

Towards https://linear.app/climate-policy-radar/issue/APP-1950/make-document-label-search-use-typevalue-instead-of-just-value
