### PR TITLE
APP-1963 remove aggregations

### DIFF
--- a/src/components/_experiment/advancedFilters/AdvancedFilters.tsx
+++ b/src/components/_experiment/advancedFilters/AdvancedFilters.tsx
@@ -3,7 +3,6 @@ import { Plus, Trash2, X } from "lucide-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
 import { useLabelSearch, TLabelResult } from "@/hooks/useLabelSearch";
-import { partitionByAvailability } from "@/utils/_experiment/labelAggregationAvailability";
 import { labelTypeLabel } from "@/utils/_experiment/labelTypeLabel";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
@@ -119,11 +118,9 @@ interface LabelPickerProps {
   onChange: (label: string) => void;
   placeholder?: string;
   autoFocus?: boolean;
-  /** When set, labels not in the set are shown but disabled. */
-  availableLabelIds?: ReadonlySet<string> | undefined;
 }
 
-function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = false, availableLabelIds }: LabelPickerProps) {
+function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = false }: LabelPickerProps) {
   const [inputValue, setInputValue] = useState(value ? "" : "");
   const [isOpen, setIsOpen] = useState(autoFocus);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -132,10 +129,7 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
 
   const { results, isLoading } = useLabelSearch(inputValue);
 
-  const isResultAvailable = (label: TLabelResult) => !availableLabelIds || availableLabelIds.has(label.id);
-  const { enabled: enabledResults, disabled: disabledResults } = partitionByAvailability(results, availableLabelIds);
-  const orderedResults: TLabelResult[] = [...enabledResults, ...disabledResults];
-  const navIndex = activeIndex >= 0 && activeIndex < orderedResults.length ? activeIndex : -1;
+  const navIndex = activeIndex >= 0 && activeIndex < results.length ? activeIndex : -1;
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -159,8 +153,8 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isOpen || orderedResults.length === 0) return;
-    const len = orderedResults.length;
+    if (!isOpen || results.length === 0) return;
+    const len = results.length;
     switch (e.key) {
       case "ArrowDown": {
         e.preventDefault();
@@ -176,8 +170,8 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
       }
       case "Enter":
         e.preventDefault();
-        if (navIndex >= 0 && orderedResults[navIndex] && isResultAvailable(orderedResults[navIndex])) {
-          handleSelect(orderedResults[navIndex]);
+        if (navIndex >= 0 && results[navIndex]) {
+          handleSelect(results[navIndex]);
         }
         break;
       case "Escape":
@@ -232,38 +226,24 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500" />
         </div>
       )}
-      {isOpen && orderedResults.length > 0 && (
+      {isOpen && results.length > 0 && (
         <ul className="absolute z-50 mt-1 max-h-48 w-75 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
-          {orderedResults.map((label, idx) => {
-            const isAvailable = isResultAvailable(label);
+          {results.map((label, idx) => {
             return (
               <Fragment key={label.id}>
-                {disabledResults.length > 0 && enabledResults.length > 0 && idx === enabledResults.length ? (
-                  <div className="h-6" aria-hidden />
-                ) : null}
                 <li
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
-                    if (!isAvailable) return;
                     handleSelect(label);
                   }}
                   onMouseEnter={() => setActiveIndex(idx)}
                   className={joinTailwindClasses(
-                    "px-3 py-1.5 text-sm",
-                    isAvailable ? "cursor-pointer" : "cursor-not-allowed",
-                    idx === navIndex
-                      ? isAvailable
-                        ? "bg-blue-50 text-blue-800"
-                        : "bg-gray-50 text-neutral-400"
-                      : isAvailable
-                        ? "text-gray-700 hover:bg-gray-50"
-                        : "text-neutral-400"
+                    "px-3 py-1.5 text-sm cursor-pointer",
+                    idx === navIndex ? "bg-blue-50 text-blue-800" : "text-gray-700 hover:bg-gray-50"
                   )}
                 >
                   <span className="font-medium">{label.value}</span>
-                  <span className={joinTailwindClasses("ml-2 text-xs", isAvailable ? "text-gray-400" : "text-neutral-400")}>
-                    - {labelTypeLabel(label.type)}
-                  </span>
+                  <span className={joinTailwindClasses("ml-2 text-xs text-gray-400")}>- {labelTypeLabel(label.type)}</span>
                 </li>
               </Fragment>
             );
@@ -360,7 +340,7 @@ interface RuleRowProps {
   availableLabelIds?: ReadonlySet<string> | undefined;
 }
 
-function RuleRow({ rule, onUpdate, onDelete, isOnly, availableLabelIds }: RuleRowProps) {
+function RuleRow({ rule, onUpdate, onDelete, isOnly }: RuleRowProps) {
   const isLabelRule = rule.field === "labels.value.id" || rule.field === "attributes.status";
   const isPublishedDateRule = rule.field === "attributes.published_date";
 
@@ -397,12 +377,7 @@ function RuleRow({ rule, onUpdate, onDelete, isOnly, availableLabelIds }: RuleRo
         <>
           <OperatorSelect value={rule.op === "not_contains" ? "not_contains" : "contains"} onChange={(op) => onUpdate({ ...rule, op })} />
           <div className="min-w-45 min-h-7.5">
-            <LabelPicker
-              value={rule.value}
-              onChange={(value) => onUpdate({ ...rule, value })}
-              autoFocus={!rule.value}
-              availableLabelIds={availableLabelIds}
-            />
+            <LabelPicker value={rule.value} onChange={(value) => onUpdate({ ...rule, value })} autoFocus={!rule.value} />
           </div>
         </>
       )}
@@ -428,10 +403,9 @@ interface GroupRendererProps {
   onChange: (newRoot: TQueryGroup) => void;
   depth: number;
   onDeleteGroup?: () => void;
-  availableLabelIds?: ReadonlySet<string> | undefined;
 }
 
-function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup, availableLabelIds }: GroupRendererProps) {
+function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup }: GroupRendererProps) {
   const borderColors = ["border-l-blue-200", "border-l-violet-200", "border-l-amber-200", "border-l-emerald-200", "border-l-rose-200"];
   const bgColors = ["bg-blue-50/30", "bg-violet-50/30", "bg-amber-50/30", "bg-emerald-50/30", "bg-rose-50/30"];
   const borderColor = borderColors[depth % borderColors.length];
@@ -505,7 +479,6 @@ function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup, avai
                   onUpdate={(updated) => handleUpdateNode(index, updated)}
                   onDelete={() => handleDeleteNode(index)}
                   isOnly={group.filters.length === 1}
-                  availableLabelIds={availableLabelIds}
                 />
               </div>
             );
@@ -528,7 +501,6 @@ function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup, avai
                 onChange={onChange}
                 depth={depth + 1}
                 onDeleteGroup={() => handleDeleteNode(index)}
-                availableLabelIds={availableLabelIds}
               />
             </div>
           );
@@ -563,10 +535,9 @@ type TProps = {
   setFilters?: (filters: TQueryGroup | null) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  availableLabelIds?: ReadonlySet<string> | undefined;
 };
 
-export function AdvancedFilters({ filters, setFilters, open, onOpenChange, availableLabelIds }: TProps) {
+export function AdvancedFilters({ filters, setFilters, open, onOpenChange }: TProps) {
   return (
     <BaseDialog.Root open={open} onOpenChange={onOpenChange}>
       <BaseDialog.Portal>
@@ -582,7 +553,7 @@ export function AdvancedFilters({ filters, setFilters, open, onOpenChange, avail
 
           {/* Body */}
           <div className="max-h-[60vh] overflow-y-auto p-4">
-            <GroupRenderer group={filters} path={[]} root={filters} onChange={setFilters} depth={0} availableLabelIds={availableLabelIds} />
+            <GroupRenderer group={filters} path={[]} root={filters} onChange={setFilters} depth={0} />
           </div>
 
           {/* Footer */}

--- a/src/components/_experiment/intellisearch/IntelliSearch.tsx
+++ b/src/components/_experiment/intellisearch/IntelliSearch.tsx
@@ -5,7 +5,6 @@ import { useMemo, useRef, useState } from "react";
 
 import { TLabelResult, useLabelSearch } from "@/hooks/useLabelSearch";
 import { buildLabelSuggestionHtml, buildSearchForRowHtml } from "@/utils/_experiment/intellisearchLabelHtml";
-import { partitionByAvailability } from "@/utils/_experiment/labelAggregationAvailability";
 import { labelTypeLabel } from "@/utils/_experiment/labelTypeLabel";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
@@ -27,7 +26,6 @@ function EnterHint() {
 
 export function IntelliSearch({
   query,
-  availableLabelIds,
   className,
   placeholder = "Search",
   debounceDelay = 50,
@@ -63,24 +61,18 @@ export function IntelliSearch({
     inputRef.current?.blur();
   }
 
-  const isSuggestionAvailable = (suggestion: TLabelResult) => !availableLabelIds || availableLabelIds.has(suggestion.id);
-
   const suggestions = useMemo(() => {
     const selectedSet = new Set(selectedLabels.map((s) => s.toLowerCase()));
     const candidateLabels: TLabelResult[] = [];
 
-    // Add label suggestions first. Unavailable ones stay visible but disabled.
     labelsResults.forEach((label) => {
       if (selectedSet.has(label.value.toLowerCase())) return; // Exclude if already selected as filter
       candidateLabels.push(label);
     });
 
-    const { enabled, disabled } = partitionByAvailability(candidateLabels, availableLabelIds);
-    const unified: TLabelResult[] = [...enabled, ...disabled];
-
     // Add search suggestion
     if (searchTerm.trim()) {
-      unified.unshift({
+      candidateLabels.unshift({
         id: "search",
         type: "search",
         value: searchTerm.trim(),
@@ -88,18 +80,12 @@ export function IntelliSearch({
     }
 
     // Apply max suggestions limit if specified
-    return maxSuggestions ? unified.slice(0, maxSuggestions) : unified;
-  }, [availableLabelIds, labelsResults, maxSuggestions, selectedLabels, searchTerm]);
-
-  const labelSuggestions = useMemo(() => suggestions.slice(1), [suggestions]);
-  const firstDisabledIndex = useMemo(
-    () => labelSuggestions.findIndex((s) => availableLabelIds && !availableLabelIds.has(s.id)),
-    [labelSuggestions, availableLabelIds]
-  );
+    return maxSuggestions ? candidateLabels.slice(0, maxSuggestions) : candidateLabels;
+  }, [labelsResults, maxSuggestions, selectedLabels, searchTerm]);
 
   return (
     <div ref={containerRef} className={joinTailwindClasses("relative w-full", className)}>
-      <Autocomplete.Root open items={suggestions} autoHighlight="always" keepHighlight>
+      <Autocomplete.Root open items={suggestions} filter={null} autoHighlight="always" keepHighlight>
         <div className="relative border border-transparent-regular rounded-xl">
           <div className="flex items-center gap-2 ml-6">
             <LucideSearch width={16} height={16} className="text-neutral-500" />
@@ -148,51 +134,38 @@ export function IntelliSearch({
                         {searchTerm.trim().length === 0 ? "Enter a search query to see suggestions" : "No suggestions found for your query"}
                       </Autocomplete.Empty>
                       {/* SUGGESTIONS */}
-                      {/* the first suggestion is always the search term, so we start from index 1 to show label suggestions first */}
                       {suggestions.length > 1 && (
-                        <Autocomplete.Group items={labelSuggestions} className="block pb-2">
+                        <Autocomplete.Group items={suggestions.slice(1, suggestions.length)} className="block pb-2">
                           <Autocomplete.GroupLabel className="sticky top-0 z-1 m-0 mr-2 bg-white px-4 py-2 text-xs text-neutral-500">
                             Suggestions
                           </Autocomplete.GroupLabel>
-                          {labelSuggestions.map((suggestion, idx) => {
-                            const isAvailable = isSuggestionAvailable(suggestion);
-                            return (
-                              <div key={suggestion.id}>
-                                {firstDisabledIndex > 0 && idx === firstDisabledIndex ? <div className="h-6" aria-hidden /> : null}
-                                <Autocomplete.Item
-                                  value={{ value: suggestion.value, type: "label" }}
-                                  onClick={() => {
-                                    if (!isAvailable) return;
-                                    handleSuggestionClick(suggestion.id);
+                          <Autocomplete.Collection>
+                            {(suggestion: TLabelResult) => (
+                              <Autocomplete.Item
+                                key={suggestion.id}
+                                value={{ value: suggestion.value, type: "label" }}
+                                onClick={() => {
+                                  handleSuggestionClick(suggestion.id);
+                                }}
+                                className={joinTailwindClasses(
+                                  suggestionRow,
+                                  "min-h-9 cursor-pointer text-inky-black data-highlighted:bg-neutral-200"
+                                )}
+                              >
+                                <span
+                                  className="truncate"
+                                  dangerouslySetInnerHTML={{
+                                    __html: buildLabelSuggestionHtml(suggestion.value, suggestion.alternative_labels, searchTerm),
                                   }}
-                                  className={joinTailwindClasses(
-                                    suggestionRow,
-                                    "min-h-9",
-                                    isAvailable
-                                      ? "cursor-pointer text-inky-black data-highlighted:bg-neutral-200"
-                                      : "cursor-not-allowed text-neutral-400"
-                                  )}
-                                >
-                                  <span
-                                    className="truncate"
-                                    dangerouslySetInnerHTML={{
-                                      __html: buildLabelSuggestionHtml(suggestion.value, suggestion.alternative_labels, searchTerm),
-                                    }}
-                                  />
-                                  <span className={isAvailable ? "text-gray-500" : "text-neutral-400"}>—</span>
-                                  <span
-                                    className={joinTailwindClasses(
-                                      "shrink-0 whitespace-nowrap",
-                                      isAvailable ? "text-neutral-500" : "text-neutral-400"
-                                    )}
-                                  >
-                                    {labelTypeLabel(suggestion.type)}
-                                  </span>
-                                  {isAvailable ? <EnterHint /> : <div className="ml-auto text-xs text-neutral-400">Unavailable</div>}
-                                </Autocomplete.Item>
-                              </div>
-                            );
-                          })}
+                                />
+                                <span className={"text-gray-500"}>—</span>
+                                <span className={joinTailwindClasses("shrink-0 whitespace-nowrap text-neutral-500")}>
+                                  {labelTypeLabel(suggestion.type)}
+                                </span>
+                                <EnterHint />
+                              </Autocomplete.Item>
+                            )}
+                          </Autocomplete.Collection>
                         </Autocomplete.Group>
                       )}
                     </Autocomplete.List>

--- a/src/components/_experiment/intellisearch/IntelliSearch.types.ts
+++ b/src/components/_experiment/intellisearch/IntelliSearch.types.ts
@@ -39,11 +39,6 @@ export type TSuggestion =
  */
 export interface IntelliSearchProps {
   query: string;
-  /**
-   * When set (search context + aggregations), labels not in this set remain
-   * visible in suggestions but are disabled.
-   */
-  availableLabelIds?: ReadonlySet<string> | undefined;
   /** Optional className for custom styling */
   className?: string;
   /** Placeholder text for the input */

--- a/src/components/_experiment/searchFilters/SearchFilters.tsx
+++ b/src/components/_experiment/searchFilters/SearchFilters.tsx
@@ -2,11 +2,9 @@ import { Popover as BasePopover } from "@base-ui/react/popover";
 import { ChevronDown, ChevronRight, ChevronUp, Circle, ListFilter, SlidersHorizontal } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { IAggregationLabel } from "@/api/search";
 import { Checkbox } from "@/components/checkbox/Checkbox";
 import { TLabelResult } from "@/hooks/useLabelSearch";
 import { hasPublishedDateRule } from "@/utils/_experiment/dateRangeFilters";
-import { getAvailableLabelIdsFromAggregations, partitionByAvailability } from "@/utils/_experiment/labelAggregationAvailability";
 import { labelTypeLabel } from "@/utils/_experiment/labelTypeLabel";
 import { joinTailwindClasses } from "@/utils/tailwind";
 
@@ -38,17 +36,6 @@ type TProps = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   onChange?: (checked: boolean, label: string) => void;
-  /**
-   * Labels aggregations from search results.
-   * When present and there is an active query or filters, only labels whose
-   * id appears here remain enabled - others are disabled/greyed.
-   */
-  aggregations?: IAggregationLabel[] | undefined;
-  /**
-   * Current text query, used so that clearing the search box also resets
-   * any aggregation‑based disabling.
-   */
-  query?: string;
   dateRangeValue?: string | null;
   onDateRangeChange?: (value: string | null) => void;
 };
@@ -62,24 +49,15 @@ export function SearchFilters({
   open,
   onOpenChange,
   onChange,
-  aggregations,
-  query,
   dateRangeValue,
   onDateRangeChange,
 }: TProps) {
   const [openOther, setOpenOther] = useState(false);
-  const availableLabelIds = useMemo(() => getAvailableLabelIdsFromAggregations(aggregations, query, filters), [aggregations, query, filters]);
 
   const sortedForLabelType = useMemo(
     () => availableFilters.filter((filter) => filter.type === activeLabelType).sort((a, b) => a.value.localeCompare(b.value)),
     [availableFilters, activeLabelType]
   );
-
-  // Available (selectable) rows first - disabled aggregations at the bottom.
-  const { enabledFilters, disabledFilters } = useMemo(() => {
-    const { enabled, disabled } = partitionByAvailability(sortedForLabelType, availableLabelIds);
-    return { enabledFilters: enabled, disabledFilters: disabled };
-  }, [sortedForLabelType, availableLabelIds]);
 
   const renderCheckboxRow = (filter: TLabelResult, isAvailable: boolean) => {
     const checked = hasValue(filters, filter.id);
@@ -222,18 +200,8 @@ export function SearchFilters({
                           <div className="border-b border-transparent-regular pb-2">
                             <h4 className="text-sm text-inky-black font-medium">{labelTypeLabel(activeLabelType)}</h4>
                           </div>
-                          {enabledFilters.length === 0 && <span>There are no available options</span>}
-                          <ul className="flex flex-col gap-1 text-inky-black">{enabledFilters.map((f) => renderCheckboxRow(f, true))}</ul>
+                          <ul className="flex flex-col gap-1 text-inky-black">{sortedForLabelType.map((f) => renderCheckboxRow(f, true))}</ul>
                         </div>
-                        {disabledFilters.length > 0 && <div className="h-0 w-full shrink-0 border-b border-transparent-regular" aria-hidden />}
-                        {disabledFilters.length > 0 && (
-                          <div className="flex flex-col gap-2">
-                            <div className="">
-                              <h4 className="text-sm text-inky-black font-medium">Not relevant to applied filters</h4>
-                            </div>
-                            <ul className="flex flex-col gap-1 text-inky-black">{disabledFilters.map((f) => renderCheckboxRow(f, false))}</ul>
-                          </div>
-                        )}
                       </>
                     )}
                   </div>

--- a/src/components/_experiment/searchResults/SearchResults.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.tsx
@@ -1,7 +1,7 @@
 import { LucideCog } from "lucide-react";
 import React, { Fragment, Suspense, use, useEffect, useMemo } from "react";
 
-import { fetchSearchDocuments, SearchDocument, SearchDocumentsResponse, IAggregationLabel, SearchDocumentsSortKey } from "@/api/search";
+import { fetchSearchDocuments, SearchDocument, SearchDocumentsResponse, SearchDocumentsSortKey } from "@/api/search";
 import { DocumentCard } from "@/components/molecules/documentCard/DocumentCard";
 
 import styles from "./SearchResults.module.css";
@@ -15,22 +15,14 @@ const isPrincipal = (result: SearchDocument): boolean => {
 
 function SearchResults({
   promise,
-  onAggregationsChange,
   onTotalResultsChange,
   onResultClicked,
 }: {
   promise: Promise<SearchDocumentsResponse>;
-  onAggregationsChange?: (labels: IAggregationLabel[] | undefined) => void;
   onTotalResultsChange?: (total: number | null) => void;
   onResultClicked?: (document: SearchDocument, event: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
   const data = use(promise);
-  const labels = data.aggregations?.labels;
-
-  // notify parent of the aggregations for the current search results
-  useEffect(() => {
-    onAggregationsChange?.(labels);
-  }, [labels, onAggregationsChange]);
 
   // notify parent of the number of results
   useEffect(() => {
@@ -78,7 +70,6 @@ export function SearchContainer({
   page_token,
   page_size,
   sort,
-  onAggregationsChange,
   onTotalResultsChange,
   onResultClicked,
 }: {
@@ -88,7 +79,6 @@ export function SearchContainer({
   page_token?: string;
   page_size?: string;
   sort?: SearchDocumentsSortKey;
-  onAggregationsChange?: (labels: IAggregationLabel[] | undefined) => void;
   onTotalResultsChange?: (total: number | null) => void;
   onResultClicked?: (document: SearchDocument, event: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
@@ -116,12 +106,7 @@ export function SearchContainer({
             </p>
           }
         >
-          <SearchResults
-            promise={searchPromise}
-            onAggregationsChange={onAggregationsChange}
-            onTotalResultsChange={onTotalResultsChange}
-            onResultClicked={onResultClicked}
-          />
+          <SearchResults promise={searchPromise} onTotalResultsChange={onTotalResultsChange} onResultClicked={onResultClicked} />
         </Suspense>
       ) : (
         <EmptySearch />

--- a/src/pages/_search/index.tsx
+++ b/src/pages/_search/index.tsx
@@ -244,7 +244,7 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
         {/* PAGINATION */}
         {totalNoOfResults !== null && totalNoOfResults > 0 && (query || !isFilterGroupEmpty(filters)) && (
           <div className={columnLayoutCss}>
-            <div className="flex justify-between items-center">
+            <div className="flex flex-wrap justify-between items-center gap-4">
               <Pagination
                 currentPage={parseInt(currentPage)}
                 totalPages={totalNoOfResults !== null ? Math.ceil(totalNoOfResults / parseInt(pageSize)) : 0}

--- a/src/pages/_search/index.tsx
+++ b/src/pages/_search/index.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { Switch } from "@base-ui/react/switch";
 import isEqual from "lodash/isEqual";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { useQueryState, parseAsBoolean, parseAsString, parseAsJson } from "nuqs";
+import { useQueryState, parseAsString, parseAsJson } from "nuqs";
 import { useCallback, useEffect, useMemo, useState, type SetStateAction } from "react";
 
 import { ApiClient } from "@/api/http-common";
-import { IAggregationLabel, normaliseSearchDocumentsSortKey, SearchDocument } from "@/api/search";
+import { normaliseSearchDocumentsSortKey, SearchDocument } from "@/api/search";
 import { createGroup, isFilterGroupEmpty, AdvancedFilters, TQueryGroup } from "@/components/_experiment/advancedFilters/AdvancedFilters";
 import { AppliedLabels } from "@/components/_experiment/appliedLabels/AppliedLabels";
 import { DocumentDrawer } from "@/components/_experiment/documentDrawer/DocumentDrawer";
@@ -23,7 +22,6 @@ import { FeaturesContext } from "@/context/FeaturesContext";
 import { TLabelResult, loadLabels } from "@/hooks/useLabelSearch";
 import { FilterGroupSchema } from "@/schemas";
 import { findPublishedDateRangeValue, removePublishedDateRules, upsertPublishedDateRangeRules } from "@/utils/_experiment/dateRangeFilters";
-import { getAvailableLabelIdsFromAggregations } from "@/utils/_experiment/labelAggregationAvailability";
 import { getFeatureFlags } from "@/utils/featureFlags";
 import { getFeatures } from "@/utils/features";
 import { addLabelRule, extractLabels, removeLabelRule } from "@/utils/filters/advancedFilters";
@@ -46,7 +44,6 @@ type TProps = InferGetServerSidePropsType<typeof getServerSideProps>;
  */
 const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
   const [availableFilters, setAvailableFilters] = useState<TLabelResult[]>([]);
-  const [labelAggregations, setLabelAggregations] = useState<IAggregationLabel[] | undefined>(undefined);
 
   // search query that is typed into the search box
   const [query, setQuery] = useQueryState("q", parseAsString.withDefault(""));
@@ -67,17 +64,10 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
    */
   const setFilters = useCallback(
     (updater: SetStateAction<TQueryGroup>) => {
-      let shouldClearAggregations = false;
       void setFiltersInUrl((prev) => {
         const nextFilters = typeof updater === "function" ? (updater as (p: TQueryGroup) => TQueryGroup)(prev) : updater;
-        if (!isEqual(prev, nextFilters) && isFilterGroupEmpty(nextFilters)) {
-          shouldClearAggregations = true;
-        }
         return nextFilters;
       });
-      if (shouldClearAggregations) {
-        setLabelAggregations(undefined);
-      }
     },
     [setFiltersInUrl]
   );
@@ -104,15 +94,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
     loadLabels("").then(setAvailableFilters);
   }, []);
 
-  /** Avoid re-renders when the search payload repeats the same aggregation list. */
-  const applyAggregationsFromSearch = useCallback((labels: IAggregationLabel[] | undefined) => {
-    setLabelAggregations((prev) => (isEqual(prev, labels) ? prev : labels));
-  }, []);
-
-  const availableLabelIds = useMemo(
-    () => getAvailableLabelIdsFromAggregations(labelAggregations, query, filters),
-    [labelAggregations, query, filters]
-  );
   const selectedPublishedDateRange = useMemo(() => findPublishedDateRangeValue(filters), [filters]);
 
   return (
@@ -158,8 +139,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
                 setCurrentPage("1");
               }
             }}
-            aggregations={labelAggregations}
-            query={query}
             onAdvancedClick={() => {
               setFiltersOpen(false);
               setAdvancedFiltersOpen(true);
@@ -199,7 +178,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
                 setQuery("");
                 setTotalNoOfResults(null);
                 setCurrentPage("1");
-                setLabelAggregations(undefined); // belt & braces
               }}
               onSelectLabel={handleSelectLabel}
               onRemoveLabel={(label) => {
@@ -222,7 +200,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
             page_token={currentPage}
             page_size={pageSize}
             sort={sortKey}
-            onAggregationsChange={applyAggregationsFromSearch}
             onTotalResultsChange={setTotalNoOfResults}
             onResultClicked={(document, event) => {
               // If command or ctrl is clicked open document new tab
@@ -272,7 +249,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
         }}
         open={advancedFiltersOpen}
         onOpenChange={setAdvancedFiltersOpen}
-        availableLabelIds={availableLabelIds}
       />
       {/* DRAWER */}
       <DocumentDrawer document={selectedDocument} open={drawerOpen} onOpenChange={setDrawerOpen} />

--- a/src/pages/_search/index.tsx
+++ b/src/pages/_search/index.tsx
@@ -125,7 +125,6 @@ const ShadowSearch = ({ theme, themeConfig, features }: TProps) => {
           {/* SEARCH INPUT */}
           <IntelliSearch
             query={query}
-            availableLabelIds={availableLabelIds}
             selectedLabels={selectedLabels}
             onSelectSuggestion={(suggestion) => {
               if (suggestion && !selectedLabels.includes(suggestion)) {


### PR DESCRIPTION
# What's changed
- Remove the aggregations from the shadow search page

## Why
1. Decision against blocking user behaviour
2. Gives us a cleaner slate to start layering up the new requirements around filters, rules, typeahead, etc
