### PR TITLE
Feat/screw you bots

### DIFF
--- a/infra/Pulumi.ccc-production.yaml
+++ b/infra/Pulumi.ccc-production.yaml
@@ -29,7 +29,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
-  frontend:apprunner_frontend_memory_gb: "8 GB"
+  frontend:apprunner_frontend_vcpu_count: 4 vCPU
+  frontend:apprunner_frontend_memory_gb: 8 GB
 environment:
   - frontend/ccc-production

--- a/infra/Pulumi.ccc-production.yaml
+++ b/infra/Pulumi.ccc-production.yaml
@@ -29,5 +29,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
+  frontend:apprunner_frontend_memory_gb: "8 GB"
 environment:
   - frontend/ccc-production

--- a/infra/Pulumi.ccc-review.yaml
+++ b/infra/Pulumi.ccc-review.yaml
@@ -27,5 +27,7 @@ config:
   frontend:theme: ccc
   frontend:validation_account_id:
     secure: AAABAO27voF7di6u38zns14+kI+/wjLr5GzuvDz8LZxc2grKbCFv2+trwMQ=
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/ccc-review

--- a/infra/Pulumi.ccc-review.yaml
+++ b/infra/Pulumi.ccc-review.yaml
@@ -27,7 +27,7 @@ config:
   frontend:theme: ccc
   frontend:validation_account_id:
     secure: AAABAO27voF7di6u38zns14+kI+/wjLr5GzuvDz8LZxc2grKbCFv2+trwMQ=
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/ccc-review

--- a/infra/Pulumi.ccc-staging.yaml
+++ b/infra/Pulumi.ccc-staging.yaml
@@ -27,5 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/ccc-staging

--- a/infra/Pulumi.ccc-staging.yaml
+++ b/infra/Pulumi.ccc-staging.yaml
@@ -27,7 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/ccc-staging

--- a/infra/Pulumi.cclw-production.yaml
+++ b/infra/Pulumi.cclw-production.yaml
@@ -28,5 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
+  frontend:apprunner_frontend_memory_gb: "8 GB"
 environment:
   - frontend/cclw-production

--- a/infra/Pulumi.cclw-production.yaml
+++ b/infra/Pulumi.cclw-production.yaml
@@ -28,7 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
-  frontend:apprunner_frontend_memory_gb: "8 GB"
+  frontend:apprunner_frontend_vcpu_count: 4 vCPU
+  frontend:apprunner_frontend_memory_gb: 8 GB
 environment:
   - frontend/cclw-production

--- a/infra/Pulumi.cclw-review.yaml
+++ b/infra/Pulumi.cclw-review.yaml
@@ -27,7 +27,7 @@ config:
   frontend:theme: cclw
   frontend:validation_account_id:
     secure: AAABAPuRdTBqdG17KLnwRCZoQXSnRhTX9zA23rCeq+Ettk8ESiauYGnV/z8=
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/cclw-review

--- a/infra/Pulumi.cclw-review.yaml
+++ b/infra/Pulumi.cclw-review.yaml
@@ -27,5 +27,7 @@ config:
   frontend:theme: cclw
   frontend:validation_account_id:
     secure: AAABAPuRdTBqdG17KLnwRCZoQXSnRhTX9zA23rCeq+Ettk8ESiauYGnV/z8=
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/cclw-review

--- a/infra/Pulumi.cclw-staging.yaml
+++ b/infra/Pulumi.cclw-staging.yaml
@@ -27,7 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/cclw-staging

--- a/infra/Pulumi.cclw-staging.yaml
+++ b/infra/Pulumi.cclw-staging.yaml
@@ -27,5 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/cclw-staging

--- a/infra/Pulumi.cpr-production.yaml
+++ b/infra/Pulumi.cpr-production.yaml
@@ -29,7 +29,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
-  frontend:apprunner_frontend_memory_gb: "8 GB"
+  frontend:apprunner_frontend_vcpu_count: 4 vCPU
+  frontend:apprunner_frontend_memory_gb: 8 GB
 environment:
   - frontend/cpr-production

--- a/infra/Pulumi.cpr-production.yaml
+++ b/infra/Pulumi.cpr-production.yaml
@@ -29,5 +29,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
+  frontend:apprunner_frontend_memory_gb: "8 GB"
 environment:
   - frontend/cpr-production

--- a/infra/Pulumi.cpr-review.yaml
+++ b/infra/Pulumi.cpr-review.yaml
@@ -30,5 +30,7 @@ config:
     secure: AAABAAdvxmEKMe/vt4YkB0vy7/99YxgHXxgPELCVZkQHXdNiwbMFhXAmsPI=
   frontend:auto_scaling_config_arn:
     secure: AAABAIYK+Jf0+zrDf5/RZv4E/6idWDa4SPInQIfztZc+cRiiTzXvriyF+iLSdKPK2ZmfoG/GJrWBzIfoIkqv1Ji2Swb2fpgrgTyuSmPgAmZitX6ots+aJ2X7gtjsPbviacmcq1CyYgmxwry5vvA1A8VyqSJdzlUySkEivolmD1GP9UK5RsNjNpd3XzeWYjPt85C1dNqfCpY=
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/cpr-review

--- a/infra/Pulumi.cpr-review.yaml
+++ b/infra/Pulumi.cpr-review.yaml
@@ -30,7 +30,7 @@ config:
     secure: AAABAAdvxmEKMe/vt4YkB0vy7/99YxgHXxgPELCVZkQHXdNiwbMFhXAmsPI=
   frontend:auto_scaling_config_arn:
     secure: AAABAIYK+Jf0+zrDf5/RZv4E/6idWDa4SPInQIfztZc+cRiiTzXvriyF+iLSdKPK2ZmfoG/GJrWBzIfoIkqv1Ji2Swb2fpgrgTyuSmPgAmZitX6ots+aJ2X7gtjsPbviacmcq1CyYgmxwry5vvA1A8VyqSJdzlUySkEivolmD1GP9UK5RsNjNpd3XzeWYjPt85C1dNqfCpY=
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/cpr-review

--- a/infra/Pulumi.cpr-staging.yaml
+++ b/infra/Pulumi.cpr-staging.yaml
@@ -28,5 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/cpr-staging

--- a/infra/Pulumi.cpr-staging.yaml
+++ b/infra/Pulumi.cpr-staging.yaml
@@ -28,7 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/cpr-staging

--- a/infra/Pulumi.mcf-production.yaml
+++ b/infra/Pulumi.mcf-production.yaml
@@ -28,5 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
+  frontend:apprunner_frontend_memory_gb: "8 GB"
 environment:
   - frontend/mcf-production

--- a/infra/Pulumi.mcf-production.yaml
+++ b/infra/Pulumi.mcf-production.yaml
@@ -28,7 +28,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "4 vCPU"
-  frontend:apprunner_frontend_memory_gb: "8 GB"
+  frontend:apprunner_frontend_vcpu_count: 4 vCPU
+  frontend:apprunner_frontend_memory_gb: 8 GB
 environment:
   - frontend/mcf-production

--- a/infra/Pulumi.mcf-review.yaml
+++ b/infra/Pulumi.mcf-review.yaml
@@ -27,5 +27,7 @@ config:
   frontend:theme: mcf
   frontend:validation_account_id:
     secure: AAABALb4+jGsEUpV9cPzWOpYfckqJ9axpWmmIy4gNI/7MGuRK0rsW1nf9UE=
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/mcf-review

--- a/infra/Pulumi.mcf-review.yaml
+++ b/infra/Pulumi.mcf-review.yaml
@@ -27,7 +27,7 @@ config:
   frontend:theme: mcf
   frontend:validation_account_id:
     secure: AAABALb4+jGsEUpV9cPzWOpYfckqJ9axpWmmIy4gNI/7MGuRK0rsW1nf9UE=
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/mcf-review

--- a/infra/Pulumi.mcf-staging.yaml
+++ b/infra/Pulumi.mcf-staging.yaml
@@ -27,5 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"
 environment:
   - frontend/mcf-staging

--- a/infra/Pulumi.mcf-staging.yaml
+++ b/infra/Pulumi.mcf-staging.yaml
@@ -27,7 +27,7 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB
 environment:
   - frontend/mcf-staging

--- a/infra/Pulumi.sandbox.yaml
+++ b/infra/Pulumi.sandbox.yaml
@@ -29,5 +29,5 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
-  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
-  frontend:apprunner_frontend_memory_gb: "2 GB"
+  frontend:apprunner_frontend_vcpu_count: 1 vCPU
+  frontend:apprunner_frontend_memory_gb: 2 GB

--- a/infra/Pulumi.sandbox.yaml
+++ b/infra/Pulumi.sandbox.yaml
@@ -29,3 +29,5 @@ config:
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
   frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:apprunner_frontend_vcpu_count: "1 vCPU"
+  frontend:apprunner_frontend_memory_gb: "2 GB"

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -197,6 +197,8 @@ if not is_review_template:
             if is_cpr_stack
             else default_min_instances
         ),
+        cpu=config.require("apprunner_frontend_vcpu_count")
+        memory=config.require("apprunner_frontend_memory_gb"),
         auto_deploy=True,
     )
 

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -197,7 +197,7 @@ if not is_review_template:
             if is_cpr_stack
             else default_min_instances
         ),
-        cpu=config.require("apprunner_frontend_vcpu_count")
+        cpu=config.require("apprunner_frontend_vcpu_count"),
         memory=config.require("apprunner_frontend_memory_gb"),
         auto_deploy=True,
     )

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -20,6 +20,7 @@ from resources.cors_policy import CloudFrontCORSPolicy, CORSPolicyConfig
 from resources.dns import DNS, DNSConfig
 from resources.ecr_repository import ECRRepository, ECRRepositoryConfig
 from resources.github_actions_role import GitHubActionsRole
+from resources.waf import FrontendWebAcl
 from resources.util import (
     BehaviourOptions,
     CookieConfig,
@@ -496,6 +497,11 @@ if not is_review_stack_or_template:
         EXTERNAL = "public facing"
 
 
+    frontend_web_acl = FrontendWebAcl(
+        name=f"{theme}-{env}-frontend-waf",
+        tags={"CUSTOM_APP_THEME": theme, "Environment": env},
+    )
+
     cf = CloudFrontDistribution(
         f"{theme.upper()}FrontendDistribution",
         DistributionType.FRONTEND,
@@ -506,6 +512,7 @@ if not is_review_stack_or_template:
         acm_certificate=dns.certificate,
         origin_request_policy_id=cast(str, cors_policy.policy.id),
         ordered_cache_behaviors=ordered_cache_behaviors,
+        web_acl_id=cast(str, frontend_web_acl.web_acl.arn),
         # Needed for auto-invalidations to work, @related: CUSTOM_APP_THEME
         tags={
             "CUSTOM_APP_THEME": theme,
@@ -551,6 +558,7 @@ if not is_review_stack_or_template:
             acm_certificate=cname_dns.certificate,
             origin_request_policy_id=cast(str, cors_policy.policy.id),
             ordered_cache_behaviors=ordered_cache_behaviors,
+            web_acl_id=cast(str, frontend_web_acl.web_acl.arn),
             # Needed for auto-invalidations to work, @related: CUSTOM_APP_THEME
             tags={
                 "CUSTOM_APP_THEME": theme,
@@ -606,12 +614,12 @@ if not is_review_stack_or_template:
             comment="Redirects for CCC",
         )
 
-        infra_dir = Path(__file__).parent.parent
-        with open(infra_dir / "redirects.json", "r") as f:
+        infra_dir = Path(__file__).parent
+        with open(infra_dir / "lambda_code" / "redirects.json", "r") as f:
             redirects: list[dict[str, str]] = json.load(f)["redirects"]
 
         # Get the code as a string for the CloudFront Function
-        with open(infra_dir / "redirection.js", "r") as f:
+        with open(infra_dir / "lambda_code" / "redirection.js", "r") as f:
             lambda_code = f.read()
 
         for redirect in redirects:
@@ -710,6 +718,7 @@ if not is_review_stack_or_template:
                     ),
                 ],
             ),
+            web_acl_id=cast(str, frontend_web_acl.web_acl.arn),
             # These are used for cache invalidations
             tags={"CUSTOM_APP_THEME": "ccc", "Environment": "production"},
         )

--- a/infra/resources/cloudfront_distribution.py
+++ b/infra/resources/cloudfront_distribution.py
@@ -50,6 +50,9 @@ class CloudFrontDistribution(pulumi.ComponentResource):
     :type ordered_cache_behaviors: Optional[List[Dict[str, Any]]]
     :param tags: Resource tags
     :type tags: Optional[Dict[str, str]]
+    :param web_acl_id: ARN of the WAFv2 WebACL to attach (despite the field
+        name, CloudFront expects the WebACL ARN, not its id)
+    :type web_acl_id: Optional[str]
     :param opts: Resource options
     :type opts: Optional[pulumi.ResourceOptions]
     """
@@ -67,6 +70,7 @@ class CloudFrontDistribution(pulumi.ComponentResource):
         default_cache_behavior: Optional[List[Dict[str, Any]]] = None,
         ordered_cache_behaviors: Optional[List[Dict[str, Any]]] = None,
         tags: Optional[Dict[str, str]] = None,
+        web_acl_id: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ):
 
@@ -99,6 +103,7 @@ class CloudFrontDistribution(pulumi.ComponentResource):
             acm_certificate,
             origin_request_policy_id,
             ordered_cache_behaviors,
+            web_acl_id,
         )
 
         # Register outputs
@@ -164,6 +169,7 @@ class CloudFrontDistribution(pulumi.ComponentResource):
         acm_certificate_arn: str,
         origin_request_policy_id: Optional[str],
         ordered_cache_behaviors: Optional[List[Dict[str, Any]]] = None,
+        web_acl_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         config = {
             "aliases": aliases,
@@ -195,6 +201,9 @@ class CloudFrontDistribution(pulumi.ComponentResource):
         if ordered_cache_behaviors:
             config["ordered_cache_behaviors"] = ordered_cache_behaviors
 
+        if web_acl_id:
+            config["web_acl_id"] = web_acl_id
+
         return config
 
     def _create_distribution(
@@ -207,6 +216,7 @@ class CloudFrontDistribution(pulumi.ComponentResource):
         acm_certificate: aws.acm.Certificate,
         origin_request_policy_id: Optional[str],
         ordered_cache_behaviors: Optional[List[Dict[str, Any]]] = None,
+        web_acl_id: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> aws.cloudfront.Distribution:
         # Allow user options to override our defaults.
@@ -227,6 +237,7 @@ class CloudFrontDistribution(pulumi.ComponentResource):
                 cast(str, acm_certificate.arn),
                 origin_request_policy_id,
                 ordered_cache_behaviors,
+                web_acl_id,
             ),
             opts=resource_opts,
             tags=self.tags,

--- a/infra/resources/util.py
+++ b/infra/resources/util.py
@@ -112,7 +112,40 @@ def validate_stack_and_branch() -> None:
     deploy_to_prod_stack_allowed = convert_str_to_bool(
         os.getenv("DEPLOY_TO_PROD_STACK_ALLOWED", "False")
     )
-    
+
+    if deploy_from_main_branch_only and is_branch_dirty():
+        raise RuntimeError("The current branch has uncommitted changes.\n\n")
+
+    if "production" in stack:
+        if not deploy_to_prod_stack_allowed:
+            raise RuntimeError(
+                f"Deploying to the '{stack}' stack is not allowed.\n\n"
+                f"Set the environment variable 'DEPLOY_TO_PROD_STACK_ALLOWED' to 'True' in the pulumi command to allow "
+                f"it.\n\n "
+            )
+        if branch != deployment_branch:
+            raise RuntimeError(
+                f"The stack '{stack}' is only deployable from the '{deployment_branch}' branch.\n\n"
+            )
+
+    elif "staging" in stack:
+        if deploy_from_main_branch_only and branch != deployment_branch:
+            raise RuntimeError(
+                f"The stack '{stack}' is only deployable from the '{deployment_branch}'. Set the environment "
+                f"variable 'DEPLOY_FROM_MAIN_BRANCH_ONLY' to 'False' in the pulumi command to allow it.\n\n"
+            )
+
+    elif "sandbox" in stack:
+        pass
+
+    elif "review" in stack or stack.startswith("pr-"):
+        # Review stacks (e.g. cpr-review, pr-climatepolicyradar-navigator-frontend-1139)
+        # are ephemeral and can be deployed from any branch.
+        pass
+
+    else:
+        raise RuntimeError(f"The stack '{stack}' is not a valid stack.\n\n")
+
 
 class BehaviourTypes(Enum):
     """Enum for behaviour types."""

--- a/infra/resources/util.py
+++ b/infra/resources/util.py
@@ -112,40 +112,7 @@ def validate_stack_and_branch() -> None:
     deploy_to_prod_stack_allowed = convert_str_to_bool(
         os.getenv("DEPLOY_TO_PROD_STACK_ALLOWED", "False")
     )
-
-    if deploy_from_main_branch_only and is_branch_dirty():
-        raise RuntimeError("The current branch has uncommitted changes.\n\n")
-
-    if "production" in stack:
-        if not deploy_to_prod_stack_allowed:
-            raise RuntimeError(
-                f"Deploying to the '{stack}' stack is not allowed.\n\n"
-                f"Set the environment variable 'DEPLOY_TO_PROD_STACK_ALLOWED' to 'True' in the pulumi command to allow "
-                f"it.\n\n "
-            )
-        if branch != deployment_branch:
-            raise RuntimeError(
-                f"The stack '{stack}' is only deployable from the '{deployment_branch}' branch.\n\n"
-            )
-
-    elif "staging" in stack:
-        if deploy_from_main_branch_only and branch != deployment_branch:
-            raise RuntimeError(
-                f"The stack '{stack}' is only deployable from the '{deployment_branch}'. Set the environment "
-                f"variable 'DEPLOY_FROM_MAIN_BRANCH_ONLY' to 'False' in the pulumi command to allow it.\n\n"
-            )
-
-    elif "sandbox" in stack:
-        pass
-
-    elif "review" in stack or stack.startswith("pr-"):
-        # Review stacks (e.g. cpr-review, pr-climatepolicyradar-navigator-frontend-1139)
-        # are ephemeral and can be deployed from any branch.
-        pass
-
-    else:
-        raise RuntimeError(f"The stack '{stack}' is not a valid stack.\n\n")
-
+    
 
 class BehaviourTypes(Enum):
     """Enum for behaviour types."""

--- a/infra/resources/waf.py
+++ b/infra/resources/waf.py
@@ -1,0 +1,96 @@
+from typing import Dict, Optional
+
+import pulumi
+import pulumi_aws as aws
+
+from resources.util import tag_name
+
+
+class FrontendWebAcl(pulumi.ComponentResource):
+    """
+    A WAFv2 WebACL for attaching to CloudFront distributions.
+
+    Creates its own us-east-1 provider internally because CLOUDFRONT-scoped
+    WebACLs must live in us-east-1, regardless of where the rest of the stack
+    is deployed. Pattern mirrors `resources/dns.py` for CloudFront ACM certs.
+
+    Exposes `.web_acl` — pass `.web_acl.arn` as `web_acl_id` to
+    `aws.cloudfront.Distribution` (CloudFront takes the ARN, not the id).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        tags: Optional[Dict[str, str]] = None,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ):
+        super().__init__("cpr:waf:FrontendWebAcl", name, None, opts)
+
+        default_tags = {
+            "CPR-Created-By": "pulumi",
+            "CPR-Pulumi-Stack-Name": pulumi.get_stack(),
+            "CPR-Pulumi-Project-Name": pulumi.get_project(),
+            "CPR-Tag": tag_name(),
+        }
+        self.tags = default_tags | (tags or {})
+
+        self._useast1 = aws.Provider(
+            f"{name}-useast1",
+            region="us-east-1",
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        count_chrome_125 = aws.wafv2.WebAclRuleArgs(
+            name="CountChrome125UserAgent",
+            priority=0,
+            action=aws.wafv2.WebAclRuleActionArgs(
+                count=aws.wafv2.WebAclRuleActionCountArgs(),
+            ),
+            statement=aws.wafv2.WebAclRuleStatementArgs(
+                byte_match_statement=aws.wafv2.WebAclRuleStatementByteMatchStatementArgs(
+                    field_to_match=aws.wafv2.WebAclRuleStatementByteMatchStatementFieldToMatchArgs(
+                        single_header=aws.wafv2.WebAclRuleStatementByteMatchStatementFieldToMatchSingleHeaderArgs(
+                            name="user-agent",
+                        ),
+                    ),
+                    positional_constraint="CONTAINS",
+                    search_string="Chrome/125.0.0.0",
+                    text_transformations=[
+                        aws.wafv2.WebAclRuleStatementByteMatchStatementTextTransformationArgs(
+                            priority=0,
+                            type="NONE",
+                        ),
+                    ],
+                ),
+            ),
+            visibility_config=aws.wafv2.WebAclRuleVisibilityConfigArgs(
+                cloudwatch_metrics_enabled=True,
+                metric_name="CountChrome125UserAgent",
+                sampled_requests_enabled=True,
+            ),
+        )
+
+        self.web_acl = aws.wafv2.WebAcl(
+            name,
+            name=name,
+            description=f"Frontend WAF for {name}",
+            scope="CLOUDFRONT",
+            default_action=aws.wafv2.WebAclDefaultActionArgs(
+                allow=aws.wafv2.WebAclDefaultActionAllowArgs(),
+            ),
+            rules=[count_chrome_125],
+            visibility_config=aws.wafv2.WebAclVisibilityConfigArgs(
+                cloudwatch_metrics_enabled=True,
+                metric_name=f"{name}-web-acl",
+                sampled_requests_enabled=True,
+            ),
+            tags=self.tags,
+            opts=pulumi.ResourceOptions(provider=self._useast1, parent=self),
+        )
+
+        self.register_outputs(
+            {
+                "web_acl_arn": self.web_acl.arn,
+                "web_acl_id": self.web_acl.id,
+            }
+        )


### PR DESCRIPTION
# What's changed

- Added vCPU and memory as pulumi stack config parameters
- Upped production frontend containers to 4 vCPUs and 8GB memory 
- Added WAF ACL to cloudfront distribution that counts (without block or challenge) user agents with Chrome/125.0.0.0 in the user agent string

The production frontend apprunners have been updated and are using the new config. 

CPR-staging has a deployment of the WAF rules, but I do not want to update production until this code has had a good going over. 

Before merging, if we're happy with the code, we should finish deploying to staging services and confirm all working, and then update production services incrementally. 

## Why

We got hit hard by scraper bots, and they all use that string in their user agent. If they come back, we'll be able to turn the count into a challenge and serve them with a captcha. This PR gets the infra in so we can test and tune. 

The interaction of this with the CCC redirects is an open question for me and therefore I would appreciate careful eyes on. 

## AI attribution

Claude wrote the WAF code, heavily supervised by myself and Katy
 