### PR TITLE
Add node to ignore for dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Manually decide when to update certain packages
     ignore:
-      # Manually decide when to update certain packages
-      - dependency-name: node
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
     groups:
       # Major updates will be raised as separate PRs by default
       minor-and-patch:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # Manually decide when to update certain packages
+      - dependency-name: node
     groups:
       # Major updates will be raised as separate PRs by default
       minor-and-patch:


### PR DESCRIPTION
# What's changed
- Adding an ignore section to the dependabot yaml
- Add Node to this list as we should do this manually

## Why
- To ignore certain packages from upgrading