### PR TITLE
fix: remove filter by label.value

### DIFF
--- a/src/components/_experiment/queryBuilder/QueryBuilder.tsx
+++ b/src/components/_experiment/queryBuilder/QueryBuilder.tsx
@@ -17,8 +17,7 @@ type TQueryGroup = {
 };
 
 type TQueryRule = {
-  // TODO: Remove as part of
-  field: "labels.value.id" | "labels.value.value";
+  field: "labels.value.id";
   op: "contains" | "not_contains";
   value: string;
 };

--- a/src/schemas/filters.ts
+++ b/src/schemas/filters.ts
@@ -3,8 +3,7 @@ import * as v from "valibot";
 import { TQueryGroup } from "@/components/_experiment/queryBuilder/QueryBuilder";
 
 export const FilterSchema = v.object({
-  // TODO: Remove.
-  field: v.picklist(["labels.value.id", "labels.value.value"]),
+  field: v.picklist(["labels.value.id"]),
   op: v.picklist(["contains", "not_contains"]),
   value: v.string(),
 });


### PR DESCRIPTION
# What's changed

- removes the ability to filter by `label.value`

## Why?

Allowing filtering by non-explicit (vespa-speak: attribute) styles values causes way more confusion than it's worth. We should be using free-text search for that. 

AKA: Filtering should always be done on IDs.

