### PR TITLE
APP-1853: Change spelling of Sabin Center

### DIFF
--- a/themes/ccc/constants/menuLinks.ts
+++ b/themes/ccc/constants/menuLinks.ts
@@ -38,7 +38,7 @@ export const MENU_LINKS: TMenuLink[] = [
     cy: "contact",
   },
   {
-    text: "Sabin Centre",
+    text: "Sabin Center",
     href: "https://climate.law.columbia.edu/",
     external: true,
     cy: "sabin-centre",

--- a/themes/cclw/components/Partners.tsx
+++ b/themes/cclw/components/Partners.tsx
@@ -4,7 +4,7 @@ const partners = [
   {
     link: "https://climate.law.columbia.edu",
     logo: "sabin-logo-full.jpg",
-    name: "The Sabin Centre for Climate Change Law at Columbia Law School",
+    name: "The Sabin Center for Climate Change Law at Columbia Law School",
   },
   {
     link: "https://www.filefoundation.org",


### PR DESCRIPTION
# What's changed

Tin

## Why

Part of [APP-1853](https://linear.app/climate-policy-radar/issue/APP-1853/add-link-to-sabin-centres-website-from-ccc-app) and due to a misspelling in the ticket requirements.

## AI attribution

## Screenshots
