### PR TITLE
fix: be bold by bolding

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -95,6 +95,9 @@ export async function fetchSearchDocuments(params: SearchDocumentsParams = {}): 
   const url = new URL(SEARCH_DOCUMENTS_BASE_URL);
   const filters = configureDocumentsFilters(params.filters, params.includeDocumentsInSearch ?? false);
 
+  // This enables `bolding` in vespa AKA highlighting, which highlights the matched terms in the results.
+  url.searchParams.set("bolding", "true");
+
   if (params.query) url.searchParams.set("query", params.query);
   if (filters) url.searchParams.set("filters", JSON.stringify(filters));
   if (params.page_size !== undefined) url.searchParams.set("page_size", params.page_size);


### PR DESCRIPTION
# What's changed

- adds bolding to the [API request](https://github.com/climatepolicyradar/search/blob/main/api/routers.py#L39) by default

## Why

- highlight messages

## Screenshots

<img width="1069" height="1167" alt="Screenshot 2026-04-23 at 13 33 04" src="https://github.com/user-attachments/assets/30c00f51-1465-45ed-b842-c76cac960f75" />


