### PR TITLE
fix: exclude role from default label list

### DIFF
--- a/src/hooks/useLabelSearch.ts
+++ b/src/hooks/useLabelSearch.ts
@@ -61,6 +61,11 @@ export const loadLabels = async (query: string): Promise<TLabelResult[]> => {
         op: "not_contains",
         value: "result_type",
       },
+      {
+        field: "type",
+        op: "not_contains",
+        value: "role",
+      },
     ],
   };
   const response = await client.get<TLabelsResponse>(


### PR DESCRIPTION
# What's changed

- excludes `role` from default labels search

## Why

It was deemed not useful

related to https://github.com/climatepolicyradar/navigator-backend/pull/1225

Towards https://linear.app/climate-policy-radar/issue/APP-2015/removing-document-role-from-entity-type-list