### PR TITLE
Handle 404s (and other responses) from app. api endpoint

### DIFF
--- a/src/bff/methods/getDocumentData.ts
+++ b/src/bff/methods/getDocumentData.ts
@@ -2,7 +2,15 @@ import { ApiClient } from "@/api/http-common";
 import { documentTransformer } from "@/bff/transformers/documentTransformer";
 import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
 import { TDataInDocument, validateDataInDocument } from "@/schemas";
-import { TApiDocumentPublic, TApiItemResponse, TApiSearchResponse, TApiSlugResponse, TDocumentPresentationalResponse, TFeatures } from "@/types";
+import {
+  TApiDocumentPublic,
+  TApiItemResponse,
+  TApiSearchResponse,
+  TApiSlugResponse,
+  TDocumentPresentationalResponse,
+  TFeatures,
+  TTopics,
+} from "@/types";
 import { extractTopicIds } from "@/utils/extractTopicIds";
 import { fetchAndProcessTopics } from "@/utils/fetchAndProcessTopics";
 
@@ -52,14 +60,20 @@ export const getDocumentData = async (slug: string, features: TFeatures): Promis
 
   let vespaDocumentData: TApiSearchResponse;
   try {
-    const { data } = await backendApiClient.get<TApiSearchResponse>(`/document/${document.import_id}`);
-    vespaDocumentData = data;
+    const vespaResponse = await backendApiClient.get<TApiSearchResponse>(`/document/${document.import_id}`);
+    // http-common's get() returns error.response rather than throwing for Axios errors,
+    // so we must check the status explicitly rather than relying on catch for non-2xx responses.
+    if (vespaResponse?.status === 200) {
+      vespaDocumentData = vespaResponse.data;
+    } else if (vespaResponse?.status === 500) {
+      errors.push(new Error("Failed to fetch Vespa document data"));
+    }
   } catch (error) {
-    errors.push(new Error("Failed to fetch data from Vespa", error));
-    return { data: null, errors };
+    errors.push(new Error("Failed to fetch Vespa document data", error));
   }
 
-  const topicsData = await fetchAndProcessTopics(extractTopicIds(vespaDocumentData));
+  let topicsData: TTopics;
+  if (vespaDocumentData) topicsData = await fetchAndProcessTopics(extractTopicIds(vespaDocumentData));
 
   /* Transform API data for presentation */
 

--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -69,12 +69,16 @@ export const getFamilyData = async (slug: string, features: TFeatures): Promise<
   try {
     // max_hits_per_family=100 is set ensure we get all documents for a family
     // this should probably be done in the `backend-api`, but it currently does not work
-    const { data: vespaFamilyDataRaw } = await backendApiClient.get<TApiSearchResponse>(`/families/${family.import_id}?max_hits_per_family=100`);
-    vespaFamilyData = vespaFamilyDataRaw;
-  } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 500) {
-      errors.push(new Error("Failed to fetch Vespa families data", error));
+    const vespaResponse = await backendApiClient.get<TApiSearchResponse>(`/families/${family.import_id}?max_hits_per_family=100`);
+    // http-common's get() returns error.response rather than throwing for Axios errors,
+    // so we must check the status explicitly rather than relying on catch for non-2xx responses.
+    if (vespaResponse?.status === 200) {
+      vespaFamilyData = vespaResponse.data;
+    } else if (vespaResponse?.status === 500) {
+      errors.push(new Error("Failed to fetch Vespa families data"));
     }
+  } catch (error) {
+    errors.push(new Error("Failed to fetch Vespa families data", error));
   }
 
   // Package the family topics


### PR DESCRIPTION
# What's changed
- Add better handling for when the API returns error codes such as 404 when fetching the Vespa data for a document.

## Why
- Causing a dead page in the front-end, incident flagged by CCC.

## AI attribution
- Sense check why the API error is not being handled