### PR TITLE
Secret merge button

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -60,40 +60,59 @@ interface SearchDocumentsParams {
   page_size?: string;
   page_token?: string;
   includeDocumentsInSearch?: boolean;
+  excludeMergedDocuments?: boolean;
 }
 
 const SEARCH_DOCUMENTS_BASE_URL = "https://api.climatepolicyradar.org/search/documents";
 
-function configureDocumentsFilters(filters: TQueryGroup | undefined, includeDocumentsInSearch: boolean): TQueryGroup {
-  // including documents in search is the default search, otherwise default to only principal documents
-  // principal will have to be added as a parent group with AND to ensure there are no conflicts if a user has built an advanced filtering ruleset
-  if (!includeDocumentsInSearch) {
-    const documentsFilter: TQueryGroup = {
-      op: "and",
-      filters: [
-        {
-          field: "labels.value.id",
-          op: "contains",
-          value: "principal",
-        },
-      ],
-    };
-    if (filters) {
-      filters = {
-        op: "and",
-        filters: [filters, documentsFilter],
-      };
-    } else {
-      filters = documentsFilter;
-    }
+function configureDocumentsFilters(
+  filters: TQueryGroup | undefined,
+  includeDocumentsInSearch: boolean,
+  excludeMergedDocuments: boolean
+): TQueryGroup {
+  const notContainsMergedLabelFilter: TQueryGroup = {
+    op: "and",
+    filters: [
+      {
+        field: "labels.value.id",
+        op: "not_contains",
+        value: "status::Merged",
+      },
+    ],
+  };
+  const principalDocumentsFilter: TQueryGroup = {
+    op: "and",
+    filters: [
+      {
+        field: "labels.value.id",
+        op: "contains",
+        value: "status::Principal",
+      },
+    ],
+  };
+
+  const filtersWithConditionals: TQueryGroup[] = [];
+  if (filters) {
+    filtersWithConditionals.push(filters);
   }
 
-  return filters;
+  if (excludeMergedDocuments) {
+    filtersWithConditionals.push(notContainsMergedLabelFilter);
+  }
+
+  if (!includeDocumentsInSearch) {
+    filtersWithConditionals.push(principalDocumentsFilter);
+  }
+
+  return {
+    op: "and",
+    filters: filtersWithConditionals,
+  };
 }
 
 export async function fetchSearchDocuments(params: SearchDocumentsParams = {}): Promise<SearchDocumentsResponse> {
   const url = new URL(SEARCH_DOCUMENTS_BASE_URL);
-  const filters = configureDocumentsFilters(params.filters, params.includeDocumentsInSearch ?? false);
+  const filters = configureDocumentsFilters(params.filters, params.includeDocumentsInSearch ?? false, params.excludeMergedDocuments ?? true);
 
   // This enables `bolding` in vespa AKA highlighting, which highlights the matched terms in the results.
   url.searchParams.set("bolding", "true");

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -95,6 +95,9 @@ export async function fetchSearchDocuments(params: SearchDocumentsParams = {}): 
   const url = new URL(SEARCH_DOCUMENTS_BASE_URL);
   const filters = configureDocumentsFilters(params.filters, params.includeDocumentsInSearch ?? false);
 
+  // This enables `bolding` in vespa AKA highlighting, which highlights the matched terms in the results.
+  url.searchParams.set("bolding", "true");
+
   if (params.query) url.searchParams.set("query", params.query);
   if (filters) url.searchParams.set("filters", JSON.stringify(filters));
   if (params.page_size !== undefined) url.searchParams.set("page_size", params.page_size);

--- a/src/components/_experiment/searchResults/SearchResults.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.tsx
@@ -88,6 +88,7 @@ export function SearchContainer({
   page_token,
   page_size,
   includeDocumentsInSearch,
+  excludeMergedDocuments,
   onSelectLabel,
   onAggregationsChange,
   onTotalResultsChange,
@@ -98,6 +99,7 @@ export function SearchContainer({
   page_token?: string;
   page_size?: string;
   includeDocumentsInSearch?: boolean;
+  excludeMergedDocuments?: boolean;
   onSelectLabel?: (label: string) => void;
   onAggregationsChange?: (labels: IAggregationLabel[] | undefined) => void;
   onTotalResultsChange?: (total: number | null) => void;
@@ -112,9 +114,10 @@ export function SearchContainer({
       page_size,
       page_token,
       includeDocumentsInSearch,
+      excludeMergedDocuments,
       filters: filtersCheckedForEmpty,
     });
-  }, [query, filtersCheckedForEmpty, page_token, page_size, includeDocumentsInSearch]);
+  }, [query, filtersCheckedForEmpty, page_token, page_size, includeDocumentsInSearch, excludeMergedDocuments]);
 
   return (
     <>

--- a/src/pages/_search/index.tsx
+++ b/src/pages/_search/index.tsx
@@ -45,6 +45,7 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
   const [totalNoOfResults, setTotalNoOfResults] = useState<number | null>(null);
   // principal or documents
   const [includeDocumentsInSearch, setIncludeDocumentsInSearch] = useQueryState("include_documents", parseAsBoolean.withDefault(true));
+  const [excludeMergedDocuments, setExcludeMergedDocuments] = useQueryState("exclude_merged_documents", parseAsBoolean.withDefault(true));
 
   /**
    * Drops aggregations only when the filter tree becomes empty so greyed options
@@ -148,6 +149,12 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
           />
           <div className="flex items-center gap-6">
             <div>
+              <button className="text-gray-300" onClick={() => setExcludeMergedDocuments(!excludeMergedDocuments)}>
+                {excludeMergedDocuments && "."}
+                {!excludeMergedDocuments && ":"}
+              </button>
+            </div>
+            <div>
               <label className="flex items-center gap-2 text-neutral-600 text-sm font-medium cursor-pointer">
                 Show individual documents
                 <Switch.Root
@@ -159,6 +166,7 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
                 </Switch.Root>
               </label>
             </div>
+
             <AdvancedFilters
               filters={filters}
               setFilters={(filters) => {
@@ -206,6 +214,7 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
             page_token={currentPage}
             page_size={pageSize}
             includeDocumentsInSearch={includeDocumentsInSearch}
+            excludeMergedDocuments={excludeMergedDocuments}
             onAggregationsChange={applyAggregationsFromSearch}
             onTotalResultsChange={setTotalNoOfResults}
           />


### PR DESCRIPTION
# What's changed

- adds a small secret button (@conordelahunty approved ✅) that hides `status::Merged` documents

A merged document is
- a family that has a document that matches it's title exactly.
- a MCF family that has a document that is called "Project document"

The aim is for folks to be able to play around with this.

## Why

To highlight that a lot of our issues on duplication is actually data-quality, not modelling or ranking, that is the issue. 

e.g. a family with a document that both share the same title AKA - they are the same thing.

i.e. the family -> document model forced us into creating two records for a Law, Project etc, when one would resolve to a cleaner, easier to use and understand dataset.

Another non-search, higher level reason was planning for when we will consume other data-sources, where the model is very much 1-1 with a PDF and document record, we no longer have to perpetuate this convoluted pattern.

This is **_a_** reason why the model was designed this way from the start.

## Screenshots

https://github.com/user-attachments/assets/060b4ae9-fccd-4691-97a7-e9325ca8ea42
