### PR TITLE
APP-1586: Show placeholder document title on collection page

### DIFF
--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -9,6 +9,7 @@ import { PageLink } from "@/components/atoms/pageLink/PageLink";
 import { Popover } from "@/components/atoms/popover/Popover";
 import { ViewMore } from "@/components/molecules/viewMore/ViewMore";
 import { ARROW_UP_RIGHT } from "@/constants/chars";
+import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { getLanguage } from "@/helpers/getLanguage";
 import { getMainDocuments } from "@/helpers/getMainDocuments";
@@ -155,7 +156,7 @@ const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, i
         href={`/documents/${document.slug}`}
         className={joinTailwindClasses(linkClasses, (isMainDocument || isLitigation) && "font-medium")}
       >
-        {document.title}
+        {document.title || DEFAULT_DOCUMENT_TITLE}
       </PageLink>
     );
   if (canViewSource)


### PR DESCRIPTION
# What's changed

Added the placeholder document title on the collection page's event tables so that placeholder documents can be clicked. This is now consistent with the same table on the family page.

## Why

Satisfies re-opened [APP-1586](https://linear.app/climate-policy-radar/issue/APP-1586/ccc-documents-without-pdf-to-appear-in-the-events-table-with-its)

## AI attribution

None used.

## Screenshots

*Collection page case showing the filing date event and the placeholder document. While this looks unsatisfying, the placeholder document can now be opened:*
<img width="1143" height="223" alt="Screenshot 2026-04-29 at 10 29 21" src="https://github.com/user-attachments/assets/782edf00-1d3a-460d-9d51-94758ef453ed" />