### PR TITLE
Handle config GET failures resiliently

### DIFF
--- a/src/api/http-common.ts
+++ b/src/api/http-common.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { AxiosInstance, AxiosResponse } from "axios";
 
-import { TApiCorpusTypeDictionary, TApiDataNode, TApiGeography, TApiLanguages } from "@/types";
+import { TApiConfig } from "@/types";
 
 export async function getEnvFromServer() {
   return await axios.get("/api/env").then((res: any) => res);
@@ -72,12 +72,20 @@ class ApiClient {
       });
   }
 
-  getConfig() {
-    return this.get<{
-      geographies: TApiDataNode<TApiGeography>[];
-      corpus_types: TApiCorpusTypeDictionary;
-      languages: TApiLanguages;
-    }>("/config");
+  async getConfig(): Promise<{ config: TApiConfig; error: Error | null }> {
+    try {
+      const config = await this.get<TApiConfig>("/config");
+      return { config: config.data, error: null };
+    } catch (error) {
+      return {
+        config: {
+          geographies: [],
+          corpus_types: {},
+          languages: {},
+        },
+        error: error as Error,
+      };
+    }
   }
 }
 

--- a/src/app/ccc/sitemap.ts
+++ b/src/app/ccc/sitemap.ts
@@ -27,11 +27,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   /* Geographies */
 
   const client = new ApiClient();
-  const {
-    data: { geographies: geographiesData },
-  } = await client.getConfig();
+  const { config, error: configError } = await client.getConfig();
+  if (configError) console.error(configError);
 
-  const geographySlugs = geographiesData.flatMap((item) => extractGeographySlugs(item));
+  const geographySlugs = config.geographies.flatMap((item) => extractGeographySlugs(item));
   const geographiesSiteMap = geographySlugs.map((slug) => ({
     url: `https://www.climatecasechart.com/geographies/${slug}`,
     lastModified: new Date(),

--- a/src/app/cpr/sitemap.ts
+++ b/src/app/cpr/sitemap.ts
@@ -27,11 +27,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   /* Geographies */
 
   const client = new ApiClient();
-  const {
-    data: { geographies: geographiesData },
-  } = await client.getConfig();
+  const { config, error: configError } = await client.getConfig();
+  if (configError) console.error(configError);
 
-  const geographySlugs = geographiesData.flatMap((item) => extractGeographySlugs(item));
+  const geographySlugs = config.geographies.flatMap((item) => extractGeographySlugs(item));
   const geographiesSiteMap = geographySlugs.map((slug) => ({
     url: `https://app.climatepolicyradar.org/geographies/${slug}`,
     lastModified: new Date(),

--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -85,10 +85,11 @@ export const getFamilyData = async (slug: string, features: TFeatures): Promise<
   let familyTopics: IApiFamilyDocumentTopics;
   if (vespaFamilyData) familyTopics = await processFamilyTopics(vespaFamilyData);
 
-  const configRaw = await backendApiClient.getConfig();
-  const response_geo = extractNestedData<TApiGeography>(configRaw.data.geographies);
+  const { config, error: configError } = await backendApiClient.getConfig();
+  if (configError) errors.push(configError);
+  const response_geo = extractNestedData<TApiGeography>(config.geographies);
   const countries = response_geo[1];
-  const corpusTypes: TCorpusTypeDictionary = configRaw.data.corpus_types;
+  const corpusTypes: TCorpusTypeDictionary = config.corpus_types;
 
   // This is because our family.geographies field isn't hydrated but rather a string[]
   const allSubdivisions = await Promise.all<TApiGeographySubdivision[]>(

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -21,17 +21,18 @@ export default function useConfig() {
     queryFn: async () => {
       const { data } = await getEnvFromServer();
       const client = new ApiClient(data?.env?.api_url, data?.env?.app_token);
-      const query_response = await client.getConfig();
-      const geographies = query_response.data.geographies;
+      const { config, error: configError } = await client.getConfig();
+      if (configError) console.error(configError);
+      const geographies = config.geographies;
       const [regions, countries, subdivisions] = extractNestedData<TGeography>(geographies);
-      const corpus_types = query_response.data.corpus_types;
+      const corpus_types = config.corpus_types;
 
       const resp_end: TConfigQueryResponse = {
         geographies,
         regions,
         countries,
         subdivisions,
-        languages: query_response.data.languages,
+        languages: config.languages,
         corpus_types,
       };
       return resp_end;

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -43,8 +43,9 @@ export const getServerSideProps = (async (context) => {
   let countryNameFromConfig;
   try {
     let geographies: TGeography[] = [];
-    const configData = await backendApiClient.getConfig();
-    const response_geo = extractNestedData<TGeography>(configData.data?.geographies || []);
+    const { config, error: configError } = await backendApiClient.getConfig();
+    if (configError) console.error(configError);
+    const response_geo = extractNestedData<TGeography>(config.geographies || []);
     geographies = [...response_geo[1], ...response_geo[2]];
     const geography = getCountryCode(id as string, geographies);
 
@@ -69,7 +70,9 @@ export const getServerSideProps = (async (context) => {
       const parentGeographyV2Data = await apiClient.get<TApiItemResponse<GeographyV2>>(`/geographies/${geographyV2.subconcept_of[0].slug}`);
       parentGeographyV2 = parentGeographyV2Data.data.data;
     }
-  } catch {}
+  } catch {
+    // Do nothing
+  }
 
   if (countryNameFromConfig) {
     geographyV2.name = countryNameFromConfig;
@@ -101,7 +104,6 @@ export const getServerSideProps = (async (context) => {
       },
     })
     .then((response) => response.data)
-    /* eslint-disable-next-line no-console -- errors monitored and alerted on */
     .catch((err) => console.error(`Could not find search results for geography ${geographyV2.slug}:`, err));
 
   if (!vespaSearchResults) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -238,6 +238,12 @@ interface IApiDictionary<T> {
 
 export type TApiCorpusTypeDictionary = IApiDictionary<TApiCorpusType>;
 
+export type TApiConfig = {
+  geographies: TApiDataNode<TApiGeography>[];
+  corpus_types: TApiCorpusTypeDictionary;
+  languages: TApiLanguages;
+};
+
 export type TApiFamilyConcept = {
   id: string;
   ids: string[];


### PR DESCRIPTION
# What's changed

- When requests to `/config` fail, an empty config data structure is returned instead.
- Any error making this request are logged.

## Why

This means that if there is a bug or other site-wide issue with the config endpoint, pages will load with some missing data rather than fail to load entirely.

## AI attribution

None used.