### PR TITLE
Clicking on labels in search result applies the label correctly

### DIFF
--- a/src/components/_experiment/searchResults/DocumentSearchResult.tsx
+++ b/src/components/_experiment/searchResults/DocumentSearchResult.tsx
@@ -64,7 +64,7 @@ export function DocumentSearchResult({ result, onSelectLabel }: { result: Search
             <button
               key={i}
               className="flex gap-1 items-center rounded px-2 py-0.5 cursor-pointer hover:bg-neutral-200"
-              onClick={() => onSelectLabel?.(relationship.value.value)}
+              onClick={() => onSelectLabel?.(relationship.value.id)}
             >
               <LucideEarth width={14} height={14} />
               <span>{relationship.value.value}</span>

--- a/src/components/_experiment/searchResults/PrincipalSearchResult.tsx
+++ b/src/components/_experiment/searchResults/PrincipalSearchResult.tsx
@@ -66,7 +66,7 @@ export function PrincipalSearchResult({ result, onSelectLabel }: { result: Searc
                   <button
                     key={i}
                     className="flex gap-1 items-center rounded px-2 py-0.5 cursor-pointer hover:bg-neutral-200"
-                    onClick={() => onSelectLabel?.(relationship.value.value)}
+                    onClick={() => onSelectLabel?.(relationship.value.id)}
                   >
                     {iconForLabelType(relationship.value.type)}
                     <span>{relationship.value.value}</span>


### PR DESCRIPTION
# What's changed
- Clicking on a label in the search result now applies the filter correctly, by using the ID of the label.

## Why?
- Wasn't working before as we had not switched it over from using the value
