### PR TITLE
Ensure we are checking for ID, not value

### DIFF
--- a/src/components/_experiment/searchFilters/SearchFilters.tsx
+++ b/src/components/_experiment/searchFilters/SearchFilters.tsx
@@ -19,7 +19,7 @@ function hasValue(group: TQueryGroup | null | undefined, value: string): boolean
 function hasActiveFilterOfType(filters: TLabelResult[], group: TQueryGroup | null | undefined, type: TLabelType): boolean {
   if (!group) return false;
   return group.filters.some((f) =>
-    "value" in f ? filters.some((label) => label.value === f.value && label.type === type) : hasActiveFilterOfType(filters, f, type)
+    "value" in f ? filters.some((label) => label.id === f.value && label.type === type) : hasActiveFilterOfType(filters, f, type)
   );
 }
 


### PR DESCRIPTION
# What's changed
- use ID to check if any filters of type applied