### PR TITLE
Update parent-child relations in new data model

### DIFF
--- a/src/bff/methods/getCollectionData.ts
+++ b/src/bff/methods/getCollectionData.ts
@@ -48,7 +48,7 @@ export const getCollectionData = async (slug: string, features: TFeatures): Prom
       errors.push(error as Error);
     }
 
-    const collectionFamilies = getChildDocuments(dataInCollection.documents, "Litigation");
+    const collectionFamilies = getChildDocuments(dataInCollection.documents);
 
     try {
       dataInFamilies = await Promise.all<TDataInDocument>(

--- a/src/bff/methods/getRelations.ts
+++ b/src/bff/methods/getRelations.ts
@@ -1,17 +1,14 @@
 import { TDataInDocumentRelation, TDataInDocumentRelationType } from "@/schemas";
-import { TAttributionCategory } from "@/types";
 
 const getRelations = (relations: TDataInDocumentRelation[], relationTypes: TDataInDocumentRelationType[]) =>
   relations.filter((relation) => relationTypes.includes(relation.type));
 
-export const getChildDocuments = (relations: TDataInDocumentRelation[] = [], category: TAttributionCategory) => {
-  const childRelationTypes: TDataInDocumentRelationType[] =
-    category === "Litigation" ? ["has_member", "is_version_of"] : ["has_member", "has_version"];
+export const getChildDocuments = (relations: TDataInDocumentRelation[] = []) => {
+  const childRelationTypes: TDataInDocumentRelationType[] = ["has_member", "has_version"];
   return getRelations(relations, childRelationTypes);
 };
 
-export const getParentDocuments = (relations: TDataInDocumentRelation[] = [], category: TAttributionCategory) => {
-  const parentRelationTypes: TDataInDocumentRelationType[] =
-    category === "Litigation" ? ["has_version", "member_of"] : ["is_version_of", "member_of"];
+export const getParentDocuments = (relations: TDataInDocumentRelation[] = []) => {
+  const parentRelationTypes: TDataInDocumentRelationType[] = ["member_of", "is_version_of"];
   return getRelations(relations, parentRelationTypes);
 };

--- a/src/bff/transformers/documentTransformer.ts
+++ b/src/bff/transformers/documentTransformer.ts
@@ -1,9 +1,7 @@
 import { oldDocumentTransformer } from "@/bff/transformers/oldDocumentTransformer";
 import { transformDocument } from "@/bff/transformers/partials/transformDocument";
 import { transformDocumentFamily } from "@/bff/transformers/partials/transformDocumentFamily";
-import { LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES, TDataInLabel, TDataInLabelType } from "@/schemas";
-import { TAttributionCategory, TDocumentApiNewData, TDocumentApiOldData, TDocumentPresentationalResponse } from "@/types";
-import { groupByType } from "@/utils/data-in/groupByType";
+import { TDocumentApiNewData, TDocumentApiOldData, TDocumentPresentationalResponse } from "@/types";
 
 export const documentTransformer = (
   documentApiOldData: TDocumentApiOldData,
@@ -17,13 +15,11 @@ export const documentTransformer = (
       const document = transformDocument(documentApiNewData, []);
       if (!document) return { data: null, errors };
 
-      const groupedLabels = groupByType<TDataInLabel, TDataInLabelType>(documentApiNewData.labels, LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES);
-
       return {
         data: {
           ...documentApiOldData,
           document,
-          family: transformDocumentFamily(documentApiNewData.documents || [], groupedLabels.category[0].value.value as TAttributionCategory),
+          family: transformDocumentFamily(documentApiNewData.documents || []),
           debug: {
             originalDocument: documentApiOldData.document,
             newApiData: documentApiNewData,

--- a/src/bff/transformers/partials/transformDocumentFamily.ts
+++ b/src/bff/transformers/partials/transformDocumentFamily.ts
@@ -1,9 +1,9 @@
 import { getParentDocuments } from "@/bff/methods/getRelations";
 import { transformFamily } from "@/bff/transformers/partials/transformFamily";
 import { TDataInDocumentRelation } from "@/schemas";
-import { TAttributionCategory, TFamilyPublic } from "@/types";
+import { TFamilyPublic } from "@/types";
 
-export const transformDocumentFamily = (relations: TDataInDocumentRelation[], category: TAttributionCategory): TFamilyPublic => {
-  const families = getParentDocuments(relations, category);
+export const transformDocumentFamily = (relations: TDataInDocumentRelation[]): TFamilyPublic => {
+  const families = getParentDocuments(relations);
   return families.length === 0 ? null : transformFamily(families[0].value);
 };

--- a/src/bff/transformers/partials/transformFamily.ts
+++ b/src/bff/transformers/partials/transformFamily.ts
@@ -19,9 +19,9 @@ export const transformFamily = (document: TDataInDocument): TFamilyPublic => {
 
   return {
     attribution,
-    collections: transformFamilyCollections(document, attribution.category),
+    collections: transformFamilyCollections(document),
     concepts: transformConcepts(groupedLabels.legal_concept),
-    documents: transformFamilyDocuments(documents, documentEvents, attribution.category),
+    documents: transformFamilyDocuments(documents, documentEvents),
     events: familyEvents,
     geographies: groupedLabels.geography.map((label) => label.value.id.split(ID_SEPARATOR)[1]),
     import_id: document.id,

--- a/src/bff/transformers/partials/transformFamilyCollections.ts
+++ b/src/bff/transformers/partials/transformFamilyCollections.ts
@@ -1,6 +1,6 @@
 import { getParentDocuments } from "@/bff/methods/getRelations";
 import { transformCollection } from "@/bff/transformers/partials/transformCollection";
-import { TAttributionCategory, TCollectionPublic, TFamilyApiNewData } from "@/types";
+import { TCollectionPublic, TFamilyApiNewData } from "@/types";
 
-export const transformFamilyCollections = (document: TFamilyApiNewData, category: TAttributionCategory): TCollectionPublic[] =>
-  getParentDocuments(document.documents, category).map(({ value: collection }) => transformCollection(collection));
+export const transformFamilyCollections = (document: TFamilyApiNewData): TCollectionPublic[] =>
+  getParentDocuments(document.documents).map(({ value: collection }) => transformCollection(collection));

--- a/src/bff/transformers/partials/transformFamilyDocuments.ts
+++ b/src/bff/transformers/partials/transformFamilyDocuments.ts
@@ -2,14 +2,10 @@ import { getChildDocuments } from "@/bff/methods/getRelations";
 import { transformDocument } from "@/bff/transformers/partials/transformDocument";
 import { TDocumentEvents } from "@/bff/transformers/partials/transformFamilyEvents";
 import { TDataInDocumentRelation } from "@/schemas";
-import { TAttributionCategory, TFamilyDocumentPublic } from "@/types";
+import { TFamilyDocumentPublic } from "@/types";
 
-export const transformFamilyDocuments = (
-  relations: TDataInDocumentRelation[],
-  documentEvents: TDocumentEvents[],
-  category: TAttributionCategory
-): TFamilyDocumentPublic[] =>
-  getChildDocuments(relations, category)
+export const transformFamilyDocuments = (relations: TDataInDocumentRelation[], documentEvents: TDocumentEvents[]): TFamilyDocumentPublic[] =>
+  getChildDocuments(relations)
     .map(({ value: document }) => {
       const events = documentEvents.find((doc) => doc.importId === document.id);
       return transformDocument(document, events ? events.events : []);

--- a/src/bff/transformers/partials/transformFamilyEvents.ts
+++ b/src/bff/transformers/partials/transformFamilyEvents.ts
@@ -62,7 +62,7 @@ export const transformFamilyEvents = (document: TFamilyApiNewData, category: TAt
     };
   }
 
-  const documentEvents: TDocumentEvents[] = getChildDocuments(document.documents, category)
+  const documentEvents: TDocumentEvents[] = getChildDocuments(document.documents)
     .map(({ value: doc }) => {
       const docAttributes = validateDocumentAttributes(doc.attributes);
       if (docAttributes.status !== "published") return null;


### PR DESCRIPTION
# What's changed

`getChildDocuments` and `getChildDocuments` were updated to reflect the correct Document => Document relationships under the new data model

See https://www.notion.so/climatepolicyradar/Data-Model-in-Frontend-SMD-2fc9109609a48092b670e39589b7e250?source=copy_link#3039109609a480189a7ec654ff195164

## Why

There was some confusion over the labelling of the relationships, made more complicated by the existence of `versions`. 

## AI attribution

None
