### PR TITLE
Fix app names, domain & environment for OTEL

### DIFF
--- a/infra/Pulumi.ccc-production.yaml
+++ b/infra/Pulumi.ccc-production.yaml
@@ -23,12 +23,12 @@ config:
     secure: AAABAJA3aIErw8POJaasaF8VlgVkbg4hThMCgqg4GqXpjfucM+4NUFS26lw=
   frontend:concepts_api_url: https://api.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: ccc-frontend
   frontend:next_public_faro_app_namespace: frontend
-  frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
+  frontend:otel_exporter_otlp_endpoint: https://otel.prod.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=production
   frontend:apprunner_frontend_vcpu_count: 4 vCPU
   frontend:apprunner_frontend_memory_gb: 8 GB
 environment:

--- a/infra/Pulumi.ccc-staging.yaml
+++ b/infra/Pulumi.ccc-staging.yaml
@@ -21,12 +21,12 @@ config:
     secure: AAABADhYOVHp6UwwZyZqMsjOOgHgQh7G3zPKRx5cSa4fPn4Io4cXWHh3UGY=
   frontend:concepts_api_url: https://api.staging.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: ccc-frontend
   frontend:next_public_faro_app_namespace: frontend
   frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=staging
   frontend:apprunner_frontend_vcpu_count: 1 vCPU
   frontend:apprunner_frontend_memory_gb: 2 GB
 environment:

--- a/infra/Pulumi.cclw-production.yaml
+++ b/infra/Pulumi.cclw-production.yaml
@@ -22,12 +22,12 @@ config:
     secure: AAABAA5twh+BeNxlnUdRCJAmaSP2FDza1lbAhre5kuAuKgHWDNYch7+93wY=
   frontend:concepts_api_url: https://api.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: cclw-frontend
   frontend:next_public_faro_app_namespace: frontend
-  frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
+  frontend:otel_exporter_otlp_endpoint: https://otel.prod.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=production
   frontend:apprunner_frontend_vcpu_count: 4 vCPU
   frontend:apprunner_frontend_memory_gb: 8 GB
 environment:

--- a/infra/Pulumi.cclw-staging.yaml
+++ b/infra/Pulumi.cclw-staging.yaml
@@ -21,12 +21,12 @@ config:
     secure: AAABAATc2POR1JGQgNMxlmfgpqCThBrWG1GU7XxYJdVoo2JOd+sMjG6IiCQ=
   frontend:concepts_api_url: https://api.staging.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: cclw-frontend
   frontend:next_public_faro_app_namespace: frontend
   frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=staging
   frontend:apprunner_frontend_vcpu_count: 1 vCPU
   frontend:apprunner_frontend_memory_gb: 2 GB
 environment:

--- a/infra/Pulumi.cpr-production.yaml
+++ b/infra/Pulumi.cpr-production.yaml
@@ -25,10 +25,10 @@ config:
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
   frontend:next_public_faro_app_name: cpr-frontend
   frontend:next_public_faro_app_namespace: frontend
-  frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
+  frontend:otel_exporter_otlp_endpoint: https://otel.prod.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=production
   frontend:apprunner_frontend_vcpu_count: 4 vCPU
   frontend:apprunner_frontend_memory_gb: 8 GB
 environment:

--- a/infra/Pulumi.cpr-staging.yaml
+++ b/infra/Pulumi.cpr-staging.yaml
@@ -27,7 +27,7 @@ config:
   frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=staging
   frontend:apprunner_frontend_vcpu_count: 1 vCPU
   frontend:apprunner_frontend_memory_gb: 2 GB
 environment:

--- a/infra/Pulumi.mcf-production.yaml
+++ b/infra/Pulumi.mcf-production.yaml
@@ -22,12 +22,12 @@ config:
     secure: AAABADYt7V0VfqPgcVDS251nxD2ViMFntfIuu6acijn69N2qISKrlJW6BzM=
   frontend:concepts_api_url: https://api.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: mcf-frontend
   frontend:next_public_faro_app_namespace: frontend
-  frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
+  frontend:otel_exporter_otlp_endpoint: https://otel.prod.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=production
   frontend:apprunner_frontend_vcpu_count: 4 vCPU
   frontend:apprunner_frontend_memory_gb: 8 GB
 environment:

--- a/infra/Pulumi.mcf-staging.yaml
+++ b/infra/Pulumi.mcf-staging.yaml
@@ -21,12 +21,12 @@ config:
     secure: AAABAPD1SMTQPKIwvq1MwDIKBH5AQgQQw8otZ7bmqWBZJYUEWnT9SbITgTg=
   frontend:concepts_api_url: https://api.staging.climatepolicyradar.org
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: mcf-frontend
   frontend:next_public_faro_app_namespace: frontend
   frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf
   frontend:otel_service_name: frontend-server
-  frontend:otel_resource_attributes: service.namespace=frontend
+  frontend:otel_resource_attributes: service.namespace=frontend,environment=staging
   frontend:apprunner_frontend_vcpu_count: 1 vCPU
   frontend:apprunner_frontend_memory_gb: 2 GB
 environment:

--- a/infra/Pulumi.sandbox.yaml
+++ b/infra/Pulumi.sandbox.yaml
@@ -23,7 +23,7 @@ config:
   frontend:validation_account_id:
     secure: AAABAAFG2k/W8GNUQlSarlVkgf3y3r5j5LY+3k9fSODx9Y/yUUOJOv9fs/4=
   frontend:next_public_faro_url: https://faro-collector-prod-gb-south-0.grafana.net/collect/74f6d4bd78b7bb2cc270036193aaa3a6
-  frontend:next_public_faro_app_name: cpr-frontend
+  frontend:next_public_faro_app_name: sandbox-frontend
   frontend:next_public_faro_app_namespace: frontend
   frontend:otel_exporter_otlp_endpoint: https://otel.staging.climatepolicyradar.org/
   frontend:otel_exporter_otlp_protocol: http/protobuf


### PR DESCRIPTION
# What's changed

- Update Faro application names to include the correct theme rather than hardcoded to 'cpr'
- Update OTel resource attributes to include the environment
- Update OTel domain to correctly reflect the right environment

## Why

As part of improving our observability and making sure that we can correctly trace & attribute errors.

## AI attribution

None

## Screenshots
N/a