### PR TITLE
APP-2007: [CCC] Display summaries for docs without pdfs

### DIFF
--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -246,7 +246,7 @@ export const getEventTableRows = ({
 
   rowsData.forEach(({ family, event, document }) => {
     // Some document events don't have corresponding documents, so keep those even when documentEventsOnly
-    if (documentEventsOnly && FILING_DATE_EVENT_TYPES.includes(event.event_type)) return;
+    if (documentEventsOnly && event && FILING_DATE_EVENT_TYPES.includes(event.event_type)) return;
 
     const date = event ? new Date(event.date) : null;
 

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -178,22 +178,21 @@ const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, i
 
 const getDocumentCell = (
   isLitigation: boolean,
-  document: TFamilyDocumentPublic,
   isMainDocument: boolean,
   languages: TLanguages,
   hasMatches: boolean,
-  overrideViewMore: boolean,
+  document?: TFamilyDocumentPublic,
   event?: TFamilyEventPublic
 ): ReactNode => {
   return (
     <div className="flex flex-col gap-2">
       {isLitigation && (
         <>
-          <div>{getDocumentLink(document, hasMatches, isMainDocument, isLitigation)}</div>
+          {document && <div>{getDocumentLink(document, hasMatches, isMainDocument, isLitigation)}</div>}
           {event?.metadata.action_taken?.[0] && <div className="italic">{event.metadata.action_taken[0]}</div>}
           {event?.metadata.description?.[0] && (
-            <ViewMore context="event-table-document-cell" maxLines={4} onButtonClick={overrideViewMore ? () => {} : undefined}>
-              {event.metadata.description[0]}
+            <ViewMore context="event-table-document-cell" maxHeight={80}>
+              <div dangerouslySetInnerHTML={{ __html: event.metadata.description[0] }} />
             </ViewMore>
           )}
         </>
@@ -246,7 +245,7 @@ export const getEventTableRows = ({
   const rowsData = isLitigation ? families.map(getEventTableRowsData).flat() : families.map(getFamilyDocuments).flat();
 
   rowsData.forEach(({ family, event, document }) => {
-    if (documentEventsOnly && !document) return;
+    if (documentEventsOnly && FILING_DATE_EVENT_TYPES.includes(event.event_type)) return;
 
     const date = event ? new Date(event.date) : null;
 
@@ -342,18 +341,16 @@ export const getEventTableRows = ({
                 value: `${document.slug}:${matches}`,
               }
             : null,
-        document: document
-          ? {
-              label: getDocumentCell(isLitigation, document, isMainDocument, languages, matches > 0, Boolean(documentRowClick), event),
-              value: isMainDocument,
-            }
-          : null,
+        document: {
+          label: getDocumentCell(isLitigation, isMainDocument, languages, matches > 0, document, event),
+          value: isMainDocument,
+        },
         topics: { label: topicsDisplay, value: "" },
         type: event?.event_type || null,
       },
     };
 
-    if (documentEventsOnly && document && documentRowClick) {
+    if (documentEventsOnly && document) {
       row.onClick = (clickedRow) => documentRowClick(clickedRow.id);
     }
 

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -245,6 +245,7 @@ export const getEventTableRows = ({
   const rowsData = isLitigation ? families.map(getEventTableRowsData).flat() : families.map(getFamilyDocuments).flat();
 
   rowsData.forEach(({ family, event, document }) => {
+    // Some document events don't have corresponding documents, so keep those even when documentEventsOnly
     if (documentEventsOnly && FILING_DATE_EVENT_TYPES.includes(event.event_type)) return;
 
     const date = event ? new Date(event.date) : null;


### PR DESCRIPTION
# What's changed

- Populating an events table with "documents only" keeps family events that look like document events but have no corresponding document.
- Event table document cells will render the action taken and summary without a document to link to.
- "View more" buttons have been reverted to actually expanding the summary rather than passing the click event through to the table row to open the drawer. 
- Table rows without a document still aren't clickable to open the drawer with more info.

## Why

Satisfies [APP-2007](https://linear.app/climate-policy-radar/issue/APP-2007/ccc-display-summaries-for-docs-without-pdfs)

## AI attribution

None

## Screenshots

<img width="991" height="898" alt="Screenshot 2026-05-12 at 14 40 44" src="https://github.com/user-attachments/assets/1182dfdd-892c-4a24-9d7e-f8a9059887e0" />