### PR TITLE
APP-1908: Update app.CPR Terms of Use page to include reference to ICCN

### DIFF
--- a/themes/cpr/pages/terms-of-use.tsx
+++ b/themes/cpr/pages/terms-of-use.tsx
@@ -54,9 +54,8 @@ const TermsOfUse = () => {
               <ul>
                 <li>
                   Climate Policy Radar is pleased to make the content of the CPR Database available as open data under the Creative Commons
-                  Attribution Licence 
-                  <ExternalLink url="https://creativecommons.org/licenses/by/4.0/">(CC-BY)</ExternalLink>. Under this Creative Commons licence you are
-                  free to:
+                  Attribution Licence <ExternalLink url="https://creativecommons.org/licenses/by/4.0/">(CC-BY)</ExternalLink>. Under this Creative
+                  Commons licence you are free to:
                   <ul>
                     <li>
                       <span className="font-medium">Adapt</span> — remix, transform, and build upon the material
@@ -379,6 +378,16 @@ const TermsOfUse = () => {
                     <td>October 2025</td>
                     <td>
                       <ExternalLink url="https://www.unccd.int/terms-of-use">View</ExternalLink>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <ExternalLink url="https://www.climatecouncils.org/">International Climate Councils Network (ICCN)</ExternalLink>
+                    </td>
+                    <td>Climate Council Reports</td>
+                    <td>April 2026</td>
+                    <td>
+                      <ExternalLink url="https://www.climatecouncils.org/tcs/">View</ExternalLink>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
# What's changed

Added a table row for ICCN

## Why

Satisfies [APP-1908](https://linear.app/climate-policy-radar/issue/APP-1908/update-appcpr-terms-of-use-page-to-include-reference-to-iccn)

## AI attribution

None

## Screenshots

<img width="820" height="78" alt="Screenshot 2026-05-12 at 17 04 37" src="https://github.com/user-attachments/assets/478e4719-6696-4de0-8324-f784c47d72a5" />