### PR TITLE
fix: temporary fix, formatting issue for linebreaks and breakpoints

### DIFF
--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -74,7 +74,7 @@ export const DocumentHead = ({ document, family, features, handleViewOtherDocsCl
             <Heading level={1}>{document.title}</Heading>
             <DocumentMetaRenderer family={family} isMain={isMain} document={document} />
 
-            <div className="text-content" dangerouslySetInnerHTML={{ __html: summary }} />
+            <div className="text-content" dangerouslySetInnerHTML={{ __html: summary.replace(/\r?\n/g, "<br/>") }} />
             {family.summary.length > MAX_FAMILY_SUMMARY_LENGTH_BRIEF && (
               <div className="mt-4">
                 <button onClick={() => setShowFullSummary(!showFullSummary)} className="anchor alt text-sm">

--- a/src/components/pages/familyPage.tsx
+++ b/src/components/pages/familyPage.tsx
@@ -159,7 +159,7 @@ export const FamilyPage = ({
 
         return (
           <TextBlock key="summary" context="summary-block" block="summary" title="Summary">
-            <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary }} />
+            <div className="text-content" dangerouslySetInnerHTML={{ __html: family.summary.replace(/\r?\n/g, "<br/>") }} />
           </TextBlock>
         );
       },


### PR DESCRIPTION
# What's changed

Fix summary formatting so line breaks are rendered correctly in case summaries.

Previously, we ignored literal \r\n / \n sequences in the summary data. This change updates the rendering to preserve real line breaks, ensuring multi-paragraph summaries display as intended.

Impact

Restores paragraph and line-break formatting in summary text.
Improves readability of long case descriptions.
Prevents summaries from appearing as a single block of text.

## Why

This was a request from the sabin team, we would normally handle this on the backend but the platform do not have capacity to deal with the data changes downstream this would cause if fixed in the backend. 


## Screenshots
<img width="1667" height="1029" alt="Screenshot 2026-06-02 at 11 54 04" src="https://github.com/user-attachments/assets/076a14e4-af45-435a-9628-9de951bc5ae7" />
<img width="1720" height="1023" alt="Screenshot 2026-06-02 at 11 54 28" src="https://github.com/user-attachments/assets/31b937ff-ae63-4850-ba8c-7928f38d444b" />
