### PR TITLE
Block late day production deploys

### DIFF
--- a/.github/workflows/deploy-all-production.yml
+++ b/.github/workflows/deploy-all-production.yml
@@ -8,7 +8,54 @@ permissions:
   contents: read
 
 jobs:
+  precheck:
+    name: Validate window before production deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_UPDATES_CHANNEL_WEBHOOK_URL }}
+    outputs:
+      blocked: ${{ steps.time-window.outputs.blocked }}
+      current_hm: ${{ steps.time-window.outputs.current_hm }}
+    steps:
+      - if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "This workflow can only be run from main."
+          exit 1
+      - name: Block deploy outside local change window
+        id: time-window
+        run: |
+          current_hm="$(TZ=Europe/London date +%H%M)"
+          echo "current_hm=$current_hm" >> "$GITHUB_OUTPUT"
+          if [[ "$current_hm" -ge 1730 || "$current_hm" -lt 0900 ]]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Notify Slack about blocked deploy
+        if: steps.time-window.outputs.blocked == 'true' && env.SLACK_WEBHOOK != ''
+        run: |
+          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+          COMMIT_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          MESSAGE="⛔ Deploy blocked outside local change window (09:00-17:30 Europe/London). Current local time: ${{ steps.time-window.outputs.current_hm }}. Attempted deploy of all production themes from <$COMMIT_URL|$COMMIT_SHORT>. @application_engineers"
+          jq -n --arg msg "$MESSAGE" '{text: $msg, mrkdwn: true}' > slack-payload.json
+      - name: Send Slack message
+        if: steps.time-window.outputs.blocked == 'true' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v3.0.2
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack-payload.json
+      - name: Fail blocked deploy
+        if: steps.time-window.outputs.blocked == 'true'
+        run: |
+          echo "Deploy blocked outside local change window (09:00-17:30 Europe/London). Current local time: ${{ steps.time-window.outputs.current_hm }}"
+          exit 1
+
   deploy-production:
+    needs: precheck
+    if: needs.precheck.outputs.blocked != 'true'
     strategy:
       matrix:
         theme: [cpr, cclw, mcf, ccc]
@@ -17,10 +64,6 @@ jobs:
     environment:
       name: production
     steps:
-      - if: ${{ github.ref != 'refs/heads/main' }}
-        run: |
-          echo "This workflow can only be run from main."
-          exit 1
       - uses: actions/checkout@v6
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,16 +27,47 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_UPDATES_CHANNEL_WEBHOOK_URL }}
     steps:
       - if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "This workflow can only be run from main."
           exit 1
+      - name: Block deploy outside local change window
+        id: time-window
+        run: |
+          current_hm="$(TZ=Europe/London date +%H%M)"
+          echo "current_hm=$current_hm" >> "$GITHUB_OUTPUT"
+          if [[ "$current_hm" -ge 1730 || "$current_hm" -lt 0900 ]]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Notify Slack about blocked deploy
+        if: steps.time-window.outputs.blocked == 'true' && env.SLACK_WEBHOOK != ''
+        run: |
+          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+          COMMIT_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          MESSAGE="⛔ Deploy blocked outside local change window (09:00-17:30 Europe/London). Current local time: ${{ steps.time-window.outputs.current_hm }}. Attempted deploy of *${{ inputs.theme }}* production from <$COMMIT_URL|$COMMIT_SHORT>. @application_engineers"
+          jq -n --arg msg "$MESSAGE" '{text: $msg, mrkdwn: true}' > slack-payload.json
+
+          echo "Deploy blocked outside local change window (09:00-17:30 Europe/London). Current local time: ${{ steps.time-window.outputs.current_hm }}"
+          exit 1
+      - name: Send Slack message
+        if: steps.time-window.outputs.blocked == 'true' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v3.0.2
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack-payload.json
+
       - uses: actions/checkout@v6
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-new-frontend-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID
+            }}:role/navigator-new-frontend-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run: build
 # Registry: set DOCKER_REGISTRY (GitHub secret name) or ECR_REGISTRY explicitly,
 # otherwise it defaults to <caller-account>.dkr.ecr.eu-west-1.amazonaws.com.
 #
-# Optional: REQUIRE_MAIN_BRANCH=0 to skip the main-branch guard (CI enforces main).
+# Optional: DEPLOY_FROM_MAIN_BRANCH_ONLY=0 to skip the main-branch guard (CI enforces main).
 AWS_REGION ?= eu-west-1
 IMAGE_TAG_PRODUCTION ?= latest
 GITHUB_SHA ?= $(shell git rev-parse HEAD)
@@ -62,20 +62,20 @@ deploy-production-build-push:
 		--build-arg THEME=$(THEME) \
 		--build-arg GITHUB_SHA=$(GITHUB_SHA) \
 		-t $(ECR_REGISTRY)/navigator-frontend-$(THEME):$(IMAGE_TAG_PRODUCTION) .
-	echo "Pushed $(ECR_REGISTRY)/navigator-frontend-$(THEME):$(IMAGE_TAG_PRODUCTION)"
+	docker push $(ECR_REGISTRY)/navigator-frontend-$(THEME):$(IMAGE_TAG_PRODUCTION)
 
 deploy-production-theme:
 	@test -n "$(THEME)" || (echo "Usage: make deploy-production-theme THEME=cpr"; exit 1)
 	@test "$(filter $(THEME),$(PRODUCTION_THEMES))" = "$(THEME)" || (echo "Invalid THEME=$(THEME)"; exit 1)
-ifeq ($(REQUIRE_MAIN_BRANCH),1)
-	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set REQUIRE_MAIN_BRANCH=0 to override)."; exit 1)
+ifeq ($(DEPLOY_FROM_MAIN_BRANCH_ONLY),1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set DEPLOY_FROM_MAIN_BRANCH_ONLY=0 to override)."; exit 1)
 endif
 	$(MAKE) deploy-production-ecr-login
 	$(MAKE) deploy-production-build-push THEME=$(THEME)
 
 deploy-production-all:
-ifeq ($(REQUIRE_MAIN_BRANCH),1)
-	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set REQUIRE_MAIN_BRANCH=0 to override)."; exit 1)
+ifeq ($(DEPLOY_FROM_MAIN_BRANCH_ONLY),1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set DEPLOY_FROM_MAIN_BRANCH_ONLY=0 to override)."; exit 1)
 endif
 	$(MAKE) deploy-production-ecr-login
 	@for t in $(PRODUCTION_THEMES); do $(MAKE) deploy-production-build-push THEME=$$t; done

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,51 @@ run: build
 		-p 8080:8080 \
 		--env-file ./.env.example \
 		${TAG}-${THEME}
+
+# --- Production deploy (local machine) ---
+# Mirrors .github/workflows/deploy-production.yml and deploy-all-production.yml:
+# build with THEME + GITHUB_SHA, push navigator-frontend-<theme>:latest.
+#
+# Prerequisites: Docker, AWS CLI, credentials for the production ECR account
+# (same as GitHub's navigator-new-frontend-github-actions role would use).
+#
+# Registry: set DOCKER_REGISTRY (GitHub secret name) or ECR_REGISTRY explicitly,
+# otherwise it defaults to <caller-account>.dkr.ecr.eu-west-1.amazonaws.com.
+#
+# Optional: REQUIRE_MAIN_BRANCH=0 to skip the main-branch guard (CI enforces main).
+AWS_REGION ?= eu-west-1
+IMAGE_TAG_PRODUCTION ?= latest
+GITHUB_SHA ?= $(shell git rev-parse HEAD)
+PRODUCTION_THEMES := cpr cclw mcf ccc
+DEPLOY_FROM_MAIN_BRANCH_ONLY ?= 1
+ECR_REGISTRY ?= $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),$(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.eu-west-1.amazonaws.com)
+
+.PHONY: deploy-production-ecr-login deploy-production-build-push deploy-production-theme deploy-production-all
+
+deploy-production-ecr-login:
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(shell aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com
+
+deploy-production-build-push:
+	@test -n "$(THEME)" || (echo "Set THEME=cpr|cclw|mcf|ccc"; exit 1)
+	@test "$(filter $(THEME),$(PRODUCTION_THEMES))" = "$(THEME)" || (echo "Invalid THEME=$(THEME)"; exit 1)
+	docker build --platform linux/amd64 \
+		--build-arg THEME=$(THEME) \
+		--build-arg GITHUB_SHA=$(GITHUB_SHA) \
+		-t $(ECR_REGISTRY)/navigator-frontend-$(THEME):$(IMAGE_TAG_PRODUCTION) .
+	echo "Pushed $(ECR_REGISTRY)/navigator-frontend-$(THEME):$(IMAGE_TAG_PRODUCTION)"
+
+deploy-production-theme:
+	@test -n "$(THEME)" || (echo "Usage: make deploy-production-theme THEME=cpr"; exit 1)
+	@test "$(filter $(THEME),$(PRODUCTION_THEMES))" = "$(THEME)" || (echo "Invalid THEME=$(THEME)"; exit 1)
+ifeq ($(REQUIRE_MAIN_BRANCH),1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set REQUIRE_MAIN_BRANCH=0 to override)."; exit 1)
+endif
+	$(MAKE) deploy-production-ecr-login
+	$(MAKE) deploy-production-build-push THEME=$(THEME)
+
+deploy-production-all:
+ifeq ($(REQUIRE_MAIN_BRANCH),1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "Production deploy expects branch main (set REQUIRE_MAIN_BRANCH=0 to override)."; exit 1)
+endif
+	$(MAKE) deploy-production-ecr-login
+	@for t in $(PRODUCTION_THEMES); do $(MAKE) deploy-production-build-push THEME=$$t; done


### PR DESCRIPTION
# What's changed

Block late day production deploys via GitHub Actions.

## Why

It's good practice not to deploy too late in the day before people log off in case anything goes wrong. This is us codifying that in the frontend repo.

NOTE: Manual deploys can still be done via Pulumi and via the '[rollback](https://github.com/climatepolicyradar/navigator-frontend/blob/main/.github/workflows/deploy-frontend.yml)' github action, so if we really need to we're not blocked. I'll write up how to do this the runbook I'm writing on how to deploy/rollback.

## AI attribution

Used to help generate the Makefile commands with extra usage help!

## Screenshots

n/a let's test at 5:30pm!