### PR TITLE
Add unit test for the tsconfig.base.json file on the critical alias

### DIFF
--- a/tsconfig.base.test.ts
+++ b/tsconfig.base.test.ts
@@ -1,7 +1,12 @@
 import config from "./tsconfig.base.json";
 
 describe("tsconfig.base.json", () => {
-  it("should not be hardcoding the theme alias path, and should contain the wildcard", () => {
-    expect(config.compilerOptions.paths["@/themes/*"]).toContain("./themes/__THEME__/*");
+  describe("the */themes alias", () => {
+    it("should only contain one path", () => {
+      expect(config.compilerOptions.paths["@/themes/*"]).toHaveLength(1);
+    });
+    it("should contain the wildcard", () => {
+      expect(config.compilerOptions.paths["@/themes/*"]).toContain("./themes/__THEME__/*");
+    });
   });
 });

--- a/tsconfig.base.test.ts
+++ b/tsconfig.base.test.ts
@@ -1,0 +1,7 @@
+import config from "./tsconfig.base.json";
+
+describe("tsconfig.base.json", () => {
+  it("should not be hardcoding the theme alias path, and should contain the wildcard", () => {
+    expect(config.compilerOptions.paths["@/themes/*"]).toContain("./themes/__THEME__/*");
+  });
+});


### PR DESCRIPTION
# What's changed
- Added a unit test for the tsconfig.base.json on the themes path alias

## Why
- This is a critical path that we recently caused a critical issue due to it being hardcoded to a specific theme