### PR TITLE
Feature/app 2069 bug missing litigation documents

### DIFF
--- a/src/bff/transformers/partials/transformDocument.ts
+++ b/src/bff/transformers/partials/transformDocument.ts
@@ -15,7 +15,9 @@ import { groupByType } from "@/utils/data-in/groupByType";
 
 export const transformDocument = (document: TDataInDocument, events: TFamilyEventPublic[]): TFamilyDocumentPublic => {
   const documentAttributes = validateDocumentAttributes(document.attributes);
-  if (["published", "awaiting_source_file"].includes(documentAttributes.status)) return null;
+  const ALLOWED_STATUSES = ["published", "awaiting_source_file"];
+  const displayAllowed = ALLOWED_STATUSES.includes(documentAttributes.status);
+  if (!displayAllowed) return null;
 
   const groupedLabels = groupByType<TDataInLabel, TDataInLabelType>(document.labels, LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES);
   const groupedItems = groupByType<TDataInItem, TDataInItemType>(document.items ?? [], ITEM_TYPES, MANDATORY_ITEM_TYPES);

--- a/src/bff/transformers/partials/transformDocument.ts
+++ b/src/bff/transformers/partials/transformDocument.ts
@@ -15,7 +15,7 @@ import { groupByType } from "@/utils/data-in/groupByType";
 
 export const transformDocument = (document: TDataInDocument, events: TFamilyEventPublic[]): TFamilyDocumentPublic => {
   const documentAttributes = validateDocumentAttributes(document.attributes);
-  if (documentAttributes.status !== "published") return null;
+  if (["published", "pending_document_file"].includes(documentAttributes.status)) return null;
 
   const groupedLabels = groupByType<TDataInLabel, TDataInLabelType>(document.labels, LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES);
   const groupedItems = groupByType<TDataInItem, TDataInItemType>(document.items ?? [], ITEM_TYPES, MANDATORY_ITEM_TYPES);

--- a/src/bff/transformers/partials/transformDocument.ts
+++ b/src/bff/transformers/partials/transformDocument.ts
@@ -15,7 +15,7 @@ import { groupByType } from "@/utils/data-in/groupByType";
 
 export const transformDocument = (document: TDataInDocument, events: TFamilyEventPublic[]): TFamilyDocumentPublic => {
   const documentAttributes = validateDocumentAttributes(document.attributes);
-  if (["published", "pending_document_file"].includes(documentAttributes.status)) return null;
+  if (["published", "awaiting_source_file"].includes(documentAttributes.status)) return null;
 
   const groupedLabels = groupByType<TDataInLabel, TDataInLabelType>(document.labels, LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES);
   const groupedItems = groupByType<TDataInItem, TDataInItemType>(document.items ?? [], ITEM_TYPES, MANDATORY_ITEM_TYPES);

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -149,6 +149,7 @@ const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, i
   if (canPreview)
     return (
       <PageLink
+        aria-label="Document link"
         keepQuery
         href={`/documents/${document.slug}`}
         className={joinTailwindClasses(linkClasses, (isMainDocument || isLitigation) && "font-medium")}

--- a/tests/ccc/collection.spec.ts
+++ b/tests/ccc/collection.spec.ts
@@ -11,7 +11,7 @@ test.describe("Collection page", () => {
     await genericPage.waitUntilLoaded(page, "Leon v. Exxon Mobil Corp");
 
     const tableOfDocuments = page.getByRole("table").first();
-    const documentLink = tableOfDocuments.getByRole("link").first();
+    const documentLink = tableOfDocuments.getByRole("link", { name: "Document link" }).first();
 
     await expect(documentLink).toBeVisible();
 

--- a/tests/generic/testDocuments.ts
+++ b/tests/generic/testDocuments.ts
@@ -28,7 +28,7 @@ export const TEST_DOCUMENTS: TTestDocument[] = [
   },
   {
     titleForTests: "Policy",
-    slug: "national-strategy-and-action-plan-for-biodiversity-2018-2030_a435",
+    slug: "national-policy-on-biological-diversity-2016-2025_a752",
     withSearch: "biodiversity",
     withTopic: "Target",
     withParentTopic: "Target",
@@ -51,8 +51,8 @@ export const TEST_DOCUMENTS: TTestDocument[] = [
     availableOn: ["cpr", "cclw"],
   },
   {
-    titleForTests: "Policy, 60 targets",
-    slug: "french-strategy-for-energy-and-climate_4282",
+    titleForTests: "Policy, 70 targets",
+    slug: "clean-electricity-regulations-sor-2024-263_2747",
     withSearch: "fossil fuel",
     withTopic: "Fossil fuel",
     withParentTopic: "Fossil fuel",

--- a/tests/generic/testFamilies.ts
+++ b/tests/generic/testFamilies.ts
@@ -25,7 +25,7 @@ export const TEST_FAMILIES: TTestFamily[] = [
   },
   {
     titleForTests: "Policy",
-    slug: "tunisian-national-strategy-and-action-plan-for-biodiversity-2018-2030_a1d7",
+    slug: "national-policy-on-biological-diversity_b248",
     withSearch: "biodiversity",
     withTopic: "target",
     availableOn: ["cpr", "cclw"],
@@ -45,8 +45,8 @@ export const TEST_FAMILIES: TTestFamily[] = [
     availableOn: ["cpr", "cclw"],
   },
   {
-    titleForTests: "Policy, 60 targets",
-    slug: "french-strategy-for-energy-and-climate_2d2e",
+    titleForTests: "Policy, 80 targets",
+    slug: "clean-electricity-regulations-sor-2024-263_3e84",
     withSearch: "fossil+fuel",
     withTopic: "fossil+fuel",
     availableOn: ["cpr", "cclw"],


### PR DESCRIPTION
# What's changed

A new document status value has been added in the new `data-in-api` document response, specifically for litigation documents that were transformed from events due to document files not being available.

## Why

FE filters out any documents that do not have status of `published`. Hence a new status to explicitly describe the state of litigation documents that have not been `published` but should still be displayed as there is relevant information for the user.

## AI attribution
None

