### PR TITLE
APP-2158: Set design system variables in Tailwind

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -7,7 +7,7 @@ export const Alert = ({ message, icon }: IProps) => {
   return (
     <div className="flex">
       <div className="w-[6px] h-full bg-blue-400 rounded-l-lg"></div>
-      <div className="bg-white p-2 border border-gray-300 border-l-0 rounded-r-lg flex items-center" role="alert">
+      <div className="bg-white p-2 border border-[#d1d5db] border-l-0 rounded-r-lg flex items-center" role="alert">
         <div className="mr-2 text-blue-400">{icon ? icon : null}</div>
         <p className="text-sm">{message}</p>
       </div>

--- a/src/components/CountryLinks.tsx
+++ b/src/components/CountryLinks.tsx
@@ -26,7 +26,7 @@ export const CountryLinks = ({ geographies, countries, showFlag = true }: TCount
           )}
           {!isSystemGeo(geography) && (
             <span className="flex gap-1">
-              <CountryLink countryCode={geography} showFlag={showFlag} className="text-textDark no-underline">
+              <CountryLink countryCode={geography} showFlag={showFlag} className="text-[#202020] no-underline">
                 <span>{countryName}</span>
               </CountryLink>
             </span>

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -61,7 +61,7 @@ export const FaqSection = ({ title, faqs, accordionMaxHeight = "464px", sectionI
           </Fragment>
         ))}
         {showMore && (
-          <LinkWithQuery href="/faq" className="!text-text-brand-darker font-semibold text-sm !no-underline">
+          <LinkWithQuery href="/faq" className="!text-[#002ca3] font-semibold text-sm !no-underline">
             See more FAQs →
           </LinkWithQuery>
         )}

--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -15,7 +15,7 @@ interface IProps {
 
 const COPY_TIMEOUT = 1000;
 
-const PassageMatches = ({ passages, onClick, pageColour = "textDark", position, positionOffset }: IProps) => {
+const PassageMatches = ({ passages, onClick, pageColour = "[#202020]", position, positionOffset }: IProps) => {
   const [hasCopied, setHasCopied] = useState<number | null>(null);
 
   const copyOnClick = (e: React.MouseEvent<HTMLDivElement>, index: number, text: string) => {

--- a/src/components/PassageMatches.tsx
+++ b/src/components/PassageMatches.tsx
@@ -50,7 +50,7 @@ const PassageMatches = ({ passages, onClick, pageColour = "[#202020]", position,
             <li key={item.text_block_id} data-analytics="document-passage-result" id={`passage-${index}`} className="mb-2 hide-in-percy">
               <button
                 type="button"
-                className={`w-full p-4 cursor-pointer border border-gray-300 rounded-md bg-white hover:border-gray-500`}
+                className={`w-full p-4 cursor-pointer border border-[#d1d5db] rounded-md bg-white hover:border-[#6b7280]`}
                 onClick={() => onButtonClick(item)}
                 data-ph-capture-attribute-position-page={hasPosition ? position : undefined}
                 data-ph-capture-attribute-position-total={hasPosition ? positionOffset + position : undefined}

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -22,7 +22,7 @@ const Pill = ({ children, onClick, extraClasses = "" }: IProps) => {
   return (
     <>
       <button
-        className={`text-xs font-medium py-1 px-3 text-inputSelected rounded-full flex gap-1 text-left items-center transition bg-inputSelected/[.07] hover:bg-inputSelected/10 active:bg-inputSelected/20 ${extraClasses}`}
+        className={`text-xs font-medium py-1 px-3 text-[#005eeb] rounded-full flex gap-1 text-left items-center transition bg-[#005eeb]/[.07] hover:bg-[#005eeb]/10 active:bg-[#005eeb]/20 ${extraClasses}`}
         onClick={handleClick}
         data-tooltip-id="tooltip"
         data-tooltip-content="Remove filter"

--- a/src/components/_experiment/advancedFilters/AdvancedFilters.tsx
+++ b/src/components/_experiment/advancedFilters/AdvancedFilters.tsx
@@ -191,7 +191,7 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
           setIsOpen(true);
           setTimeout(() => inputRef.current?.focus(), 0);
         }}
-        className="text-left inline-flex items-center gap-1 rounded bg-gray-100 text-gray-700 px-2 py-2 text-xs font-medium hover:bg-red-100 transition-colors"
+        className="text-left inline-flex items-center gap-1 rounded bg-[#f3f4f6] text-[#374151] px-2 py-2 text-xs font-medium hover:bg-red-100 transition-colors"
       >
         {value}
         <X className="h-3 w-3" />
@@ -215,7 +215,7 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
         placeholder={placeholder}
         autoFocus={autoFocus}
         className={joinTailwindClasses(
-          "w-full rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-800",
+          "w-full rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm text-[#1d2939]",
           "placeholder:text-gray-400",
           "focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-200"
         )}
@@ -223,7 +223,7 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
       />
       {isLoading && (
         <div className="absolute right-2 top-1.5">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500" />
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-[#d1d5db] border-t-blue-500" />
         </div>
       )}
       {isOpen && results.length > 0 && (
@@ -239,7 +239,7 @@ function LabelPicker({ value, onChange, placeholder = "Search...", autoFocus = f
                   onMouseEnter={() => setActiveIndex(idx)}
                   className={joinTailwindClasses(
                     "px-3 py-1.5 text-sm cursor-pointer",
-                    idx === navIndex ? "bg-blue-50 text-blue-800" : "text-gray-700 hover:bg-gray-50"
+                    idx === navIndex ? "bg-blue-50 text-blue-800" : "text-[#374151] hover:bg-[#f9fafb]"
                   )}
                 >
                   <span className="font-medium">{label.value}</span>
@@ -275,7 +275,7 @@ function OperatorSelect({ value, onChange }: { value: "contains" | "not_contains
       value={value}
       onChange={(e) => onChange(e.target.value as "contains" | "not_contains")}
       className={joinTailwindClasses(
-        "rounded border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700",
+        "rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm font-medium text-[#374151]",
         "focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-200",
         "cursor-pointer"
       )}
@@ -301,7 +301,7 @@ function PublishedDateOperatorSelect({
       value={value}
       onChange={(e) => onChange(e.target.value as "eq" | "not_eq" | "lt" | "lte" | "gt" | "gte")}
       className={joinTailwindClasses(
-        "rounded border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700",
+        "rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm font-medium text-[#374151]",
         "focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-200",
         "cursor-pointer"
       )}
@@ -347,9 +347,9 @@ function RuleRow({ rule, onUpdate, onDelete, isOnly }: RuleRowProps) {
   if (isPublishedDateRule) {
     return (
       <div className="flex items-center gap-2 group">
-        <span className="rounded border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700">Published date</span>
+        <span className="rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm font-medium text-[#374151]">Published date</span>
         <PublishedDateOperatorSelect value={rule.op} onChange={(op) => onUpdate({ ...rule, op })} />
-        <span className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 truncate max-w-[360px]">{rule.value}</span>
+        <span className="rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm text-[#374151] truncate max-w-[360px]">{rule.value}</span>
         {!isOnly && (
           <button
             type="button"
@@ -369,7 +369,7 @@ function RuleRow({ rule, onUpdate, onDelete, isOnly }: RuleRowProps) {
       <select
         value={rule.field}
         onChange={() => onUpdate({ field: "labels.value.id", op: "contains", value: "" })}
-        className="rounded border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700"
+        className="rounded border border-[#d1d5db] bg-white px-2 py-1 text-sm font-medium text-[#374151]"
       >
         <option value="labels.value.id">Label</option>
       </select>
@@ -444,7 +444,7 @@ function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup }: Gr
       {/* Group header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500 font-medium">Group</span>
+          <span className="text-xs text-[#6b7280] font-medium">Group</span>
           <ConnectorPill value={group.op} onChange={handleChangeOp} />
         </div>
         {onDeleteGroup && (
@@ -512,7 +512,7 @@ function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup }: Gr
         <button
           type="button"
           onClick={handleAddRule}
-          className="inline-flex items-center gap-1 rounded-md border border-dashed border-gray-300 px-2 py-1 text-xs text-gray-500 hover:border-gray-400 hover:text-gray-700 hover:bg-white transition-colors"
+          className="inline-flex items-center gap-1 rounded-md border border-dashed border-[#d1d5db] px-2 py-1 text-xs text-[#6b7280] hover:border-gray-400 hover:text-[#374151] hover:bg-white transition-colors"
         >
           <Plus className="h-3 w-3" />
           Rule
@@ -520,7 +520,7 @@ function GroupRenderer({ group, path, root, onChange, depth, onDeleteGroup }: Gr
         <button
           type="button"
           onClick={handleAddGroup}
-          className="inline-flex items-center gap-1 rounded-md border border-dashed border-gray-300 px-2 py-1 text-xs text-gray-500 hover:border-gray-400 hover:text-gray-700 hover:bg-white transition-colors"
+          className="inline-flex items-center gap-1 rounded-md border border-dashed border-[#d1d5db] px-2 py-1 text-xs text-[#6b7280] hover:border-gray-400 hover:text-[#374151] hover:bg-white transition-colors"
         >
           <Plus className="h-3 w-3" />
           Group
@@ -544,9 +544,9 @@ export function AdvancedFilters({ filters, setFilters, open, onOpenChange }: TPr
         <BaseDialog.Backdrop className="fixed inset-0 min-h-dvh bg-inky-black opacity-20 transition-all duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 dark:opacity-70 supports-[-webkit-touch-callout:none]:absolute" />
         <BaseDialog.Popup className="w-3/4 max-w-4xl fixed top-1/5 left-1/2 -translate-x-1/2 rounded-xl border border-transparent-regular bg-white shadow-2xl focus-visible:outline-none  transition-all duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 ">
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <div className="flex items-center justify-between border-b border-[#f3f4f6] px-4 py-3">
             <h3 className="text-sm font-semibold text-gray-900">Advanced Filters</h3>
-            <BaseDialog.Close className="rounded p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors" aria-label="Close">
+            <BaseDialog.Close className="rounded p-1 text-gray-400 hover:text-gray-600 hover:bg-[#f3f4f6] transition-colors" aria-label="Close">
               <X className="h-4 w-4" />
             </BaseDialog.Close>
           </div>
@@ -557,8 +557,8 @@ export function AdvancedFilters({ filters, setFilters, open, onOpenChange }: TPr
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-between border-t border-gray-100 px-4 py-3">
-            <button type="button" onClick={() => setFilters(createGroup())} className="text-xs text-gray-500 hover:text-gray-700 transition-colors">
+          <div className="flex items-center justify-between border-t border-[#f3f4f6] px-4 py-3">
+            <button type="button" onClick={() => setFilters(createGroup())} className="text-xs text-[#6b7280] hover:text-[#374151] transition-colors">
               Reset all
             </button>
             <div className="text-[10px] text-gray-400">

--- a/src/components/_experiment/appliedLabels/AppliedLabels.tsx
+++ b/src/components/_experiment/appliedLabels/AppliedLabels.tsx
@@ -21,11 +21,11 @@ function isFilterComplex(filters: TQueryGroup | null | undefined): boolean {
 
 function AppliedLabel({ label, type, onSelect, onRemove }: { label: string; type?: string; onSelect: () => void; onRemove: () => void }) {
   return (
-    <span className="bg-white rounded-lg inline-flex items-center border border-gray-300 hover:bg-gray-50">
-      <button className="py-1 px-2 border-r border-gray-300" onClick={onSelect}>
+    <span className="bg-white rounded-lg inline-flex items-center border border-[#d1d5db] hover:bg-[#f9fafb]">
+      <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
         <span>{type.slice(0, 1).toUpperCase() + type.replace("_", " ").slice(1)}</span>
       </button>
-      <button className="py-1 px-2 border-r border-gray-300" onClick={onSelect}>
+      <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
         <span>{label.split("::")?.[1]}</span>
       </button>
       <button className="px-2 rounded-r-lg h-7 hover:bg-gray-200" onClick={onRemove}>
@@ -38,11 +38,11 @@ function AppliedLabel({ label, type, onSelect, onRemove }: { label: string; type
 function AppliedDateRange({ value, onSelect, onRemove }: { value: string; onSelect: () => void; onRemove: () => void }) {
   const [startYear, endYear] = value.split(":");
   return (
-    <span className="bg-white rounded-lg inline-flex items-center border border-gray-300 hover:bg-gray-50">
-      <button className="py-1 px-2 border-r border-gray-300" onClick={onSelect}>
+    <span className="bg-white rounded-lg inline-flex items-center border border-[#d1d5db] hover:bg-[#f9fafb]">
+      <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
         <span>Date</span>
       </button>
-      <button className="py-1 px-2 border-r border-gray-300" onClick={onSelect}>
+      <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
         <span>
           {startYear} - {endYear}
         </span>
@@ -76,16 +76,16 @@ export function AppliedLabels({
   onRemoveDateRange?: () => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-1 text-sm text-gray-700 rounded-lg bg-gray-100 p-2">
+    <div className="flex flex-wrap gap-1 text-sm text-[#374151] rounded-lg bg-[#f3f4f6] p-2">
       {dateRangeValue && !isFilterComplex(filters) && (
         <AppliedDateRange value={dateRangeValue} onSelect={() => onSelectLabel?.("", "published_date")} onRemove={() => onRemoveDateRange?.()} />
       )}
       {isFilterComplex(filters) ? (
         <button
-          className="bg-white py-1 px-2 rounded-lg inline-flex gap-2 items-center border border-gray-300 hover:bg-gray-50"
+          className="bg-white py-1 px-2 rounded-lg inline-flex gap-2 items-center border border-[#d1d5db] hover:bg-[#f9fafb]"
           onClick={() => onAdvancedClick?.()}
         >
-          <SlidersHorizontal className="text-neutral-400 h-4 w-4" />
+          <SlidersHorizontal className="text-[#a3a3a3] h-4 w-4" />
           Advanced filters applied
         </button>
       ) : (

--- a/src/components/_experiment/documentDrawer/DocumentDrawer.module.css
+++ b/src/components/_experiment/documentDrawer/DocumentDrawer.module.css
@@ -51,7 +51,7 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    outline: 1px solid var(--color-gray-300);
+    outline: 1px solid #d1d5db;
   }
 
   &::after {

--- a/src/components/_experiment/intellisearch/IntelliSearch.tsx
+++ b/src/components/_experiment/intellisearch/IntelliSearch.tsx
@@ -109,7 +109,7 @@ export function IntelliSearch({
           </div>
           {isLoadingLabels && (
             <div className="absolute right-4 top-4">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500" />
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-[#d1d5db] border-t-blue-500" />
             </div>
           )}
         </div>
@@ -158,7 +158,7 @@ export function IntelliSearch({
                                     __html: buildLabelSuggestionHtml(suggestion.value, suggestion.alternative_labels, searchTerm),
                                   }}
                                 />
-                                <span className={"text-gray-500"}>—</span>
+                                <span className={"text-[#6b7280]"}>—</span>
                                 <span className={joinTailwindClasses("shrink-0 whitespace-nowrap text-neutral-500")}>
                                   {labelTypeLabel(suggestion.type)}
                                 </span>
@@ -172,7 +172,7 @@ export function IntelliSearch({
                   </ScrollArea.Content>
                 </ScrollArea.Viewport>
                 <ScrollArea.Scrollbar className="-mr-1 flex w-6 justify-center py-2">
-                  <ScrollArea.Thumb className="flex w-full justify-center before:block before:h-full before:w-1 before:rounded-sm before:bg-neutral-400 before:content-['']" />
+                  <ScrollArea.Thumb className="flex w-full justify-center before:block before:h-full before:w-1 before:rounded-sm before:bg-[#a3a3a3] before:content-['']" />
                 </ScrollArea.Scrollbar>
               </ScrollArea.Root>
 

--- a/src/components/_experiment/pagination/Pagination.tsx
+++ b/src/components/_experiment/pagination/Pagination.tsx
@@ -11,7 +11,7 @@ type TProps = {
 
 const sharedPaginationButtonClasses = "h-8 min-w-8 px-1 border border-transparent-regular rounded transition hover:bg-inky-black hover:text-white";
 const prevNextButtonClasses =
-  "px-2.5 flex items-center disabled:cursor-not-allowed! disabled:text-neutral-400 disabled:hover:bg-transparent disabled:hover:text-neutral-400";
+  "px-2.5 flex items-center disabled:cursor-not-allowed! disabled:text-[#a3a3a3] disabled:hover:bg-transparent disabled:hover:text-[#a3a3a3]";
 
 export function Pagination({ currentPage, totalPages, onPageChange }: TProps) {
   const handlePageChange = (page: number) => {

--- a/src/components/_experiment/searchFilters/PublishedDateFilterSection.tsx
+++ b/src/components/_experiment/searchFilters/PublishedDateFilterSection.tsx
@@ -66,7 +66,7 @@ export function PublishedDateFilterSection({ value, onChange }: TProps) {
             type="radio"
             checked={selectedPreset === preset.value}
             onChange={() => applyPresetDateRange(preset.value)}
-            className="h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-gray-300 bg-white checked:border-4 checked:border-inky-black"
+            className="h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-[#d1d5db] bg-white checked:border-4 checked:border-inky-black"
           />
           <span>{preset.label}</span>
         </label>
@@ -84,7 +84,7 @@ export function PublishedDateFilterSection({ value, onChange }: TProps) {
             value={startYearInput}
             onChange={(event) => setStartYearInput(event.target.value)}
             onBlur={applyCustomDateRange}
-            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-inky-black"
+            className="rounded border border-[#d1d5db] bg-white px-2 py-1.5 text-sm text-inky-black"
           />
         </div>
         <div className="flex flex-col gap-1">
@@ -96,7 +96,7 @@ export function PublishedDateFilterSection({ value, onChange }: TProps) {
             value={endYearInput}
             onChange={(event) => setEndYearInput(event.target.value)}
             onBlur={applyCustomDateRange}
-            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-inky-black"
+            className="rounded border border-[#d1d5db] bg-white px-2 py-1.5 text-sm text-inky-black"
           />
         </div>
       </div>

--- a/src/components/_experiment/searchFilters/SearchFilters.tsx
+++ b/src/components/_experiment/searchFilters/SearchFilters.tsx
@@ -80,11 +80,11 @@ export function SearchFilters({
     <BasePopover.Root open={open} onOpenChange={(value) => onOpenChange?.(value)}>
       <BasePopover.Trigger
         className={joinTailwindClasses(
-          "inline-flex items-center gap-2 rounded-full border border-transparent-regular bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-neutral-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-500",
+          "inline-flex items-center gap-2 rounded-full border border-transparent-regular bg-white px-3 py-2 text-sm font-medium text-[#374151] shadow-sm hover:bg-neutral-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-500",
           open ? "bg-inky-black! text-white!" : ""
         )}
       >
-        <ListFilter className="text-neutral-400 h-4 w-4" />
+        <ListFilter className="text-[#a3a3a3] h-4 w-4" />
         Filters
       </BasePopover.Trigger>
 
@@ -92,7 +92,7 @@ export function SearchFilters({
         <BasePopover.Positioner positionMethod="fixed" sideOffset={8} side="bottom" align="start" className="z-50">
           <BasePopover.Popup className="w-160 rounded-xl border border-transparent-regular bg-white shadow-xl focus-visible:outline-none">
             <div className="">
-              {!availableFilters.length && <p className="text-sm text-gray-500 p-2">No filter options found, please refresh the page.</p>}
+              {!availableFilters.length && <p className="text-sm text-[#6b7280] p-2">No filter options found, please refresh the page.</p>}
               {availableFilters.length > 0 && (
                 <div className="flex gap-2">
                   <div className="basis-60 shrink-0 p-2 border-r border-transparent-regular flex flex-col gap-2">

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -66,7 +66,7 @@ export const Accordion = ({
               className={`relative max-h-[${fixedHeight}] ${
                 overflowOverride
                   ? "overflow-visible"
-                  : "overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500"
+                  : "overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-[#6b7280]"
               } `}
             >
               <>

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -47,7 +47,7 @@ export const Accordion = ({
           <Heading>{title}</Heading>
           {headContent}
         </div>
-        <span className="text-textDark opacity-40 group-hover:opacity-100">{isOpen ? <ChevronUp /> : <ChevronDown />}</span>
+        <span className="text-[#202020] opacity-40 group-hover:opacity-100">{isOpen ? <ChevronUp /> : <ChevronDown />}</span>
       </button>
       <AnimatePresence initial={false}>
         {isOpen && (

--- a/src/components/accordion/Heading.tsx
+++ b/src/components/accordion/Heading.tsx
@@ -3,5 +3,5 @@ interface IProps {
 }
 
 export const Heading = ({ children }: IProps) => {
-  return <h3 className="text-[15px] font-medium text-textDark text-left">{children}</h3>;
+  return <h3 className="text-[15px] font-medium text-[#202020] text-left">{children}</h3>;
 };

--- a/src/components/atoms/SlideOut/SlideOut.tsx
+++ b/src/components/atoms/SlideOut/SlideOut.tsx
@@ -42,7 +42,7 @@ export const SlideOut = ({ children, showCloseButton = true }: IProps) => {
             transition: { duration: 0.25, ease: [0.04, 0.62, 0.23, 0.98] },
           }}
           exit={{ opacity: 0, transition: { duration: 0 } }}
-          className="absolute z-20 top-0 left-0 h-full bg-white p-5 pb-45 w-screen md:px-9 md:z-0 md:w-auto md:min-w-115 md:left-full md:pb-0 md:border-r md:border-gray-300"
+          className="absolute z-20 top-0 left-0 h-full bg-white p-5 pb-45 w-screen md:px-9 md:z-0 md:w-auto md:min-w-115 md:left-full md:pb-0 md:border-r md:border-[#d1d5db]"
         >
           {showCloseButton && (
             <button className="absolute z-20 top-5 right-5" onClick={() => setCurrentSlideOut("")}>

--- a/src/components/atoms/badge/Badge.tsx
+++ b/src/components/atoms/badge/Badge.tsx
@@ -10,7 +10,7 @@ interface IBadgeClassArgs {
 type TProps = IBadgeClassArgs & ComponentProps<"div">;
 
 const getBadgeClasses = ({ className, size = "medium" }: TProps) => {
-  const baseClasses = "inline-block bg-surface-brand rounded-sm text-text-light leading-none whitespace-nowrap align-baseline select-none";
+  const baseClasses = "inline-block bg-[#005eeb] rounded-sm text-text-light leading-none whitespace-nowrap align-baseline select-none";
   const textClasses = size === "medium" ? "text-[13px] leading-1 font-medium" : "text-xs leading-normal font-semibold";
   const shapeClasses = size === "medium" ? "px-1.5 py-[5px]" : "px-1 py-0.5";
 

--- a/src/components/atoms/badge/Badge.tsx
+++ b/src/components/atoms/badge/Badge.tsx
@@ -10,7 +10,7 @@ interface IBadgeClassArgs {
 type TProps = IBadgeClassArgs & ComponentProps<"div">;
 
 const getBadgeClasses = ({ className, size = "medium" }: TProps) => {
-  const baseClasses = "inline-block bg-[#005eeb] rounded-sm text-text-light leading-none whitespace-nowrap align-baseline select-none";
+  const baseClasses = "inline-block bg-[#005eeb] rounded-sm text-text-inverse leading-none whitespace-nowrap align-baseline select-none";
   const textClasses = size === "medium" ? "text-[13px] leading-1 font-medium" : "text-xs leading-normal font-semibold";
   const shapeClasses = size === "medium" ? "px-1.5 py-[5px]" : "px-1 py-0.5";
 

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -31,13 +31,13 @@ export const getButtonClasses = ({
 
   /* Colour */
 
-  let bgColor = color === "brand" ? "bg-[#005eeb] hocus:bg-[#0049b8]" : "bg-surface-mono hocus:bg-surface-mono-dark";
-  let textColor = "text-text-light";
+  let bgColor = color === "brand" ? "bg-[#005eeb] hocus:bg-[#0049b8]" : "bg-bg-inverse";
+  let textColor = "text-text-inverse";
 
   if (variant)
     switch (variant) {
       case "faded":
-        bgColor = color === "brand" ? "bg-[#005eeb]/16 hocus:bg-[#005eeb]/32" : "bg-surface-mono/8 hocus:bg-surface-mono/16";
+        bgColor = color === "brand" ? "bg-[#005eeb]/16 hocus:bg-[#005eeb]/32" : "bg-bg-inverse/8 hocus:bg-bg-inverse/16";
         textColor = color === "brand" ? "text-[#005eeb]" : "text-text-primary";
         break;
       case "outlined":

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -42,13 +42,13 @@ export const getButtonClasses = ({
         break;
       case "outlined":
       case "ghost":
-        bgColor = "bg-transparent hover:bg-surface-ui";
+        bgColor = "bg-transparent hover:bg-[#f5f5f5]";
         textColor = color === "brand" ? "text-[#005eeb]" : "text-text-primary";
         break;
     }
 
   if (disabled) {
-    bgColor = "bg-surface-ui";
+    bgColor = "bg-[#f5f5f5]";
     textColor = "text-text-tertiary";
   }
 

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -55,7 +55,7 @@ export const getButtonClasses = ({
   /* Shape */
 
   const border = variant === "outlined" ? "border border-border-light" : "";
-  const outlineColor = color === "brand" ? "outline-[#0049b8]" : "outline-surface-mono-dark";
+  const outlineColor = color === "brand" ? "outline-[#0049b8]" : "outline-inky-black";
   const roundness = rounded ? "rounded-full" : "rounded-md";
 
   /* Size */

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -31,19 +31,19 @@ export const getButtonClasses = ({
 
   /* Colour */
 
-  let bgColor = color === "brand" ? "bg-surface-brand hocus:bg-surface-brand-dark" : "bg-surface-mono hocus:bg-surface-mono-dark";
+  let bgColor = color === "brand" ? "bg-[#005eeb] hocus:bg-[#0049b8]" : "bg-surface-mono hocus:bg-surface-mono-dark";
   let textColor = "text-text-light";
 
   if (variant)
     switch (variant) {
       case "faded":
-        bgColor = color === "brand" ? "bg-surface-brand/16 hocus:bg-surface-brand/32" : "bg-surface-mono/8 hocus:bg-surface-mono/16";
-        textColor = color === "brand" ? "text-cpr-blue" : "text-text-primary";
+        bgColor = color === "brand" ? "bg-[#005eeb]/16 hocus:bg-[#005eeb]/32" : "bg-surface-mono/8 hocus:bg-surface-mono/16";
+        textColor = color === "brand" ? "text-[#005eeb]" : "text-text-primary";
         break;
       case "outlined":
       case "ghost":
         bgColor = "bg-transparent hover:bg-surface-ui";
-        textColor = color === "brand" ? "text-cpr-blue" : "text-text-primary";
+        textColor = color === "brand" ? "text-[#005eeb]" : "text-text-primary";
         break;
     }
 
@@ -55,7 +55,7 @@ export const getButtonClasses = ({
   /* Shape */
 
   const border = variant === "outlined" ? "border border-border-light" : "";
-  const outlineColor = color === "brand" ? "outline-surface-brand-dark" : "outline-surface-mono-dark";
+  const outlineColor = color === "brand" ? "outline-[#0049b8]" : "outline-surface-mono-dark";
   const roundness = rounded ? "rounded-full" : "rounded-md";
 
   /* Size */

--- a/src/components/atoms/card/Card.stories.tsx
+++ b/src/components/atoms/card/Card.stories.tsx
@@ -84,7 +84,7 @@ export const CookieConsent: TStory = {
         </div>
       </>
     ),
-    className: "bg-surface-ui select-none",
+    className: "bg-[#f5f5f5] select-none",
     color: "mono",
     variant: "outlined",
   },

--- a/src/components/atoms/card/Card.tsx
+++ b/src/components/atoms/card/Card.tsx
@@ -17,7 +17,7 @@ const getCardClasses = ({ className = "", color = "brand", variant = "solid" }: 
   /* Colour */
 
   const border = isSolid ? "" : "border border-border-light";
-  const textColor = isSolid ? "text-text-light" : "text-text-primary";
+  const textColor = isSolid ? "text-text-inverse" : "text-text-primary";
   let bgColor = "bg-surface-light";
 
   if (isSolid) {

--- a/src/components/atoms/card/Card.tsx
+++ b/src/components/atoms/card/Card.tsx
@@ -18,10 +18,10 @@ const getCardClasses = ({ className = "", color = "brand", variant = "solid" }: 
 
   const border = isSolid ? "" : "border border-border-light";
   const textColor = isSolid ? "text-text-inverse" : "text-text-primary";
-  let bgColor = "bg-surface-light";
+  let bgColor = "bg-bg-primary";
 
   if (isSolid) {
-    bgColor = color === "brand" ? "bg-[#005eeb]" : "bg-surface-mono";
+    bgColor = color === "brand" ? "bg-[#005eeb]" : "bg-bg-inverse";
   }
 
   return joinTailwindClasses(baseClasses, bgColor, border, textColor, className);

--- a/src/components/atoms/card/Card.tsx
+++ b/src/components/atoms/card/Card.tsx
@@ -21,7 +21,7 @@ const getCardClasses = ({ className = "", color = "brand", variant = "solid" }: 
   let bgColor = "bg-surface-light";
 
   if (isSolid) {
-    bgColor = color === "brand" ? "bg-surface-brand" : "bg-surface-mono";
+    bgColor = color === "brand" ? "bg-[#005eeb]" : "bg-surface-mono";
   }
 
   return joinTailwindClasses(baseClasses, bgColor, border, textColor, className);

--- a/src/components/atoms/checkbox/Checkbox.tsx
+++ b/src/components/atoms/checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ export const Checkbox = ({ className, label, ...rootProps }: IProps) => {
     className
   );
   const rootClasses = joinTailwindClasses(
-    "box-border flex shrink-0 w-5 h-5 items-center justify-center  border border-border-checkbox rounded-xs outline-inky-blue focus-visible:outline-2 outline-offset-2",
+    "box-border flex shrink-0 w-5 h-5 items-center justify-center  border border-border-input rounded-xs outline-inky-blue focus-visible:outline-2 outline-offset-2",
     rootProps.disabled
       ? "data-checked:bg-text-tertiary data-indeterminate:bg-text-tertiary"
       : "data-checked:bg-inky-blue data-indeterminate:bg-inky-blue"

--- a/src/components/atoms/debug/Debug.tsx
+++ b/src/components/atoms/debug/Debug.tsx
@@ -6,7 +6,7 @@ interface IProps {
 export const Debug = ({ data, title }: IProps) => (
   <div className="grid grid-cols-subgrid gap-y-3 col-start-1 -col-end-1">
     <p className="col-start-1 -col-end-1">{title}:</p>
-    <pre className="col-start-1 -col-end-1 max-h-[700px] bg-surface-ui text-sm text-text-tertiary overflow-scroll">
+    <pre className="col-start-1 -col-end-1 max-h-[700px] bg-[#f5f5f5] text-sm text-text-tertiary overflow-scroll">
       {JSON.stringify(data, null, 2)}
     </pre>
   </div>

--- a/src/components/atoms/drawer/Drawer.stories.tsx
+++ b/src/components/atoms/drawer/Drawer.stories.tsx
@@ -21,7 +21,7 @@ const trigger = <Button>Open drawer</Button>;
 
 export const RightSide: TStory = {
   args: {
-    children: <h1 className="text-2xl text-gray-950 font-heavy leading-tight">This is a drawer</h1>,
+    children: <h1 className="text-2xl text-[#030712] font-heavy leading-tight">This is a drawer</h1>,
     trigger,
   },
 };

--- a/src/components/atoms/drawer/Drawer.tsx
+++ b/src/components/atoms/drawer/Drawer.tsx
@@ -22,7 +22,7 @@ export const Drawer = ({ children, direction = "right", title, trigger, ...rootP
       <VaulDrawer.Portal>
         <VaulDrawer.Overlay className="fixed inset-0 bg-black/40" />
         <VaulDrawer.Content className={contentClasses} role="dialog">
-          <VaulDrawer.Title className="text-2xl text-gray-950 font-heavy leading-7 mb-6">{title}</VaulDrawer.Title>
+          <VaulDrawer.Title className="text-2xl text-[#030712] font-heavy leading-7 mb-6">{title}</VaulDrawer.Title>
           <VaulDrawer.Description asChild>
             <div>{children}</div>
           </VaulDrawer.Description>

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -53,13 +53,13 @@ export const Input = ({
     return {
       button: joinTailwindClasses("shrink-0 text-icon-standard", iconPadding),
       container: joinTailwindClasses(
-        "w-full px-2 flex flex-row justify-around items-center bg-surface-ui rounded-md focus-within:outline",
+        "w-full px-2 flex flex-row justify-around items-center bg-[#f5f5f5] rounded-md focus-within:outline",
         outlineColor,
         containerClasses
       ),
       icon: joinTailwindClasses("shrink-0", iconPadding),
       input: joinTailwindClasses(
-        "w-full block bg-transparent border-none focus:shadow-[none] leading-none font-medium text-text-primary placeholder:text-text-tertiary caret-text-brand",
+        "w-full block bg-transparent border-none focus:shadow-[none] leading-none font-medium text-text-primary placeholder:text-text-tertiary caret-text-[#0038a9]",
         inputPadding,
         textSize,
         inputClasses

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -31,7 +31,7 @@ export const Input = ({
   const classes = useMemo(() => {
     /* Colour */
 
-    const outlineColor = color === "brand" ? "focus-within:outline-[#005eeb]" : "focus-within:outline-border-mono";
+    const outlineColor = color === "brand" ? "focus-within:outline-[#005eeb]" : "focus-within:outline-border-normal";
 
     /* Size */
 
@@ -51,7 +51,7 @@ export const Input = ({
     }
 
     return {
-      button: joinTailwindClasses("shrink-0 text-icon-standard", iconPadding),
+      button: joinTailwindClasses("shrink-0 text-elem-icon", iconPadding),
       container: joinTailwindClasses(
         "w-full px-2 flex flex-row justify-around items-center bg-[#f5f5f5] rounded-md focus-within:outline",
         outlineColor,

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -31,7 +31,7 @@ export const Input = ({
   const classes = useMemo(() => {
     /* Colour */
 
-    const outlineColor = color === "brand" ? "focus-within:outline-border-brand" : "focus-within:outline-border-mono";
+    const outlineColor = color === "brand" ? "focus-within:outline-[#005eeb]" : "focus-within:outline-border-mono";
 
     /* Size */
 

--- a/src/components/atoms/labelButton/LabelButton.tsx
+++ b/src/components/atoms/labelButton/LabelButton.tsx
@@ -8,7 +8,7 @@ interface IProps extends ComponentProps<"button"> {
 
 export const LabelButton = ({ children, className = "", role = "button", ...buttonProps }: IProps) => {
   const allClasses = joinTailwindClasses(
-    "inline-block px-2 py-1 bg-white hover:bg-brand border border-gray-300 hover:border-brand rounded-xl text-sm text-brand hover:text-white text-left font-medium leading-4 transition duration-100",
+    "inline-block px-2 py-1 bg-white hover:bg-[#0038a9] border border-[#d1d5db] hover:border-[#0038a9] rounded-xl text-sm text-[#0038a9] hover:text-white text-left font-medium leading-4 transition duration-100",
     className
   );
 

--- a/src/components/atoms/menu/MenuItem.tsx
+++ b/src/components/atoms/menu/MenuItem.tsx
@@ -12,7 +12,7 @@ export const MenuItem = ({ className, color = "mono", disabled, heading = false,
   const allClasses = joinTailwindClasses(
     "px-2.5 py-2 rounded-md hover:outline-none focus-visible:outline-none leading-none select-none",
     disabled ? "text-text-tertiary" : "hover:bg-[#f5f5f5] focus-visible:bg-[#f5f5f5] cursor-pointer",
-    !disabled && color === "brand" ? "text-text-[#0038a9]" : "text-text-primary",
+    !disabled && color === "brand" ? "text-[#0038a9]" : "text-text-primary",
     heading ? "text-xs font-semibold" : "text-sm",
     className
   );

--- a/src/components/atoms/menu/MenuItem.tsx
+++ b/src/components/atoms/menu/MenuItem.tsx
@@ -11,8 +11,8 @@ interface IProps extends BaseMenu.Item.Props {
 export const MenuItem = ({ className, color = "mono", disabled, heading = false, ...props }: IProps) => {
   const allClasses = joinTailwindClasses(
     "px-2.5 py-2 rounded-md hover:outline-none focus-visible:outline-none leading-none select-none",
-    disabled ? "text-text-tertiary" : "hover:bg-surface-ui focus-visible:bg-surface-ui cursor-pointer",
-    !disabled && color === "brand" ? "text-text-brand" : "text-text-primary",
+    disabled ? "text-text-tertiary" : "hover:bg-[#f5f5f5] focus-visible:bg-[#f5f5f5] cursor-pointer",
+    !disabled && color === "brand" ? "text-text-[#0038a9]" : "text-text-primary",
     heading ? "text-xs font-semibold" : "text-sm",
     className
   );

--- a/src/components/atoms/menu/MenuPopup.tsx
+++ b/src/components/atoms/menu/MenuPopup.tsx
@@ -8,7 +8,7 @@ interface IProps extends BaseMenu.Popup.Props {
 
 export const MenuPopup = ({ className, ...props }: IProps) => {
   const allClasses = joinTailwindClasses(
-    "min-w-37.5 p-1 bg-surface-light border border-border-light rounded-lg shadow-xs focus-visible:outline-none",
+    "min-w-37.5 p-1 bg-bg-primary border border-border-light rounded-lg shadow-xs focus-visible:outline-none",
     className
   );
 

--- a/src/components/atoms/pageLink/PageLink.tsx
+++ b/src/components/atoms/pageLink/PageLink.tsx
@@ -14,7 +14,7 @@ const getDebugClasses = (external: boolean, keepQuery: boolean, query?: ParsedUr
   return "outline-2! outline-green-500"; // Internal = green
 };
 
-const LINK_UNDERLINE = "underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500";
+const LINK_UNDERLINE = "underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]";
 
 export interface IProps extends LinkProps {
   children: ReactNode;

--- a/src/components/atoms/popover/Popover.tsx
+++ b/src/components/atoms/popover/Popover.tsx
@@ -40,7 +40,7 @@ type TProps = IPopoverElementProps | IPopoverChildrenProps;
 
 export const Popover = ({ children, description, link, onOpenChange, openOnHover = false, popupClasses = "", title, trigger }: TProps) => {
   const allPopupClasses = joinTailwindClasses(
-    "p-3 max-w-[350px] bg-white border border-gray-300 rounded-md shadow-md text-sm text-gray-700 leading-normal select-auto focus-visible:outline-0 z-[50]",
+    "p-3 max-w-[350px] bg-white border border-[#d1d5db] rounded-md shadow-md text-sm text-[#374151] leading-normal select-auto focus-visible:outline-0 z-[50]",
     popupClasses
   );
 
@@ -51,11 +51,11 @@ export const Popover = ({ children, description, link, onOpenChange, openOnHover
         <BasePopover.Positioner positionMethod="fixed" sideOffset={8} className="z-50">
           <BasePopover.Popup className={allPopupClasses}>
             <BasePopover.Arrow className="flex -top-2">
-              <BaseUIArrow fill="fill-white" stroke="fill-gray-300" />
+              <BaseUIArrow fill="fill-white" stroke="fill-[#d1d5db]" />
             </BasePopover.Arrow>
             {children || (
               <>
-                {title && <BasePopover.Title className="mb-2 text-gray-950 font-bold">{title}</BasePopover.Title>}
+                {title && <BasePopover.Title className="mb-2 text-[#030712] font-bold">{title}</BasePopover.Title>}
                 <BasePopover.Description>
                   <span className="block">{description}</span>
                   {link && (
@@ -63,7 +63,7 @@ export const Popover = ({ children, description, link, onOpenChange, openOnHover
                       external={link.external}
                       href={link.href}
                       hash={link.hash}
-                      className="block mt-2 underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+                      className="block mt-2 underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
                     >
                       {link.text}
                     </PageLink>

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -23,7 +23,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
 
   return (
     <BaseSelect.Root defaultValue={defaultValue} onValueChange={handleValueChange} value={value} id={id}>
-      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-inputSelected active:bg-surface-ui data-popup-open:bg-surface-ui focus:border-inputSelected">
+      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-[#005eeb] active:bg-surface-ui data-popup-open:bg-surface-ui focus:border-[#005eeb]">
         <BaseSelect.Value />
         <BaseSelect.Icon className="flex">
           <ChevronsUpDown height="12" width="12" />
@@ -40,7 +40,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
                 <BaseSelect.Item
                   key={option.value}
                   value={option.value}
-                  className="text-text-primary bg-white-ui p-1 rounded-sm cursor-default data-highlighted:bg-surface-mono data-highlighted:text-white data-highlighted:outline-inputSelected"
+                  className="text-text-primary bg-white-ui p-1 rounded-sm cursor-default data-highlighted:bg-surface-mono data-highlighted:text-white data-highlighted:outline-[#005eeb]"
                 >
                   <BaseSelect.ItemText className="">{option.label}</BaseSelect.ItemText>
                 </BaseSelect.Item>

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -23,7 +23,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
 
   return (
     <BaseSelect.Root defaultValue={defaultValue} onValueChange={handleValueChange} value={value} id={id}>
-      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-[#005eeb] active:bg-surface-ui data-popup-open:bg-surface-ui focus:border-[#005eeb]">
+      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-[#005eeb] active:bg-[#f5f5f5] data-popup-open:bg-[#f5f5f5] focus:border-[#005eeb]">
         <BaseSelect.Value />
         <BaseSelect.Icon className="flex">
           <ChevronsUpDown height="12" width="12" />

--- a/src/components/atoms/tooltip/Tooltip.tsx
+++ b/src/components/atoms/tooltip/Tooltip.tsx
@@ -30,7 +30,7 @@ export const Tooltip = ({ arrow = false, children, content, popupClasses, side =
             <BaseTooltip.Popup className={allPopupClasses}>
               {arrow && (
                 <BaseTooltip.Arrow className={arrowClasses}>
-                  <BaseUIArrow fill="fill-surface-mono-dark" stroke="fill-surface-mono-dark" />
+                  <BaseUIArrow fill="fill-bg-inverse" stroke="fill-bg-inverse" />
                 </BaseTooltip.Arrow>
               )}
               {content}

--- a/src/components/atoms/tooltip/Tooltip.tsx
+++ b/src/components/atoms/tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ interface IProps {
 
 export const Tooltip = ({ arrow = false, children, content, popupClasses, side = "top", triggerClasses }: IProps) => {
   const allPopupClasses = joinTailwindClasses(
-    "px-1.5 py-1 bg-gray-950 rounded-md text-xs text-white text-nowrap leading-none font-medium",
+    "px-1.5 py-1 bg-[#030712] rounded-md text-xs text-white text-nowrap leading-none font-medium",
     popupClasses
   );
 

--- a/src/components/blocks/collectionsBlock/CollectionsBlock.tsx
+++ b/src/components/blocks/collectionsBlock/CollectionsBlock.tsx
@@ -17,13 +17,13 @@ export const CollectionsBlock = ({ collections }: IProps) => {
       <div className="col-start-1 -col-end-1 flex flex-col gap-4">
         {collections.map((collection) => (
           <div key={collection.import_id}>
-            <h3 className="text-gray-950 font-medium">{collection.title}</h3>
+            <h3 className="text-[#030712] font-medium">{collection.title}</h3>
             <ul className="list-disc pl-4">
               {collection.families.map((family) => (
                 <li key={family.import_id}>
                   <PageLink
                     href={`/document/${family.slug}`}
-                    className="text-gray-700 underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+                    className="text-[#374151] underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
                   >
                     {family.title}
                   </PageLink>

--- a/src/components/blocks/eventsBlock/EventsBlock.tsx
+++ b/src/components/blocks/eventsBlock/EventsBlock.tsx
@@ -43,7 +43,7 @@ export const EventsBlock = ({ families }: IProps) => {
           <button
             type="button"
             onClick={toggleShowAll}
-            className="p-2 mt-3 hover:bg-gray-50 active:bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 leading-4 font-medium"
+            className="p-2 mt-3 hover:bg-[#f9fafb] active:bg-[#f3f4f6] border border-[#d1d5db] rounded-md text-sm text-[#374151] leading-4 font-medium"
           >
             {showAllEntries ? "View less" : "View more"}
           </button>

--- a/src/components/blocks/familyBlock/FamilyBlock.tsx
+++ b/src/components/blocks/familyBlock/FamilyBlock.tsx
@@ -42,12 +42,12 @@ export const FamilyBlock = ({ family }: IProps) => {
     <Section id={`section-${family.slug}`} wide>
       <div className="col-start-1 -col-end-1">
         <PageLink keepQuery href={`/document/${family.slug}`}>
-          <h2 className="text-2xl text-gray-950 font-heavy leading-tight hover:underline underline-offset-6">
+          <h2 className="text-2xl text-[#030712] font-heavy leading-tight hover:underline underline-offset-6">
             {family.title}&nbsp;
-            <span className="text-brand">{ARROW_UP_RIGHT}</span>
+            <span className="text-[#0038a9]">{ARROW_UP_RIGHT}</span>
           </h2>
         </PageLink>
-        <div className="mt-2 mb-3 flex gap-4 flex-wrap text-sm text-gray-500 leading-none">
+        <div className="mt-2 mb-3 flex gap-4 flex-wrap text-sm text-[#6b7280] leading-none">
           {caseNumbers && <span>{caseNumbers}</span>}
           {courts && <span>{courts}</span>}
           <span>
@@ -64,7 +64,7 @@ export const FamilyBlock = ({ family }: IProps) => {
           <button
             type="button"
             onClick={toggleShowAll}
-            className="p-2 mt-2 hover:bg-gray-50 active:bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 leading-4 font-medium"
+            className="p-2 mt-2 hover:bg-[#f9fafb] active:bg-[#f3f4f6] border border-[#d1d5db] rounded-md text-sm text-[#374151] leading-4 font-medium"
           >
             {showAllEntries ? "Show less" : "Show all"}
           </button>

--- a/src/components/blocks/latestItemsBlock/LatestItemsBlock.tsx
+++ b/src/components/blocks/latestItemsBlock/LatestItemsBlock.tsx
@@ -8,7 +8,7 @@ interface IProps {
 
 export const LatestItemsBlock = ({ latestItems }: IProps) => {
   return (
-    <aside aria-labelledby="latest" className="bg-surface-heavy p-5 flex flex-col space-y-4 text-text-primary h-full">
+    <aside aria-labelledby="latest" className="bg-[#e5e5e5] p-5 flex flex-col space-y-4 text-text-primary h-full">
       <h2 id="latest" className="font-bold border-b border-[#0000001a] pb-4">
         Latest
       </h2>

--- a/src/components/blocks/latestItemsBlock/LatestItemsBlock.tsx
+++ b/src/components/blocks/latestItemsBlock/LatestItemsBlock.tsx
@@ -9,7 +9,7 @@ interface IProps {
 export const LatestItemsBlock = ({ latestItems }: IProps) => {
   return (
     <aside aria-labelledby="latest" className="bg-surface-heavy p-5 flex flex-col space-y-4 text-text-primary h-full">
-      <h2 id="latest" className="font-bold border-b border-border-semi-transparent pb-4">
+      <h2 id="latest" className="font-bold border-b border-[#0000001a] pb-4">
         Latest
       </h2>
 
@@ -17,7 +17,7 @@ export const LatestItemsBlock = ({ latestItems }: IProps) => {
         {latestItems.map((item) => {
           const [year, day, month] = formatDate(item.date);
           return (
-            <li key={item.url} className="border-b border-border-semi-transparent pb-4">
+            <li key={item.url} className="border-b border-[#0000001a] pb-4">
               <p className="text-sm text-text-tertiary">
                 {day} {month} {year}
               </p>

--- a/src/components/blocks/metadataBlock/MetadataBlock.tsx
+++ b/src/components/blocks/metadataBlock/MetadataBlock.tsx
@@ -13,11 +13,11 @@ export const MetadataBlock = ({ block, metadata, title }: IProps) => {
   return (
     <Section block={block} title={title}>
       <div className="grid grid-cols-subgrid gap-y-3 col-start-1 -col-end-1">
-        {metadata.length === 0 && <div className="text-gray-500 col-start-1 -col-end-1">Sorry, there is no data available at this time.</div>}
+        {metadata.length === 0 && <div className="text-[#6b7280] col-start-1 -col-end-1">Sorry, there is no data available at this time.</div>}
         {metadata.map((item, itemIndex) => (
           <div key={itemIndex} className="grid grid-cols-subgrid col-start-1 -col-end-1">
-            <div className="text-gray-950 font-medium col-start-1 -col-end-1 cols-3:col-end-3">{item.label}</div>
-            <div className="text-gray-700 -col-end-1 col-start-1 cols-3:col-start-3">{item.value}</div>
+            <div className="text-[#030712] font-medium col-start-1 -col-end-1 cols-3:col-end-3">{item.label}</div>
+            <div className="text-[#374151] -col-end-1 col-start-1 cols-3:col-start-3">{item.value}</div>
           </div>
         ))}
       </div>

--- a/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
+++ b/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
@@ -82,7 +82,7 @@ export const RecentFamiliesCategory = ({
     placeholder = (
       <p className="mt-4 mb-12 text-text-primary">
         Visit the{" "}
-        <PageLink external href="https://www.climatecasechart.com/" className="text-brand underline">
+        <PageLink external href="https://www.climatecasechart.com/" className="text-[#0038a9] underline">
           Climate Litigation Database
         </PageLink>{" "}
         to see litigation documents.

--- a/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
+++ b/src/components/blocks/recentFamiliesBlock/RecentFamiliesCategory.tsx
@@ -66,7 +66,7 @@ export const RecentFamiliesCategory = ({
     onAccordionClick?.();
   };
 
-  const accordionIconClasses = joinTailwindClasses("text-text-brand-darker", isExpanded && "rotate-180");
+  const accordionIconClasses = joinTailwindClasses("text-[#002ca3]", isExpanded && "rotate-180");
 
   const viewAllUrlQuery = {
     [QUERY_PARAMS.country]: geography.slug,
@@ -125,7 +125,7 @@ export const RecentFamiliesCategory = ({
                       pathname: "/search",
                       query: { ...viewAllUrlQuery },
                     }}
-                    className="min-w-16 max-w-25 flex-1 flex justify-center items-center bg-surface-brand-darker/8 text-text-brand-darker font-semibold leading-tight"
+                    className="min-w-16 max-w-25 flex-1 flex justify-center items-center bg-[#002ca3]/8 text-[#002ca3] font-semibold leading-tight"
                     data-ph-capture-attribute-link-purpose="all-recents"
                     data-ph-capture-attribute-category={id}
                   >

--- a/src/components/blocks/subDivisionBlock/SubDivisionBlock.tsx
+++ b/src/components/blocks/subDivisionBlock/SubDivisionBlock.tsx
@@ -72,7 +72,7 @@ export const SubDivisionBlock = ({ subdivisions, title = "Geographic sub-divisio
               {subdivision.has_data ? (
                 <LinkWithQuery
                   href={`/geographies/${subdivision.slug}`}
-                  className="underline text-text-primary hover:text-text-brand-darker"
+                  className="underline text-text-primary hover:text-[#002ca3]"
                   data-ph-capture-attribute-link-purpose="subdivision"
                   data-ph-capture-attribute-subdivision={subdivision.id}
                 >

--- a/src/components/blocks/subDivisionBlock/SubDivisionBlock.tsx
+++ b/src/components/blocks/subDivisionBlock/SubDivisionBlock.tsx
@@ -62,7 +62,7 @@ export const SubDivisionBlock = ({ subdivisions, title = "Geographic sub-divisio
 
   return (
     <Section block="subdivisions" title={title} count={subGeosWithHasData.length}>
-      <div className="col-start-1 -col-end-1 rounded bg-surface-ui py-6 px-10">
+      <div className="col-start-1 -col-end-1 rounded bg-[#f5f5f5] py-6 px-10">
         <ol className="text-sm list-none pl-5 grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 grid-flow-dense">
           {subGeosWithHasData.map((subdivision, index) => (
             <li

--- a/src/components/blocks/targetsBlock/TargetsBlock.tsx
+++ b/src/components/blocks/targetsBlock/TargetsBlock.tsx
@@ -50,12 +50,12 @@ export const TargetsBlock = ({ targets }: IProps) => {
               data-ph-capture-attribute-link-purpose="target"
               data-ph-capture-attribute-target={target.ID}
             >
-              <h3 className="text-gray-950 font-medium" dangerouslySetInnerHTML={{ __html: target.Description }} />
+              <h3 className="text-[#030712] font-medium" dangerouslySetInnerHTML={{ __html: target.Description }} />
               <span className="block text-sm">{getMetadata(target).join(`, `)}</span>
               {showSourceLink(target) && (
                 <span className="block text-sm">
                   Source:{" "}
-                  <span className="underline underline-offset-4 decoration-gray-300 group-hover:decoration-gray-500">{target["family-name"]}</span>
+                  <span className="underline underline-offset-4 decoration-[#d1d5db] group-hover:decoration-[#6b7280]">{target["family-name"]}</span>
                 </span>
               )}
             </PageLink>
@@ -65,7 +65,7 @@ export const TargetsBlock = ({ targets }: IProps) => {
           <button
             type="button"
             onClick={toggleShowAll}
-            className="p-2 hover:bg-gray-50 active:bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 leading-4 font-medium"
+            className="p-2 hover:bg-[#f9fafb] active:bg-[#f3f4f6] border border-[#d1d5db] rounded-md text-sm text-[#374151] leading-4 font-medium"
           >
             {showAllEntries ? "View less" : "View more"}
           </button>

--- a/src/components/blocks/topicsBlock/TopicsBlock.tsx
+++ b/src/components/blocks/topicsBlock/TopicsBlock.tsx
@@ -37,7 +37,7 @@ export const TopicsBlock = ({ family, familyTopics, getCategoryText }: TProps) =
         <p className="mb-3">
           See how often topics get mentioned in this {getCategoryText("familySingular")} and view specific passages of text highlighted in each
           document. Accuracy is not 100%.{" "}
-          <PageLink href="/faq" hash="topics-faqs" className="inline-block underline decoration-gray-300 hover:decoration-gray-500">
+          <PageLink href="/faq" hash="topics-faqs" className="inline-block underline decoration-[#d1d5db] hover:decoration-[#6b7280]">
             Learn more
           </PageLink>
         </p>

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -106,13 +106,13 @@ export const BreadCrumbs = ({
     if (label) breadCrumbs.push(<BreadCrumb key="current" label={label} last cy="current" />);
   }
 
-  const containerClasses = joinTailwindClasses(dark && "bg-gray-100");
+  const containerClasses = joinTailwindClasses(dark && "bg-[#f3f4f6]");
 
   return (
     <div className={containerClasses}>
       <FiveColumns>
         <ul
-          className="col-start-1 -col-end-1 flex flex-wrap items-baseline gap-2 py-3 text-sm text-gray-700 leading-tight select-none"
+          className="col-start-1 -col-end-1 flex flex-wrap items-baseline gap-2 py-3 text-sm text-[#374151] leading-tight select-none"
           data-cy="breadcrumbs"
         >
           {breadCrumbs}

--- a/src/components/cookies/CookieConsent.tsx
+++ b/src/components/cookies/CookieConsent.tsx
@@ -58,7 +58,7 @@ export const CookieConsent = ({ onConsentChange, themeConfig }: IProps) => {
   return (
     <>
       <div className={`flex justify-end ${hide ? "hidden" : ""}`}>
-        <Card color="mono" variant="outlined" className="m-3 sm:m-4 max-w-[550px] bg-surface-ui pointer-events-auto select-none">
+        <Card color="mono" variant="outlined" className="m-3 sm:m-4 max-w-[550px] bg-[#f5f5f5] pointer-events-auto select-none">
           <p className="text-base leading-normal font-semibold text-text-primary">Cookies and your privacy</p>
           <p className="mt-2 mb-4 text-sm leading-normal font-normal text-text-primary">
             We take your trust and privacy seriously. Climate Policy Radar uses cookies to make our site work optimally, analyse traffic to our

--- a/src/components/documents/ConceptsDocumentViewer.tsx
+++ b/src/components/documents/ConceptsDocumentViewer.tsx
@@ -205,7 +205,7 @@ export const ConceptsDocumentViewer = ({
           {/* Preview */}
           <div
             id="document-preview"
-            className={`flex-1 relative order-last border-t border-t-gray-200 h-[600px] basis-full lg:basis-auto lg:border-t-0 lg:order-none lg:h-full md:border-gray-300 ${hasConcepts ? "lg:border-x" : "lg:border-r"}`}
+            className={`flex-1 relative order-last border-t border-t-gray-200 h-[600px] basis-full lg:basis-auto lg:border-t-0 lg:order-none lg:h-full md:border-[#d1d5db] ${hasConcepts ? "lg:border-x" : "lg:border-r"}`}
           >
             {canPreview && (
               <EmbeddedPDF
@@ -236,13 +236,13 @@ export const ConceptsDocumentViewer = ({
                   id="document-search"
                   role="region"
                   aria-label="Passage matches"
-                  className="flex flex-col gap-2 md:pl-4 pb-4 border-b border-gray-300"
+                  className="flex flex-col gap-2 md:pl-4 pb-4 border-b border-[#d1d5db]"
                 >
                   <p className="text-text-primary">Passage matches</p>
                   <div className="relative z-10 flex gap-4">
                     <div className="relative">
                       <button
-                        className={`flex items-center gap-1 px-2 py-1 -mt-1 -ml-2 rounded-md text-sm text-text-primary font-normal ${showSearchOptions ? "bg-surface-ui" : ""}`}
+                        className={`flex items-center gap-1 px-2 py-1 -mt-1 -ml-2 rounded-md text-sm text-text-primary font-normal ${showSearchOptions ? "bg-[#f5f5f5]" : ""}`}
                         onClick={() => setShowSearchOptions(!showSearchOptions)}
                       >
                         <span className="font-bold">Search:</span>{" "}
@@ -264,7 +264,7 @@ export const ConceptsDocumentViewer = ({
                     </div>
                     <div className="relative">
                       <button
-                        className={`flex items-center gap-1 px-2 py-1 -mt-1 -ml-2 rounded-md text-sm text-text-primary font-normal ${showSortOptions ? "bg-surface-ui" : ""}`}
+                        className={`flex items-center gap-1 px-2 py-1 -mt-1 -ml-2 rounded-md text-sm text-text-primary font-normal ${showSortOptions ? "bg-[#f5f5f5]" : ""}`}
                         onClick={() => setShowSortOptions(!showSortOptions)}
                       >
                         <span className="font-bold">Order:</span>{" "}
@@ -312,7 +312,7 @@ export const ConceptsDocumentViewer = ({
                 {hasQuery && state.totalNoOfMatches > 0 && (
                   <div
                     id="document-passage-matches"
-                    className="relative overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 md:pl-4"
+                    className="relative overflow-y-scroll scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-[#6b7280] md:pl-4"
                   >
                     {/* Removing active passage index for now as we don't use indexes any more //activeIndex={pageNumber ?? startingPassage} */}
                     <PassageMatches passages={state.passageMatches} onClick={handlePassageClick} />

--- a/src/components/documents/DocumentHead.tsx
+++ b/src/components/documents/DocumentHead.tsx
@@ -60,7 +60,7 @@ export const DocumentHead = ({ document, family, features, handleViewOtherDocsCl
   }, [family, showFullSummary]);
 
   return (
-    <div className="bg-white border-solid border-lineBorder border-b border-gray-300">
+    <div className="bg-white border-solid border-lineBorder border-b border-[#d1d5db]">
       <BreadCrumbs
         geography={breadcrumbGeography}
         family={breadcrumbFamily}

--- a/src/components/documents/EmptyDocument.tsx
+++ b/src/components/documents/EmptyDocument.tsx
@@ -3,7 +3,7 @@ import { BookOpen } from "lucide-react";
 import { ExternalLink } from "@/components/ExternalLink";
 
 export const EmptyDocument = () => (
-  <div className="ml-4 mt-4 text-center text-gray-700">
+  <div className="ml-4 mt-4 text-center text-[#374151]">
     <div className="mb-2 flex justify-center">
       <BookOpen width="24" height="24" />
     </div>

--- a/src/components/documents/EmptyPassages.tsx
+++ b/src/components/documents/EmptyPassages.tsx
@@ -5,7 +5,7 @@ interface IProps {
 }
 
 export const EmptyPassages = ({ hasQueryString }: IProps) => (
-  <div className="flex flex-col gap-4 flex-1 pt-10 text-center text-gray-700 px-4">
+  <div className="flex flex-col gap-4 flex-1 pt-10 text-center text-[#374151] px-4">
     <div className="text-blue-800 flex justify-center items-center">
       <div className="rounded-full bg-blue-50 p-6 mb-2">
         <FileSearchCorner width="48" height="48" />

--- a/src/components/drawers/documentDrawer/DocumentDrawer.tsx
+++ b/src/components/drawers/documentDrawer/DocumentDrawer.tsx
@@ -100,14 +100,14 @@ export const DocumentDrawer = ({ documentImportId, family, familyTopics, languag
         <PageLink
           keepQuery
           href={"/documents/" + document.slug}
-          className="underline text-brand underline-offset-5 decoration-gray-300 hover:decoration-brand"
+          className="underline text-[#0038a9] underline-offset-5 decoration-[#d1d5db] hover:decoration-[#0038a9]"
         >
           {document.title}
         </PageLink>
       }
     >
       {metadata.length > 0 && (
-        <div className="grid grid-cols-[120px_auto] gap-x-3 gap-y-2 mb-6 text-sm text-gray-700 leading-5" data-vaul-no-drag={true}>
+        <div className="grid grid-cols-[120px_auto] gap-x-3 gap-y-2 mb-6 text-sm text-[#374151] leading-5" data-vaul-no-drag={true}>
           {metadata.map((item, itemIndex) => (
             <Fragment key={itemIndex}>
               <div className="font-medium">{item.label}</div>
@@ -119,7 +119,7 @@ export const DocumentDrawer = ({ documentImportId, family, familyTopics, languag
 
       {topicRows.length > 0 && (
         <div className="mt-9">
-          <h3 className="mt-6 mb-2 text-lg text-gray-950 font-heavy leading-6">Topics mentioned</h3>
+          <h3 className="mt-6 mb-2 text-lg text-[#030712] font-heavy leading-6">Topics mentioned</h3>
           <p className="mb-4">See exactly where a topic is mentioned in this document.</p>
           <InteractiveTable<TTopicTableColumnId> columns={DOCUMENT_DRAWER_TOPICS_TABLE_COLUMNS} rows={topicRows} />
         </div>

--- a/src/components/drawers/topicDrawer/TopicDrawer.tsx
+++ b/src/components/drawers/topicDrawer/TopicDrawer.tsx
@@ -43,7 +43,7 @@ export const TopicDrawer = ({ family, familyTopics, onOpenChange, open, topicWik
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange} title={topicName}>
-      <div className="grid grid-cols-[120px_auto] gap-x-3 gap-y-2 text-sm text-gray-700 leading-5">
+      <div className="grid grid-cols-[120px_auto] gap-x-3 gap-y-2 text-sm text-[#374151] leading-5">
         <div className="font-medium">Definition</div>
         <p>{firstCase(topic.description)}</p>
         <div className="font-medium">Methodology</div>
@@ -51,22 +51,26 @@ export const TopicDrawer = ({ family, familyTopics, onOpenChange, open, topicWik
           <PageLink
             external
             href={getConceptStoreLink(topic.wikibase_id)}
-            className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+            className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
           >
-            View source data&nbsp;<span className="text-gray-500">{ARROW_UP_RIGHT}</span>
+            View source data&nbsp;<span className="text-[#6b7280]">{ARROW_UP_RIGHT}</span>
           </PageLink>
         </div>
       </div>
 
-      <h3 className="mt-9 mb-5 text-lg text-gray-950 font-heavy leading-6">Documents that mention this topic</h3>
+      <h3 className="mt-9 mb-5 text-lg text-[#030712] font-heavy leading-6">Documents that mention this topic</h3>
       <InteractiveTable<TDocumentMentionsTableColumnId>
         columns={TOPIC_DRAWER_DOCUMENTS_TABLE_COLUMNS}
         rows={documentRows}
         defaultSort={{ column: "mentions", order: "desc" }}
       />
-      <p className="mt-3 text-sm text-gray-700 italic">
+      <p className="mt-3 text-sm text-[#374151] italic">
         We automatically identify mentions of key topics in documents, helping you quickly find exactly where they are. Accuracy is not 100%.{" "}
-        <PageLink href="/faq" hash="topics-faqs" className="inline-block underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500">
+        <PageLink
+          href="/faq"
+          hash="topics-faqs"
+          className="inline-block underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
+        >
           Learn more
         </PageLink>
       </p>

--- a/src/components/filters/FilterOptions.tsx
+++ b/src/components/filters/FilterOptions.tsx
@@ -62,7 +62,7 @@ export const FilterOptions = ({ filter, query, handleFilterChange, corpus_types,
           return (
             <Fragment key={filterGroup[0].group || "ungrouped"}>
               {groupedOptions.length > 1 && (
-                <span className="not-first:mt-3 text-xs text-gray-500 leading-none font-heavy cursor-default">{filterGroup[0].group}</span>
+                <span className="not-first:mt-3 text-xs text-[#6b7280] leading-none font-heavy cursor-default">{filterGroup[0].group}</span>
               )}
               {filterGroup.map((option) =>
                 filter.type === "radio" ? (

--- a/src/components/filters/SearchFilters.tsx
+++ b/src/components/filters/SearchFilters.tsx
@@ -131,7 +131,7 @@ const SearchFilters = ({
               </Badge>
             </Heading>
             <span
-              className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+              className={`text-[#202020] opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
                 currentSlideOut === "concepts" ? "transform rotate-180" : ""
               }`}
             >
@@ -151,7 +151,7 @@ const SearchFilters = ({
           >
             <Heading>Case categories</Heading>
             <span
-              className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+              className={`text-[#202020] opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
                 currentSlideOut === "categories" ? "transform rotate-180" : ""
               }`}
             >
@@ -166,7 +166,7 @@ const SearchFilters = ({
           >
             <Heading>Principal laws</Heading>
             <span
-              className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+              className={`text-[#202020] opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
                 currentSlideOut === "principalLaws" ? "transform rotate-180" : ""
               }`}
             >
@@ -181,7 +181,7 @@ const SearchFilters = ({
           >
             <Heading>Jurisdictions</Heading>
             <span
-              className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+              className={`text-[#202020] opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
                 currentSlideOut === "jurisdictions" ? "transform rotate-180" : ""
               }`}
             >
@@ -240,7 +240,7 @@ const SearchFilters = ({
         >
           <Heading>Geography</Heading>
           <span
-            className={`text-textDark opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
+            className={`text-[#202020] opacity-40 group-hover:opacity-100 transition-transform pointer-events-none ${
               currentSlideOut === "geographies" ? "transform rotate-180" : ""
             }`}
           >

--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -109,7 +109,7 @@ export const SearchSettings = ({
                     <span>{SEARCH_SETTINGS.semantic}</span>
                     <span className="block text-text-secondary">
                       Temporarily unavailable.{" "}
-                      <PageLink external href="https://form.jotform.com/260824503109350" className="text-brand underline">
+                      <PageLink external href="https://form.jotform.com/260824503109350" className="text-[#0038a9] underline">
                         Get notified
                       </PageLink>{" "}
                       when this is available.

--- a/src/components/filters/SuggestList.tsx
+++ b/src/components/filters/SuggestList.tsx
@@ -72,7 +72,7 @@ const SuggestList: React.FC<SuggestListProps> = ({ list, setList, keyField, keyF
   }, [handleKeyDown]);
 
   return (
-    <ul ref={ulRef} className="bg-white rounded-b-xl border border-borderNormal border-t-0 m-0">
+    <ul ref={ulRef} className="bg-white rounded-b-xl border border-[#dedede] border-t-0 m-0">
       {list.map(
         (item: SuggestListItem, idx: number) =>
           idx < 10 && (
@@ -81,7 +81,7 @@ const SuggestList: React.FC<SuggestListProps> = ({ list, setList, keyField, keyF
               onClick={() => {
                 handleClick(item);
               }}
-              className="cursor-pointer p-2 hover:text-textDark hover:font-medium hover:bg-blue-100 last:rounded-b-xl"
+              className="cursor-pointer p-2 hover:text-[#202020] hover:font-medium hover:bg-blue-100 last:rounded-b-xl"
             >
               {item[keyFieldDisplay ?? keyField]}
             </li>

--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -19,7 +19,7 @@ const CheckBox = ({ checked, onChange, name }: IProps) => {
 export const InputCheck = ({ label, checked, onChange, name, additionalInfo, learnMoreUrl, learnMoreExternal, className }: IProps) => {
   return (
     <>
-      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""} ${className}`}>
+      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-[#202020]" : ""} ${className}`}>
         <CheckBox checked={checked} onChange={onChange} name={name} />
         <span className="flex items-center">{label}</span>
       </label>

--- a/src/components/forms/InputLearnMoreLink.tsx
+++ b/src/components/forms/InputLearnMoreLink.tsx
@@ -11,7 +11,7 @@ export const InputLearnMoreLink = ({ additionalInfo, learnMoreUrl, learnMoreExte
     <p className="ml-[24px] pl-2 opacity-80">
       {additionalInfo}{" "}
       {learnMoreUrl && (
-        <a href={learnMoreUrl} target={learnMoreExternal ? "_blank" : ""} className="text-textNormal italic underline" rel="noreferrer">
+        <a href={learnMoreUrl} target={learnMoreExternal ? "_blank" : ""} className="text-[#505050] italic underline" rel="noreferrer">
           Learn more
         </a>
       )}

--- a/src/components/forms/Radio.tsx
+++ b/src/components/forms/Radio.tsx
@@ -19,7 +19,7 @@ const Radio = ({ checked, onChange, onClick, name }: IProps) => {
 export const InputRadio = ({ label, checked, onChange, onClick, name, additionalInfo, learnMoreUrl, learnMoreExternal, className }: IProps) => {
   return (
     <>
-      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-textDark" : ""} ${className}`}>
+      <label className={`flex gap-2 cursor-pointer ${checked ? "font-medium text-[#202020]" : ""} ${className}`}>
         <Radio checked={checked} onChange={onChange} onClick={onClick} name={name} />
         <span className="flex items-center">{label}</span>
       </label>

--- a/src/components/forms/SearchDropdown.tsx
+++ b/src/components/forms/SearchDropdown.tsx
@@ -45,7 +45,7 @@ export const SearchDropdown = ({ show = false, term, handleSearchClick, largeSpa
   };
 
   const anchorClasses = (last: boolean) =>
-    `flex flex-wrap items-center cursor-pointer py-2 px-4 block text-cpr-dark hover:no-underline hover:bg-gray-200 focus:bg-gray-200 ${
+    `flex flex-wrap items-center cursor-pointer py-2 px-4 block text-[#071e4a] hover:no-underline hover:bg-gray-200 focus:bg-gray-200 ${
       last ? "rounded-b-lg" : ""
     }`;
 
@@ -83,7 +83,7 @@ export const SearchDropdown = ({ show = false, term, handleSearchClick, largeSpa
 
   return (
     <div
-      className={`search-dropdown absolute bg-gray-50 text-cpr-dark border-t-transparent border border-gray-300 w-full rounded-b-lg max-h-[300px] overflow-y-auto z-10 shadow-inner ${
+      className={`search-dropdown absolute bg-gray-50 text-[#071e4a] border-t-transparent border border-gray-300 w-full rounded-b-lg max-h-[300px] overflow-y-auto z-10 shadow-inner ${
         largeSpacing ? "search-dropdown_large" : ""
       }`}
     >

--- a/src/components/forms/SearchDropdown.tsx
+++ b/src/components/forms/SearchDropdown.tsx
@@ -83,7 +83,7 @@ export const SearchDropdown = ({ show = false, term, handleSearchClick, largeSpa
 
   return (
     <div
-      className={`search-dropdown absolute bg-gray-50 text-[#071e4a] border-t-transparent border border-gray-300 w-full rounded-b-lg max-h-[300px] overflow-y-auto z-10 shadow-inner ${
+      className={`search-dropdown absolute bg-[#f9fafb] text-[#071e4a] border-t-transparent border border-[#d1d5db] w-full rounded-b-lg max-h-[300px] overflow-y-auto z-10 shadow-inner ${
         largeSpacing ? "search-dropdown_large" : ""
       }`}
     >

--- a/src/components/map/GeographySelect.tsx
+++ b/src/components/map/GeographySelect.tsx
@@ -39,7 +39,7 @@ const GeographySelect = ({ title, list, keyField, keyFieldDisplay, filterType, h
       <div className={`bg-white relative z-20 ${suggestList.length > 0 ? "rounded-b-none rounded-t-lg" : "rounded-full"}`}>
         <div className="absolute p-px pr-0 top-0 left-0 h-full flex items-center justify-start z-20">
           <div
-            className={`text-gray-300 py-1 px-2 pl-4 h-full transition duration-300 shrink-0 flex items-center ${
+            className={`text-[#d1d5db] py-1 px-2 pl-4 h-full transition duration-300 shrink-0 flex items-center ${
               suggestList.length > 0 ? "rounded-tl-lg" : "rounded-l-full"
             }`}
           >
@@ -49,7 +49,7 @@ const GeographySelect = ({ title, list, keyField, keyFieldDisplay, filterType, h
         <input
           data-analytics="map-searchInput"
           data-cy="map-input"
-          className={`w-full bg-white appearance-none py-2 pl-12 pr-2 z-10 leading-snug relative grow border-gray-300 placeholder:text-grey-300 ${
+          className={`w-full bg-white appearance-none py-2 pl-12 pr-2 z-10 leading-snug relative grow border-[#d1d5db] placeholder:text-grey-300 ${
             suggestList.length > 0 ? "rounded-b-none rounded-t-lg" : "rounded-full"
           }`}
           type="search"

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -18,7 +18,7 @@ export const Legend = ({ max, showLitigation, showMcf }: IProps) => {
   const scale = [1, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), max];
 
   return (
-    <div className="border border-gray-300 border-t-0 p-4 flex gap-4 items-baseline text-gray-700">
+    <div className="border border-[#d1d5db] border-t-0 p-4 flex gap-4 items-baseline text-[#374151]">
       <div className="map-circles">
         <div className="scale-item">
           <div className="circle"></div>

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -130,7 +130,7 @@ const GeographyDetail = ({ geo, geographies }: { geo: any; geographies: TGeograp
   }
   return (
     <>
-      <p className="text-textDark font-medium">{geography.display_value}</p>
+      <p className="text-[#202020] font-medium">{geography.display_value}</p>
       {(geography.familyCounts?.EXECUTIVE > 0 || geography.familyCounts?.LEGISLATIVE > 0) && (
         <p>Laws and policies: {(geography.familyCounts?.EXECUTIVE || 0) + (geography.familyCounts?.LEGISLATIVE || 0)}</p>
       )}

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -314,7 +314,7 @@ export default function WorldMap({ showLitigation = false, showCategorySelect = 
         {showCategorySelect && (
           <div>
             <select
-              className="border border-gray-300 small rounded-full pl-4!"
+              className="border border-[#d1d5db] small rounded-full pl-4!"
               onChange={(e) => {
                 setSelectedFamCategory(e.currentTarget.value as "lawsPolicies" | "unfccc" | "mcf" | "reports" | "litigation");
               }}
@@ -441,11 +441,11 @@ export default function WorldMap({ showLitigation = false, showCategorySelect = 
         {showEUCheckbox && (
           <div className="absolute top-0 right-0 p-4">
             <label
-              className="checkbox-input flex items-center p-2 px-4 rounded-full cursor-pointer border border-gray-300 bg-white"
+              className="checkbox-input flex items-center p-2 px-4 rounded-full cursor-pointer border border-[#d1d5db] bg-white"
               htmlFor="show_eu_aggregated"
             >
               <input
-                className="border-gray-300 cursor-pointer"
+                className="border-[#d1d5db] cursor-pointer"
                 id="show_eu_aggregated"
                 type="checkbox"
                 name="exact_match"

--- a/src/components/map/ZoomControls.tsx
+++ b/src/components/map/ZoomControls.tsx
@@ -10,18 +10,18 @@ interface IProps {
 export const ZoomControls = ({ mapZoom, minZoom, maxZoom, handleZoomIn, handleZoomOut, handleReset }: IProps) => {
   return (
     <div className="absolute bottom-0 right-0 p-4 flex gap-2">
-      <button className="text-xs bg-white text-gray-500 rounded-full border border-gray-300 h-[40px] px-4" onClick={handleReset}>
+      <button className="text-xs bg-white text-[#6b7280] rounded-full border border-[#d1d5db] h-[40px] px-4" onClick={handleReset}>
         Reset
       </button>
       <button
-        className="bg-white text-gray-500 rounded-full border w-[40px] h-[40px] border-gray-300 disabled:opacity-50"
+        className="bg-white text-[#6b7280] rounded-full border w-[40px] h-[40px] border-[#d1d5db] disabled:opacity-50"
         disabled={mapZoom === maxZoom}
         onClick={handleZoomIn}
       >
         +
       </button>
       <button
-        className="bg-white text-gray-500 rounded-full border w-[40px] h-[40px] border-gray-300 disabled:opacity-50"
+        className="bg-white text-[#6b7280] rounded-full border w-[40px] h-[40px] border-[#d1d5db] disabled:opacity-50"
         disabled={mapZoom === minZoom}
         onClick={handleZoomOut}
       >

--- a/src/components/modals/DownloadCsv.tsx
+++ b/src/components/modals/DownloadCsv.tsx
@@ -16,7 +16,7 @@ export const DownloadCsvPopup = ({ isOpen, onClose, onDownload }: IProps) => {
       <p>
         Please read our <LinkWithQuery href="/terms-of-use">terms of use</LinkWithQuery>, including any specific terms relevant to commercial use.
         Please contact{" "}
-        <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-[#0038a9] underline">
+        <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-[#0038a9] underline">
           partners@climatepolicyradar.org
         </ExternalLink>{" "}
         with any questions. Note that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.

--- a/src/components/modals/DownloadCsv.tsx
+++ b/src/components/modals/DownloadCsv.tsx
@@ -16,7 +16,7 @@ export const DownloadCsvPopup = ({ isOpen, onClose, onDownload }: IProps) => {
       <p>
         Please read our <LinkWithQuery href="/terms-of-use">terms of use</LinkWithQuery>, including any specific terms relevant to commercial use.
         Please contact{" "}
-        <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-brand underline">
+        <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-[#0038a9] underline">
           partners@climatepolicyradar.org
         </ExternalLink>{" "}
         with any questions. Note that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.

--- a/src/components/molecules/conceptLink/ConceptLink.tsx
+++ b/src/components/molecules/conceptLink/ConceptLink.tsx
@@ -19,7 +19,7 @@ export const ConceptLink = ({ concept, label, onClick, triggerClasses = "", chil
 
   const allTriggerClasses = joinTailwindClasses(
     "inline underline underline-offset-4",
-    isOpen ? "decoration-gray-500" : "decoration-gray-300 hover:decoration-gray-500",
+    isOpen ? "decoration-[#6b7280]" : "decoration-[#d1d5db] hover:decoration-[#6b7280]",
     onClick ? "" : "!cursor-help",
     triggerClasses
   );

--- a/src/components/molecules/entityCard/EntityCard.tsx
+++ b/src/components/molecules/entityCard/EntityCard.tsx
@@ -7,9 +7,9 @@ export interface IProps {
 }
 
 export const EntityCard = ({ href, metadata, title }: IProps) => (
-  <PageLink keepQuery href={href} className="inline-block w-51 h-67 shrink-0 border-t-2 border-t-surface-brand-darker">
+  <PageLink keepQuery href={href} className="inline-block w-51 h-67 shrink-0 border-t-2 border-t-[#002ca3]">
     <div className="flex flex-col justify-between gap-5 h-full p-5 border border-border-light border-t-0">
-      <div className=" text-text-brand-darker font-semibold leading-tight line-clamp-7">{title}</div>
+      <div className=" text-[#002ca3] font-semibold leading-tight line-clamp-7">{title}</div>
       <ul className="flex flex-col gap-1.5 text-[13px] text-text-tertiary leading-tight">
         {metadata.map((line, lineIndex) => (
           <li key={lineIndex} className="overflow-hidden whitespace-nowrap text-ellipsis">

--- a/src/components/molecules/geographyLink/GeographyLink.stories.tsx
+++ b/src/components/molecules/geographyLink/GeographyLink.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: { layout: "centered" },
   argTypes: {},
   render: (props) => (
-    <div className="text-sm text-gray-700">
+    <div className="text-sm text-[#374151]">
       <GeographyLink {...props} />
     </div>
   ),

--- a/src/components/molecules/geographyLink/GeographyLink.tsx
+++ b/src/components/molecules/geographyLink/GeographyLink.tsx
@@ -17,7 +17,7 @@ export const GeographyLink = ({ code, name, slug }: IProps) => {
   );
 
   return slug ? (
-    <PageLink href={`/geographies/${slug}`} className="hover:underline decoration-gray-500">
+    <PageLink href={`/geographies/${slug}`} className="hover:underline decoration-[#6b7280]">
       {content}
     </PageLink>
   ) : (

--- a/src/components/molecules/info/Info.tsx
+++ b/src/components/molecules/info/Info.tsx
@@ -14,7 +14,7 @@ interface IProps {
 export const Info = ({ className, description, link, title }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const infoClasses = joinTailwindClasses("!cursor-help", isOpen ? "text-text-[#0038a9]" : "text-text-secondary", className);
+  const infoClasses = joinTailwindClasses("!cursor-help", isOpen ? "text-[#0038a9]" : "text-text-secondary", className);
 
   return (
     <Popover

--- a/src/components/molecules/info/Info.tsx
+++ b/src/components/molecules/info/Info.tsx
@@ -14,7 +14,7 @@ interface IProps {
 export const Info = ({ className, description, link, title }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const infoClasses = joinTailwindClasses("!cursor-help", isOpen ? "text-text-brand" : "text-text-secondary", className);
+  const infoClasses = joinTailwindClasses("!cursor-help", isOpen ? "text-text-[#0038a9]" : "text-text-secondary", className);
 
   return (
     <Popover

--- a/src/components/molecules/mainMenu/MainMenu.stories.tsx
+++ b/src/components/molecules/mainMenu/MainMenu.stories.tsx
@@ -19,8 +19,8 @@ export default meta;
 export const CPR: TStory = {
   args: {
     icon: (
-      <div className="flex items-center gap-1 px-2 py-1 rounded-md text-gray-950 font-medium group-data-[popup-open]:bg-gray-100">
-        <LucideMenu size={16} className="text-brand" /> Menu
+      <div className="flex items-center gap-1 px-2 py-1 rounded-md text-[#030712] font-medium group-data-[popup-open]:bg-[#f3f4f6]">
+        <LucideMenu size={16} className="text-[#0038a9]" /> Menu
       </div>
     ),
     links: CPR_MENU_LINKS,
@@ -29,7 +29,7 @@ export const CPR: TStory = {
 
 export const MCF: TStory = {
   args: {
-    icon: <LucideMenu size={24} className="text-gray-950" />,
+    icon: <LucideMenu size={24} className="text-[#030712]" />,
     links: MCF_MENU_LINKS,
   },
 };

--- a/src/components/molecules/mainMenu/MainMenu.tsx
+++ b/src/components/molecules/mainMenu/MainMenu.tsx
@@ -20,10 +20,10 @@ const MainMenu = ({ icon, links }: IProps) => {
         <NavigationMenu.Item className="flex items-center">
           <NavigationMenu.Trigger className="group">{triggerContent}</NavigationMenu.Trigger>
           <NavigationMenu.Content>
-            <ul className="p-2 bg-white border border-gray-200 rounded-md shadow-lg text-sm text-gray-700 leading-4 font-medium">
+            <ul className="p-2 bg-white border border-gray-200 rounded-md shadow-lg text-sm text-[#374151] leading-4 font-medium">
               {links.map(({ text, href, external, cy }) => {
                 const cyValue = `navigation-${cy}`;
-                const linkClasses = "block p-2 pr-8 rounded-sm hover:bg-gray-100 hover:text-gray-950";
+                const linkClasses = "block p-2 pr-8 rounded-sm hover:bg-[#f3f4f6] hover:text-[#030712]";
                 const linkElement = external ? (
                   <ExternalLink url={href} cy={cyValue} className={linkClasses}>
                     {text}

--- a/src/components/molecules/modal/Modal.stories.tsx
+++ b/src/components/molecules/modal/Modal.stories.tsx
@@ -48,7 +48,7 @@ export const DownloadCSV: TStory = {
         <p>
           Please read our <LinkWithQuery href="/terms-of-use">terms of use</LinkWithQuery>, including any specific terms relevant to commercial use.
           Please contact{" "}
-          <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-[#0038a9] underline">
+          <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-[#0038a9] underline">
             partners@climatepolicyradar.org
           </ExternalLink>{" "}
           with any questions. Note that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.

--- a/src/components/molecules/modal/Modal.stories.tsx
+++ b/src/components/molecules/modal/Modal.stories.tsx
@@ -48,7 +48,7 @@ export const DownloadCSV: TStory = {
         <p>
           Please read our <LinkWithQuery href="/terms-of-use">terms of use</LinkWithQuery>, including any specific terms relevant to commercial use.
           Please contact{" "}
-          <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-brand underline">
+          <ExternalLink url="mailto:partners@climatepolicyradar.org" className="text-text-[#0038a9] underline">
             partners@climatepolicyradar.org
           </ExternalLink>{" "}
           with any questions. Note that the actual number of entries returned may be 1 or 2 below the total indicated on the search results page.

--- a/src/components/molecules/modal/Modal.tsx
+++ b/src/components/molecules/modal/Modal.tsx
@@ -56,7 +56,7 @@ export const Modal = ({
 
   return (
     <div
-      className={`fixed inset-0 z-2000 flex flex-col justify-center items-center bg-surface-mono-dark/50 overflow-hidden transition duration-200 ${
+      className={`fixed inset-0 z-2000 flex flex-col justify-center items-center bg-bg-inverse/50 overflow-hidden transition duration-200 ${
         isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
       }`}
       onClick={onModalClick}
@@ -66,7 +66,7 @@ export const Modal = ({
         <div className={allContentClasses}>
           <div className="mb-3 flex flex-row-reverse justify-between items-center gap-3">
             {showCloseButton && (
-              <button role="button" title="Dismiss modal" onClick={onClose} className="text-icon-standard">
+              <button role="button" title="Dismiss modal" onClick={onClose} className="text-elem-icon">
                 <X size="18" />
               </button>
             )}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -166,7 +166,7 @@ export const NavSearch = () => {
 
       {/* Results */}
       {isFocused && (
-        <div className="absolute top-0 left-0 z-20 right-0 min-h-[56px] outline -outline-offset-1 outline-border-lighter rounded-xl bg-surface-light shadow-lg">
+        <div className="absolute top-0 left-0 z-20 right-0 min-h-[56px] outline -outline-offset-1 outline-[#ececec] rounded-xl bg-surface-light shadow-lg">
           {showResults && (
             <div className="flex flex-col gap-3 p-2 pt-[56px]">
               {/* Geographies */}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -172,13 +172,17 @@ export const NavSearch = () => {
               {/* Geographies */}
               {geographyResults.length > 0 && (
                 <div>
-                  <h3 className="px-2.5 py-1.5 mb-1 text-text-brand text-sm font-medium select-none">Geographies</h3>
+                  <h3 className="px-2.5 py-1.5 mb-1 text-text-[#0038a9] text-sm font-medium select-none">Geographies</h3>
                   {geographyResults.map((geography) => (
                     <NavSearchSuggestion
                       key={geography.id}
                       href={`/geographies/${geography.slug}`}
                       Icon={
-                        <ArrowRight height="16" width="16" className="opacity-0 group-hover:opacity-100 text-text-brand transition duration-200" />
+                        <ArrowRight
+                          height="16"
+                          width="16"
+                          className="opacity-0 group-hover:opacity-100 text-text-[#0038a9] transition duration-200"
+                        />
                       }
                       onClick={handleSuggestionClick}
                     >
@@ -194,7 +198,7 @@ export const NavSearch = () => {
                 Icon={<Search height="16" width="16" />}
                 hint={
                   <div className="text-xs text-text-tertiary font-[440]">
-                    Press <CornerDownLeft height="12" width="12" className="inline group-hover:text-text-brand transition duration-200" /> ENTER
+                    Press <CornerDownLeft height="12" width="12" className="inline group-hover:text-text-[#0038a9] transition duration-200" /> ENTER
                   </div>
                 }
                 onClick={handleSuggestionClick}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -172,17 +172,13 @@ export const NavSearch = () => {
               {/* Geographies */}
               {geographyResults.length > 0 && (
                 <div>
-                  <h3 className="px-2.5 py-1.5 mb-1 text-text-[#0038a9] text-sm font-medium select-none">Geographies</h3>
+                  <h3 className="px-2.5 py-1.5 mb-1 text-[#0038a9] text-sm font-medium select-none">Geographies</h3>
                   {geographyResults.map((geography) => (
                     <NavSearchSuggestion
                       key={geography.id}
                       href={`/geographies/${geography.slug}`}
                       Icon={
-                        <ArrowRight
-                          height="16"
-                          width="16"
-                          className="opacity-0 group-hover:opacity-100 text-text-[#0038a9] transition duration-200"
-                        />
+                        <ArrowRight height="16" width="16" className="opacity-0 group-hover:opacity-100 text-[#0038a9] transition duration-200" />
                       }
                       onClick={handleSuggestionClick}
                     >
@@ -198,7 +194,7 @@ export const NavSearch = () => {
                 Icon={<Search height="16" width="16" />}
                 hint={
                   <div className="text-xs text-text-tertiary font-[440]">
-                    Press <CornerDownLeft height="12" width="12" className="inline group-hover:text-text-[#0038a9] transition duration-200" /> ENTER
+                    Press <CornerDownLeft height="12" width="12" className="inline group-hover:text-[#0038a9] transition duration-200" /> ENTER
                   </div>
                 }
                 onClick={handleSuggestionClick}

--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -166,7 +166,7 @@ export const NavSearch = () => {
 
       {/* Results */}
       {isFocused && (
-        <div className="absolute top-0 left-0 z-20 right-0 min-h-[56px] outline -outline-offset-1 outline-[#ececec] rounded-xl bg-surface-light shadow-lg">
+        <div className="absolute top-0 left-0 z-20 right-0 min-h-[56px] outline -outline-offset-1 outline-[#ececec] rounded-xl bg-bg-primary shadow-lg">
           {showResults && (
             <div className="flex flex-col gap-3 p-2 pt-[56px]">
               {/* Geographies */}

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -59,7 +59,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
     <div className="h-[40px] overflow-visible">
       <div
         ref={ref}
-        className={`flex flex-col bg-surface-light -outline-offset-1 outline-border-lighter rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
+        className={`flex flex-col bg-surface-light -outline-offset-1 outline-[#ececec] rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
       >
         {dropdownOptions.map((option, optionIndex) => (
           <button

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -69,7 +69,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
             className={`w-full flex items-center justify-between gap-2 text-sm leading-4 font-medium text-nowrap cursor-pointer
           ${
             isOpen
-              ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
+              ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-inverse focus:outline-0"
               : "h-[40px] px-3 bg-[#f5f5f5] rounded-md hover:text-text-primary"
           }
           ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -70,7 +70,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
           ${
             isOpen
               ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-light focus:outline-0"
-              : "h-[40px] px-3 bg-surface-ui rounded-md hover:text-text-primary"
+              : "h-[40px] px-3 bg-[#f5f5f5] rounded-md hover:text-text-primary"
           }
           ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}
           >

--- a/src/components/molecules/navSearch/NavSearchDropdown.tsx
+++ b/src/components/molecules/navSearch/NavSearchDropdown.tsx
@@ -57,10 +57,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
 
   return (
     <div className="h-[40px] overflow-visible">
-      <div
-        ref={ref}
-        className={`flex flex-col bg-surface-light -outline-offset-1 outline-[#ececec] rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}
-      >
+      <div ref={ref} className={`flex flex-col bg-bg-primary -outline-offset-1 outline-[#ececec] rounded-md ${isOpen ? "p-1 gap-0.5 outline" : ""}`}>
         {dropdownOptions.map((option, optionIndex) => (
           <button
             key={option.name}
@@ -69,7 +66,7 @@ export const NavSearchDropdown = ({ contextualSearchName, isEverything, setIsEve
             className={`w-full flex items-center justify-between gap-2 text-sm leading-4 font-medium text-nowrap cursor-pointer
           ${
             isOpen
-              ? "h-[32px] px-2 hocus:bg-surface-mono-dark rounded-xs text-text-primary hocus:text-text-inverse focus:outline-0"
+              ? "h-[32px] px-2 hocus:bg-bg-inverse rounded-xs text-text-primary hocus:text-text-inverse focus:outline-0"
               : "h-[40px] px-3 bg-[#f5f5f5] rounded-md hover:text-text-primary"
           }
           ${optionIndex > 0 && !isOpen ? "!h-0 overflow-hidden" : ""}`}

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -20,7 +20,7 @@ export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick, query
     onClick={onClick}
     className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-[#f5f5f5] transition duration-200 group"
   >
-    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-[#0038a9] transition duration-200" : ""}`}>{Icon}</div>
+    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-[#0038a9] transition duration-200" : ""}`}>{Icon}</div>
     <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>
     {hint}
   </PageLink>

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -18,9 +18,9 @@ export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick, query
     href={href}
     query={query}
     onClick={onClick}
-    className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-surface-ui transition duration-200 group"
+    className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-[#f5f5f5] transition duration-200 group"
   >
-    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-brand transition duration-200" : ""}`}>{Icon}</div>
+    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-text-[#0038a9] transition duration-200" : ""}`}>{Icon}</div>
     <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>
     {hint}
   </PageLink>

--- a/src/components/molecules/navSearch/NavSearchSuggestion.tsx
+++ b/src/components/molecules/navSearch/NavSearchSuggestion.tsx
@@ -20,7 +20,7 @@ export const NavSearchSuggestion = ({ children, hint, href, Icon, onClick, query
     onClick={onClick}
     className="flex items-center gap-2 px-2.5 py-2 rounded-md hocus:bg-[#f5f5f5] transition duration-200 group"
   >
-    <div className={`w-4 shrink-0 ${Icon ? "text-icon-standard group-hover:text-[#0038a9] transition duration-200" : ""}`}>{Icon}</div>
+    <div className={`w-4 shrink-0 ${Icon ? "text-elem-icon group-hover:text-[#0038a9] transition duration-200" : ""}`}>{Icon}</div>
     <div className="flex-1 text-sm leading-4 text-text-secondary font-medium">{children}</div>
     {hint}
   </PageLink>

--- a/src/components/molecules/section/Section.tsx
+++ b/src/components/molecules/section/Section.tsx
@@ -37,15 +37,15 @@ export const Section = ({ badge, block, children, count, Icon, id, title, wide =
   return (
     <section className={sectionClasses} id={sectionId} role="region">
       {title && (
-        <h2 className="block col-start-1 -col-end-1 mb-5 text-2xl text-gray-950 font-heavy leading-tight">
+        <h2 className="block col-start-1 -col-end-1 mb-5 text-2xl text-[#030712] font-heavy leading-tight">
           {Icon && (
             <span>
-              <Icon size={22} className="inline mb-1.5 text-brand" />
+              <Icon size={22} className="inline mb-1.5 text-[#0038a9]" />
               &nbsp;
             </span>
           )}
           <span>{title}</span>
-          {count !== undefined && <span className="text-gray-500 font-normal">&nbsp;&nbsp;{count}</span>}
+          {count !== undefined && <span className="text-[#6b7280] font-normal">&nbsp;&nbsp;{count}</span>}
           {badge && (
             <span>
               &nbsp;&nbsp;<Badge className="align-middle">{badge}</Badge>

--- a/src/components/molecules/toggleGroup/ToggleGroup.tsx
+++ b/src/components/molecules/toggleGroup/ToggleGroup.tsx
@@ -28,7 +28,7 @@ export const ToggleGroup = <ToggleId extends string>({
 }: IProps<ToggleId>) => {
   const allGroupClasses = joinTailwindClasses("inline-flex gap-1", groupClasses);
   const allButtonClasses = joinTailwindClasses(
-    "rounded-full text-base text-gray-700 font-heavy leading-none data-[pressed]:bg-gray-950 data-[pressed]:text-white",
+    "rounded-full text-base text-[#374151] font-heavy leading-none data-[pressed]:bg-[#030712] data-[pressed]:text-white",
     buttonSize === "medium" ? "px-3 py-2 text-base" : "px-4 py-2.5 text-lg",
     buttonClasses
   );

--- a/src/components/molecules/tutorials/TutorialBanner.tsx
+++ b/src/components/molecules/tutorials/TutorialBanner.tsx
@@ -19,14 +19,14 @@ export const TutorialBanner = ({ name, banner: { buttonPrimary, buttonSecondary,
 
   return (
     <div className="flex gap-x-4 gap-y-3 justify-center items-center flex-wrap p-3 bg-[#005eeb] pointer-events-auto select-none">
-      <span className="text-sm leading-normal text-text-light">{text}</span>
+      <span className="text-sm leading-normal text-text-inverse">{text}</span>
       <div className="flex gap-2">
         <TutorialButton
           {...buttonPrimary}
           actions={buttonActions}
           name={name}
           use="banner"
-          className="border-border-light/75 hover:border-border-light hover:bg-transparent! text-text-light"
+          className="border-text-inverse/75 hover:border-text-inverse hover:bg-transparent! text-text-inverse"
         />
         {buttonSecondary && (
           <TutorialButton
@@ -34,7 +34,7 @@ export const TutorialBanner = ({ name, banner: { buttonPrimary, buttonSecondary,
             actions={buttonActions}
             name={name}
             use="banner"
-            className="text-text-light/75 hover:text-text-light hover:bg-transparent!"
+            className="text-text-inverse/75 hover:text-text-inverse hover:bg-transparent!"
           />
         )}
       </div>

--- a/src/components/molecules/tutorials/TutorialBanner.tsx
+++ b/src/components/molecules/tutorials/TutorialBanner.tsx
@@ -18,7 +18,7 @@ export const TutorialBanner = ({ name, banner: { buttonPrimary, buttonSecondary,
   };
 
   return (
-    <div className="flex gap-x-4 gap-y-3 justify-center items-center flex-wrap p-3 bg-surface-brand pointer-events-auto select-none">
+    <div className="flex gap-x-4 gap-y-3 justify-center items-center flex-wrap p-3 bg-[#005eeb] pointer-events-auto select-none">
       <span className="text-sm leading-normal text-text-light">{text}</span>
       <div className="flex gap-2">
         <TutorialButton

--- a/src/components/molecules/tutorials/TutorialCard.tsx
+++ b/src/components/molecules/tutorials/TutorialCard.tsx
@@ -23,7 +23,7 @@ export const TutorialCard = ({ className, name, card: { buttonPrimary, buttonSec
   return (
     <Card className={className}>
       {(title || close) && (
-        <div className="flex justify-end text-text-light">
+        <div className="flex justify-end text-text-inverse">
           {title && <span className="flex-1 text-sm leading-tight font-semibold">{title}</span>}
           {close && (
             <button type="button" onClick={buttonActions.dismiss}>
@@ -32,14 +32,14 @@ export const TutorialCard = ({ className, name, card: { buttonPrimary, buttonSec
           )}
         </div>
       )}
-      <p className="mt-1.5 mb-3 text-sm text-text-light/85">{text}</p>
+      <p className="mt-1.5 mb-3 text-sm text-text-inverse/85">{text}</p>
       <div className="flex gap-2">
         <TutorialButton
           {...buttonPrimary}
           actions={buttonActions}
           name={name}
           use="card"
-          className="border-border-light/75 hover:border-border-light hover:bg-transparent! text-text-light"
+          className="border-text-inverse/75 hover:border-text-inverse hover:bg-transparent! text-text-inverse"
         />
         {buttonSecondary && (
           <TutorialButton
@@ -47,7 +47,7 @@ export const TutorialCard = ({ className, name, card: { buttonPrimary, buttonSec
             actions={buttonActions}
             name={name}
             use="card"
-            className="text-text-light/75 hover:text-text-light hover:bg-transparent!"
+            className="text-text-inverse/75 hover:text-text-inverse hover:bg-transparent!"
           />
         )}
       </div>

--- a/src/components/molecules/viewMore/ViewMore.tsx
+++ b/src/components/molecules/viewMore/ViewMore.tsx
@@ -80,7 +80,7 @@ export const ViewMore = ({
         <button
           type="button"
           onClick={onViewMore}
-          className="p-2 mt-3 hover:bg-gray-50 active:bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 leading-4 font-medium"
+          className="p-2 mt-3 hover:bg-[#f9fafb] active:bg-[#f3f4f6] border border-[#d1d5db] rounded-md text-sm text-[#374151] leading-4 font-medium"
           data-ph-capture-attribute-button-purpose="view-more"
           data-ph-capture-attribute-view-more-context={context}
           data-ph-capture-attribute-view-more-intent={onButtonClick || !isOpen ? "more" : "less"}

--- a/src/components/molecules/warning/Warning.tsx
+++ b/src/components/molecules/warning/Warning.tsx
@@ -49,7 +49,7 @@ export const Warning = ({ className, variant = "info", hideableId, children }: T
   return (
     <div className={joinTailwindClasses(baseClasses, bgColor, textColor, spacing, className)}>
       {hideableId && (
-        <button onClick={onHideClick} className="text-text-[#0038a9] absolute top-4 right-4 hover:opacity-80 transition-opacity">
+        <button onClick={onHideClick} className="text-[#0038a9] absolute top-4 right-4 hover:opacity-80 transition-opacity">
           <X size="16" />
         </button>
       )}{" "}

--- a/src/components/molecules/warning/Warning.tsx
+++ b/src/components/molecules/warning/Warning.tsx
@@ -21,7 +21,7 @@ export const Warning = ({ className, variant = "info", hideableId, children }: T
   if (variant)
     switch (variant) {
       case "info":
-        bgColor = "bg-surface-brand/16";
+        bgColor = "bg-[#005eeb]/16";
         textColor = "text-black";
         break;
       case "error":

--- a/src/components/molecules/warning/Warning.tsx
+++ b/src/components/molecules/warning/Warning.tsx
@@ -49,7 +49,7 @@ export const Warning = ({ className, variant = "info", hideableId, children }: T
   return (
     <div className={joinTailwindClasses(baseClasses, bgColor, textColor, spacing, className)}>
       {hideableId && (
-        <button onClick={onHideClick} className="text-text-brand absolute top-4 right-4 hover:opacity-80 transition-opacity">
+        <button onClick={onHideClick} className="text-text-[#0038a9] absolute top-4 right-4 hover:opacity-80 transition-opacity">
           <X size="16" />
         </button>
       )}{" "}

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -118,7 +118,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
       {/* HEADER */}
       {showKnowledgeGraphTutorial && <TutorialCard name="knowledgeGraph" card={TUTORIALS.knowledgeGraph.card} />}
       <span className="text-base font-semibold text-text-primary">
-        <TextSearch size={20} className="inline mr-2 text-text-[#0038a9] align-text-bottom" />
+        <TextSearch size={20} className="inline mr-2 text-[#0038a9] align-text-bottom" />
         {title}
         {!showKnowledgeGraphTutorial && showBadge && <Badge className="ml-2">Beta</Badge>}
       </span>

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -179,7 +179,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
                   fixedHeight="100%"
                   startOpen={startOpen}
                   open={search === "" ? undefined : true}
-                  className="py-3 border-b border-border-lighter"
+                  className="py-3 border-b border-[#ececec]"
                 >
                   <div className="flex flex-col gap-2 pb-2">
                     {filteredTopics

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -118,7 +118,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
       {/* HEADER */}
       {showKnowledgeGraphTutorial && <TutorialCard name="knowledgeGraph" card={TUTORIALS.knowledgeGraph.card} />}
       <span className="text-base font-semibold text-text-primary">
-        <TextSearch size={20} className="inline mr-2 text-text-brand align-text-bottom" />
+        <TextSearch size={20} className="inline mr-2 text-text-[#0038a9] align-text-bottom" />
         {title}
         {!showKnowledgeGraphTutorial && showBadge && <Badge className="ml-2">Beta</Badge>}
       </span>

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -122,7 +122,7 @@ export const FamilyConceptPicker = ({
     <div className={`relative flex flex-col max-h-full pb-4 ${containerClasses}`} ref={ref}>
       {/* HEADER */}
       <span className="text-base font-semibold text-text-primary pb-4">
-        <TextSearch size={20} className="inline mr-2 text-text-brand align-text-bottom" />
+        <TextSearch size={20} className="inline mr-2 text-text-[#0038a9] align-text-bottom" />
         {title}
         {showBadge && <Badge className="ml-2">Beta</Badge>}
       </span>

--- a/src/components/organisms/FamilyConceptPicker.tsx
+++ b/src/components/organisms/FamilyConceptPicker.tsx
@@ -122,7 +122,7 @@ export const FamilyConceptPicker = ({
     <div className={`relative flex flex-col max-h-full pb-4 ${containerClasses}`} ref={ref}>
       {/* HEADER */}
       <span className="text-base font-semibold text-text-primary pb-4">
-        <TextSearch size={20} className="inline mr-2 text-text-[#0038a9] align-text-bottom" />
+        <TextSearch size={20} className="inline mr-2 text-[#0038a9] align-text-bottom" />
         {title}
         {showBadge && <Badge className="ml-2">Beta</Badge>}
       </span>

--- a/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
+++ b/src/components/organisms/contentsSideBar/ContentsSideBar.tsx
@@ -29,17 +29,17 @@ export const ContentsSideBar = <BlockId extends string = TBlock>({ items, sticky
     <aside className="relative pb-8 cols-4:pb-0 col-start-1 cols-4:col-end-3 -col-end-1 select-none">
       <div className={allStickyClasses}>
         <div className="inline-flex flex-col">
-          <h2 className="mb-4 text-2xl text-gray-950 font-heavy leading-tight cols-4:hidden">On this page</h2>
+          <h2 className="mb-4 text-2xl text-[#030712] font-heavy leading-tight cols-4:hidden">On this page</h2>
           {items.map((item) => {
             const isActive = "section-" + item.id === activeId;
 
             const buttonClasses = joinTailwindClasses(
               "pr-4 cols-4:pl-4 py-2 text-sm text-left group cols-4:border-l-2",
-              isActive ? "border-l-brand cols-4:text-gray-950 cols-4:font-heavy" : "border-l-transparent text-gray-700 hover:text-gray-950"
+              isActive ? "border-l-[#0038a9] cols-4:text-[#030712] cols-4:font-heavy" : "border-l-transparent text-[#374151] hover:text-[#030712]"
             );
             const contextClasses = joinTailwindClasses(
               "block pt-1 text-xs font-normal",
-              isActive ? "cols-4:text-gray-950" : "text-gray-500 group-hover:text-gray-950"
+              isActive ? "cols-4:text-[#030712]" : "text-[#6b7280] group-hover:text-[#030712]"
             );
 
             return (

--- a/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.stories.tsx
@@ -19,7 +19,7 @@ export default meta;
 type TWainwrightColumns = "height" | "link" | "number" | "region" | "summited" | "wainwright";
 const linkToCell = (link: string): TTableCell => ({
   label: (
-    <a href={link} className="underline decoration-gray-300">
+    <a href={link} className="underline decoration-[#d1d5db]">
       View
     </a>
   ),

--- a/src/components/organisms/interactiveTable/InteractiveTable.tsx
+++ b/src/components/organisms/interactiveTable/InteractiveTable.tsx
@@ -23,11 +23,11 @@ const DEFAULT_SORT_ICONS: Record<TTableOrder, LucideIcon> = {
 };
 
 const renderCellDisplay = (cell: TTableCell, showValues: boolean) => {
-  if (cell === null) return <span className="text-gray-500">{EN_DASH}</span>;
+  if (cell === null) return <span className="text-[#6b7280]">{EN_DASH}</span>;
 
   let content: ReactNode = `${cell}`;
   if (typeof cell === "object") content = showValues ? cell.value : cell.label;
-  return showValues ? <div className="inline-block bg-surface-ui text-sm text-text-tertiary font-mono">{`${content}`}</div> : content;
+  return showValues ? <div className="inline-block bg-[#f5f5f5] text-sm text-text-tertiary font-mono">{`${content}`}</div> : content;
 };
 
 interface IProps<ColumnKey extends string> {
@@ -90,7 +90,7 @@ export const InteractiveTable = <ColumnKey extends string>({
     const menuIsOpen = openSortMenu === column.id;
 
     const sortButtonClasses = joinTailwindClasses(
-      "p-1 rounded-sm focus-visible:outline-none text-gray-500",
+      "p-1 rounded-sm focus-visible:outline-none text-[#6b7280]",
       !columnIsSorted && !menuIsOpen && "invisible group-hover:visible"
     );
 
@@ -143,18 +143,18 @@ export const InteractiveTable = <ColumnKey extends string>({
     );
   };
 
-  const allTableClasses = joinTailwindClasses("grid text-table text-gray-700 leading-5 cursor-default", tableClasses);
+  const allTableClasses = joinTailwindClasses("grid text-table text-[#374151] leading-5 cursor-default", tableClasses);
   const gridTemplateColumns = columns.map((column) => `${column.fraction || 1}fr`).join(" ");
-  const commonCellClasses = "px-3 py-2 not-first:border-l border-gray-300";
+  const commonCellClasses = "px-3 py-2 not-first:border-l border-[#d1d5db]";
 
   return (
-    <div className="bg-white border border-gray-300 rounded-md overflow-x-auto">
+    <div className="bg-white border border-[#d1d5db] rounded-md overflow-x-auto">
       <div className={allTableClasses} style={{ gridTemplateColumns }} role="table">
         {/* Heading */}
         <div className="contents" role="row">
           {columns.map((column) => {
             const cellClasses = joinTailwindClasses(
-              "bg-gray-100 text-gray-900 font-medium group",
+              "bg-[#f3f4f6] text-gray-900 font-medium group",
               column.sortable && "pr-2",
               commonCellClasses,
               column.classes
@@ -166,7 +166,7 @@ export const InteractiveTable = <ColumnKey extends string>({
                   <span className="block">{column.name || firstCase(column.id)}</span>
                   {column.tooltip && (
                     <Tooltip content={column.tooltip} popupClasses="text-wrap max-w-62">
-                      <LucideInfo size={16} className="text-gray-500 leading-5" />
+                      <LucideInfo size={16} className="text-[#6b7280] leading-5" />
                     </Tooltip>
                   )}
                   {column.sortable === true && renderSortControls(column)}
@@ -186,7 +186,7 @@ export const InteractiveTable = <ColumnKey extends string>({
             const cellClasses = joinTailwindClasses(
               "border-t",
               commonCellClasses,
-              isClickable && "group-hover:bg-gray-100 cursor-pointer",
+              isClickable && "group-hover:bg-[#f3f4f6] cursor-pointer",
               column.classes,
               row.classes
             );

--- a/src/components/organisms/pageHeader/PageHeader.tsx
+++ b/src/components/organisms/pageHeader/PageHeader.tsx
@@ -37,24 +37,24 @@ export const PageHeader = <TabId extends string>({
   title,
 }: TProps<TabId>) => {
   const hasTabs = tabs.length > 0;
-  const containerClasses = joinTailwindClasses("pt-9", hasTabs ? "pb-6" : "pb-12", dark && "mb-8 bg-gray-100");
+  const containerClasses = joinTailwindClasses("pt-9", hasTabs ? "pb-6" : "pb-12", dark && "mb-8 bg-[#f3f4f6]");
 
   return (
     <div className={containerClasses}>
       <FiveColumns verticalGap>
-        <div className="col-span-2">{label && <h2 className="text-3xl text-gray-500 leading-9 font-heavy">{label}</h2>}</div>
+        <div className="col-span-2">{label && <h2 className="text-3xl text-[#6b7280] leading-9 font-heavy">{label}</h2>}</div>
         <div className="col-start-1 cols-4:col-start-3 -col-end-1 cols-5:col-end-9 flex flex-col gap-6">
           {/* Title */}
 
-          <h1 className="text-3xl text-gray-950 leading-9 font-heavy">{title}</h1>
+          <h1 className="text-3xl text-[#030712] leading-9 font-heavy">{title}</h1>
 
           {/* Metadata */}
           {metadata.length > 0 && (
             <div className="grid grid-cols-[min-content_auto] gap-x-8 gap-y-2 text-sm">
               {metadata.map((property, index) => (
                 <Fragment key={index}>
-                  <div className="text-gray-950 font-medium whitespace-nowrap">{property.label}</div>
-                  <div className="text-gray-700">{property.value}</div>
+                  <div className="text-[#030712] font-medium whitespace-nowrap">{property.label}</div>
+                  <div className="text-[#374151]">{property.value}</div>
                 </Fragment>
               ))}
             </div>

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -43,7 +43,7 @@ const SearchResult = ({ family, active, onClick, position, positionOffset }: IPr
           <button
             type="button"
             onClick={onClick}
-            className="text-text-[#0038a9] flex items-center"
+            className="text-[#0038a9] flex items-center"
             aria-label={matchesText}
             data-analytics="search-result-matches-button"
             data-slug={family_slug}

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -43,7 +43,7 @@ const SearchResult = ({ family, active, onClick, position, positionOffset }: IPr
           <button
             type="button"
             onClick={onClick}
-            className="text-text-brand flex items-center"
+            className="text-text-[#0038a9] flex items-center"
             aria-label={matchesText}
             data-analytics="search-result-matches-button"
             data-slug={family_slug}

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -29,7 +29,7 @@ const SearchResultList = ({ category, families, activeFamilyIndex, onClick, offs
       <>
         <p className="my-4 md:mt-0">
           Visit the{" "}
-          <PageLink external href="https://www.climatecasechart.com/" className="text-brand underline">
+          <PageLink external href="https://www.climatecasechart.com/" className="text-[#0038a9] underline">
             Climate Litigation Database
           </PageLink>{" "}
           to see litigation documents.

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -13,7 +13,7 @@ const Tooltip = ({ id, tooltip, icon = "?", place, interactableContent, colour }
   let colourCss = "";
   switch (colour) {
     case "grey":
-      colourCss = "text-textNormal border-gray-500";
+      colourCss = "text-[#505050] border-gray-500";
       break;
     default:
       colourCss = "text-blue-600 border-blue-600";

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -13,7 +13,7 @@ const Tooltip = ({ id, tooltip, icon = "?", place, interactableContent, colour }
   let colourCss = "";
   switch (colour) {
     case "grey":
-      colourCss = "text-[#505050] border-gray-500";
+      colourCss = "text-[#505050] border-[#6b7280]";
       break;
     default:
       colourCss = "text-blue-600 border-blue-600";

--- a/src/components/typography/Heading.tsx
+++ b/src/components/typography/Heading.tsx
@@ -8,7 +8,7 @@ interface IProps {
 }
 
 // Dev note: because we have dynamic content that we may not have control over, please update the style.css with the corresponding html heading tags
-const coreClasses = "text-textDark font-medium";
+const coreClasses = "text-[#202020] font-medium";
 const h1Classes = "text-4xl";
 const h2Classes = "text-2xl mb-5";
 const h3Classes = "text-xl mb-5";

--- a/src/hooks/useFamilyPageHeaderData.tsx
+++ b/src/hooks/useFamilyPageHeaderData.tsx
@@ -107,7 +107,7 @@ export const useFamilyPageHeaderData = ({ countries, family, subdivisions }: IPr
           &ensp;
           <button
             role="button"
-            className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+            className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
             onClick={scrollToBlock("metadata")}
           >
             +{hiddenGeographiesCount} {pluralise(hiddenGeographiesCount, ["other", "others"])}
@@ -148,7 +148,7 @@ export const useFamilyPageHeaderData = ({ countries, family, subdivisions }: IPr
                 <button
                   key={collection.import_id}
                   role="button"
-                  className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+                  className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
                   onClick={scrollToBlock("collections")}
                 >
                   {collection.title}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -747,7 +747,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                               )}
                               {showSearchOnboarding(router.query) && (
                                 <Warning variant="info" hideableId="search-onboarding-info">
-                                  <p className="font-semibold text-text-[#0038a9]">Get better results</p>
+                                  <p className="font-semibold text-[#0038a9]">Get better results</p>
                                   <p>
                                     {getAppText("searchOnboarding")}
                                     {features.knowledgeGraph && (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -443,7 +443,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
           <SlideOutContext.Provider value={{ currentSlideOut, setCurrentSlideOut }}>
             <WikiBaseConceptsContext.Provider value={familyConceptsData || []}>
               <section>
-                <div className="md:flex justify-between items-center border-b border-gray-300">
+                <div className="md:flex justify-between items-center border-b border-[#d1d5db]">
                   <BreadCrumbs label={"Search results"} />
                   <div className="px-2 cols-2:px-4 cols-3:px-6 cols-4:px-8">
                     <span className="text-sm mb-4 md:mb-0 text-right flex flex-wrap gap-x-2 md:justify-end">
@@ -496,7 +496,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                       <Loader size="20px" />
                     ) : (
                       <>
-                        <div className="sticky cols-4:top-[72px] h-screen cols-4:h-[calc(100vh-72px)] px-5 cols-4:border-r border-gray-300 pt-5 pb-[180px] overflow-y-auto scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-gray-500 cols-4:pb-4">
+                        <div className="sticky cols-4:top-[72px] h-screen cols-4:h-[calc(100vh-72px)] px-5 cols-4:border-r border-[#d1d5db] pt-5 pb-[180px] overflow-y-auto scrollbar-thumb-gray-200 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full hover:scrollbar-thumb-[#6b7280] cols-4:pb-4">
                           <SearchFilters
                             searchCriteria={searchQuery}
                             query={router.query}
@@ -602,7 +602,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                                             <PageLink
                                               external
                                               href="mailto:manager@climatecasechart.com"
-                                              className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+                                              className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
                                             >
                                               manager@climatecasechart.com
                                             </PageLink>{" "}
@@ -624,7 +624,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                                 <div className="shrink-0 flex flex-col lg:flex-row gap-1 lg:gap-4">
                                   <div className="relative z-10 -top-0.5 flex justify-end">
                                     <button
-                                      className={`flex items-center gap-1 px-2 py-1 -mt-1 rounded-md text-sm text-text-primary font-normal ${showSearchOptions ? "bg-surface-ui" : ""}`}
+                                      className={`flex items-center gap-1 px-2 py-1 -mt-1 rounded-md text-sm text-text-primary font-normal ${showSearchOptions ? "bg-[#f5f5f5]" : ""}`}
                                       onClick={() => setShowSearchOptions(!showSearchOptions)}
                                       data-cy="search-options"
                                       ref={searchSettingsButtonRef}
@@ -658,7 +658,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                                   </div>
                                   <div className="relative z-8 -top-0.5 flex justify-end">
                                     <button
-                                      className={`flex items-center gap-1 px-2 py-1 -mt-1 rounded-md text-sm text-text-primary font-normal ${showSortOptions ? "bg-surface-ui" : ""}`}
+                                      className={`flex items-center gap-1 px-2 py-1 -mt-1 rounded-md text-sm text-text-primary font-normal ${showSortOptions ? "bg-[#f5f5f5]" : ""}`}
                                       onClick={() => setShowSortOptions(!showSortOptions)}
                                       data-cy="search-options"
                                       ref={sortSettingsButtonRef}
@@ -747,7 +747,7 @@ const Search = ({ familyConceptsData, features, theme, themeConfig, topicsData }
                               )}
                               {showSearchOnboarding(router.query) && (
                                 <Warning variant="info" hideableId="search-onboarding-info">
-                                  <p className="font-semibold text-text-brand">Get better results</p>
+                                  <p className="font-semibold text-text-[#0038a9]">Get better results</p>
                                   <p>
                                     {getAppText("searchOnboarding")}
                                     {features.knowledgeGraph && (

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -23,7 +23,7 @@
   [type="text"],
   [type="search"],
   [type="number"] {
-    @apply text-text-primary p-2 bg-surface-ui border-border-light leading-[1.4] w-full;
+    @apply text-text-primary p-2 bg-[#f5f5f5] border-border-light leading-[1.4] w-full;
 
     &.extra-content-left {
       @apply pl-8;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -4,20 +4,20 @@
   [type="text"],
   [type="search"],
   [type="number"] {
-    @apply rounded border-borderNormal text-sm;
+    @apply rounded border-[#dedede] text-sm;
 
     &:hover {
-      @apply border-inputSelected;
+      @apply border-[#005eeb];
     }
 
     &:focus {
-      @apply outline-none outline-transparent ring-offset-0 ring-0 border-inputSelected;
+      @apply outline-none outline-transparent ring-offset-0 ring-0 border-[#005eeb];
     }
   }
 
   [type="checkbox"],
   [type="radio"] {
-    @apply text-inputSelected cursor-pointer;
+    @apply text-[#005eeb] cursor-pointer;
   }
 
   [type="text"],
@@ -66,16 +66,16 @@
   [type="checkbox"]:checked:focus {
     background: none;
     background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23ffffff' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-    @apply bg-inputSelected;
+    @apply bg-[#005eeb];
   }
 
   [type="radio"]:checked,
   [type="radio"]:checked:focus {
     background: none;
-    @apply bg-white border-[8px] border-inputSelected;
+    @apply bg-white border-[8px] border-[#005eeb];
 
     &:hover {
-      @apply border-inputSelected bg-white;
+      @apply border-[#005eeb] bg-white;
     }
   }
 
@@ -105,7 +105,7 @@
   .semi-checked [type="checkbox"]:checked:focus {
     background: none;
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3e%3cpath d='M3.33331 8H12.6666' stroke='white' stroke-width='2'/%3e%3c/svg%3e");
-    @apply bg-inputSelected;
+    @apply bg-[#005eeb];
   }
 }
 
@@ -121,7 +121,7 @@ html,
 }
 
 body {
-  @apply text-textNormal font-inter;
+  @apply text-[#505050] font-inter;
 }
 
 input[type="text"],
@@ -141,7 +141,7 @@ a,
 
 a.alt,
 .anchor.alt {
-  @apply underline text-textNormal hover:text-blue-800;
+  @apply underline text-[#505050] hover:text-blue-800;
 }
 
 a.button {
@@ -166,7 +166,7 @@ hr {
   @apply my-6;
 }
 .form-row__border {
-  @apply border-b border-cpr-dark py-6;
+  @apply border-b border-[#071e4a] py-6;
 }
 
 select {
@@ -267,7 +267,7 @@ input[type="search"]::-webkit-search-results-decoration {
 
 /* Tooltips styles to override the default */
 .customTooltip {
-  @apply z-50! text-sm! bg-nearBlack! border-nearBlack! rounded-lg! leading-5! max-w-[300px]! opacity-100! pointer-events-auto!;
+  @apply z-50! text-sm! bg-[#101010]! border-[#101010]! rounded-lg! leading-5! max-w-[300px]! opacity-100! pointer-events-auto!;
 }
 .customTooltip:hover {
   visibility: visible !important;
@@ -280,7 +280,7 @@ input[type="search"]::-webkit-search-results-decoration {
   filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2)) !important;
 }
 .customTooltip.place-top:after {
-  border-top-color: cpr-dark !important;
+  border-top-color: #071e4a !important;
   border-top-style: solid !important;
   border-top-width: 6px !important;
 }
@@ -288,7 +288,7 @@ input[type="search"]::-webkit-search-results-decoration {
   filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2)) !important;
 }
 .customTooltip.place-left:after {
-  border-left-color: cpr-dark !important;
+  border-left-color: #071e4a !important;
   border-left-style: solid !important;
   border-left-width: 6px !important;
 }
@@ -296,7 +296,7 @@ input[type="search"]::-webkit-search-results-decoration {
   filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2)) !important;
 }
 .customTooltip.place-right:after {
-  border-right-color: cpr-dark !important;
+  border-right-color: #071e4a !important;
   border-right-style: solid !important;
   border-right-width: 6px !important;
 }
@@ -304,7 +304,7 @@ input[type="search"]::-webkit-search-results-decoration {
   filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2)) !important;
 }
 .customTooltip.place-bottom:after {
-  border-bottom-color: cpr-dark !important;
+  border-bottom-color: #071e4a !important;
   border-bottom-style: solid !important;
   border-bottom-width: 6px !important;
 }
@@ -359,7 +359,7 @@ ul li.selected {
 .search-results b,
 .search-results strong,
 .search-results .bold {
-  @apply font-medium text-textDark;
+  @apply font-medium text-[#202020];
 }
 .text-content i,
 .text-content em,
@@ -369,7 +369,7 @@ ul li.selected {
 }
 .text-content a.accordion-item,
 .search-results a.accordion-item {
-  @apply text-textNormal text-lg cursor-pointer flex items-center no-underline hover:no-underline md:text-xl;
+  @apply text-[#505050] text-lg cursor-pointer flex items-center no-underline hover:no-underline md:text-xl;
 }
 .text-content a {
   @apply text-blue-600 underline hover:text-blue-800;
@@ -399,7 +399,7 @@ ul li.selected {
 }
 .text-content .m-table .row.heading,
 .search-results .m-table .row.heading {
-  @apply text-textDark font-medium;
+  @apply text-[#202020] font-medium;
 }
 .text-content .m-table .row .term,
 .search-results .m-table .row .term {
@@ -445,7 +445,7 @@ ul li.selected {
 .search-results h4,
 .search-results h5,
 .search-results h6 {
-  @apply font-medium text-textDark;
+  @apply font-medium text-[#202020];
 }
 .text-content h1,
 .search-results h1 {
@@ -540,7 +540,7 @@ ul li.selected {
   }
 }
 .family-document:hover .matches-button {
-  @apply bg-cpr-dark;
+  @apply bg-[#071e4a];
 }
 
 .arrow {
@@ -585,7 +585,7 @@ ul li.selected {
 }
 
 #mapToolTip {
-  @apply text-textNormal bg-white p-4 rounded-lg drop-shadow border border-gray-300 opacity-100;
+  @apply text-[#505050] bg-white p-4 rounded-lg drop-shadow border border-gray-300 opacity-100;
 }
 
 .middot-between > span:after {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,39 +1,52 @@
 @theme {
   /* CPR Design System variables (June 2026) */
 
-  --color-border-normal: #101a2429;
-  --color-border-light: #101a241f;
-  --color-border-checkbox: #101a2452;
+  /* Color / ID Core */
+  --color-white: #FFFFFF;
+  --color-paper: #FBFBF9;
+  --color-recycled-paper: #E5E3DC;
+  --color-inky-blue: #1A4F8C;
+  --color-inky-navy: #133051;
+  --color-inky-black: #101A24;
 
-  /* NEW SEARCH */
+  /* Color / ID Extended */
+  --color-light-blue: #C6DDE8;
+  --color-mustard: #C8B500;
+  --color-green: #A0AF54;
+  --color-forest: #164F4A;
+  --color-cardboard: #B7AE8E;
 
-  --color-inky-blue: #1a4f8c;
-  --color-inky-black: #101a24;
-  --color-recycled-paper: #e5e3dc;
-  --color-transparent-regular: rgba(13, 26, 37, 0.16);
-  --color-transparent-light: rgba(13, 26, 37, 0.12);
-  --color-transparent-checkbox: rgba(13, 26, 37, 0.32);
+  /* Color / UI / Background */
+  --color-bg-primary: var(--color-white);
+  --color-bg-inverse: var(--color-inky-black);
+  --color-bg-flat: var(--color-neutral-100);
 
-  /* REFERENCES FROM FIGMA - BECAUSE THE VARIABLE SYSTEM IS DRIVING ME MAD */
-  /*
-  TEXT:
-  Primary: inky-black
-  Secondary: neutral-600
-  Tertiary: neutral-500
-  Inverse: white
-  Brand: inky-blue
-  Disabled: neutral-400
+  /* Color / UI / Text */
+  --color-text-primary: var(--color-inky-black);
+  --color-text-secondary: var(--color-neutral-600);
+  --color-text-tertiary: var(--color-neutral-500);
+  --color-text-inverse: var(--color-white);
+  --color-text-brand: var(--color-inky-blue);
+  --color-text-disabled: var(--color-neutral-400);
 
-  BACKGROUND:
-  Primary: white
-  Inverse: inky-black
-  Flat: neutral-100
+  /* Color / UI / Element */
+  --color-elem-icon: var(--color-neutral-500);
+  --color-elem-focus: var(--color-neutral-200);
 
-  ELEMENT:
-  Icon: neutral-500
-  Focus: neutral-200
+  /* Color / UI / Border */
+  --color-border-normal: #101A2429;
+  --color-border-light: #101A241F;
+  --color-border-checkbox: #101A2452;
 
-  */
+  /* Font / Weight */
+  --font-weight-normal: 400;
+  --font-weight-medium: 550;
+  --font-weight-heavy: 650;
+
+  /* Font / Size */
+  --text-table: 15px;
+
+  /* DEPRECATED BELOW THIS LINE --------------- */
 
   /* COLOURS */
 
@@ -135,12 +148,6 @@
     "greycliff-cf", "InterVariable", "Inter", "ui-sans-serif", "system-ui", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji"; /* MCF */
   --font-display--font-feature-settings: "ss03", "cv05";
-
-  --text-table: 15px;
-
-  --font-weight-normal: 400;
-  --font-weight-medium: 550;
-  --font-weight-heavy: 650;
 
   /* SIZING */
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,5 +1,5 @@
 @theme {
-  /* CPR Design System variables (June 2026) */
+  /* -- CPR Design System variables (June 2026) -- */
 
   /* Color / ID Core */
   --color-white: #FFFFFF;
@@ -43,16 +43,59 @@
   --font-weight-medium: 550;
   --font-weight-heavy: 650;
 
+  /* Font / Family */
+  --font-inter:
+    "InterVariable", "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-display--font-feature-settings: "ss03", "cv05";
+
   /* Font / Size */
   --text-table: 15px;
+
+  /* -- App-specific variables -- */
+
+  --color-cclw-dark: #2e3152;
+  --color-cclw-light: #414466;
+
+  --color-mcf-blue: #082c43;
+  --color-mcf-iconGrey: #7a7a7a;
+  --color-mcf-blueOpacity64: rgba(8, 44, 67, 0.64);
+
+  --color-oep-dark-blue: #080840;
+  --color-oep-royal-blue: #08084c;
+  --color-oep-salmon: #ff4f58;
+
+  --font-tenez: "tenez", "system-ui", serif; /* OEP */
+  --font-greycliff:
+    "greycliff-cf", "InterVariable", "Inter", "ui-sans-serif", "system-ui", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji"; /* MCF */
+
+  /* -- Other variables -- */
+
+  --radius-4xl: 30px;
+
+  --spacing-maxSiteWidth: var(--MAX_SITE_WIDTH);
+  --spacing-maxContent: var(--MAX_CONTENT_WIDTH);
+  --spacing-maxSidebar: var(--MAX_SIDEBAR_WIDTH);
+  --spacing-max-cols: 1500px;
+
+  /* FiveColumns breakpoints */
+  --breakpoint-cols-2: 500px;
+  --breakpoint-cols-3: 700px;
+  --breakpoint-cols-4: 900px;
+  --breakpoint-cols-5: 1100px;
+
+  --shadow-lg: 0px 4px 48px 0px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0px 4px 16px 0px rgba(0, 0, 0, 0.08);
+  --shadow-xs: 0px 2px 2px 0px rgba(0, 0, 0, 0.08);
+  --shadow-oep: 0px 8px 44px 0px rgba(32, 32, 32, 0.16);
+
+  --tracking-slight: 0.015em;
 
   /* DEPRECATED BELOW THIS LINE --------------- */
 
   /* COLOURS */
 
   --color-brand: #0038a9;
-  --color-white: #ffffff;
-
   --color-gray-50: #f9fafb; /* Surfaces */
   --color-gray-100: #f3f4f6;
   --color-gray-300: #d1d5db; /* Borders */
@@ -76,17 +119,6 @@
   --color-cpr-dark: #071e4a;
   --color-cpr-banner: #00244d;
 
-  --color-cclw-dark: #2e3152;
-  --color-cclw-light: #414466;
-
-  --color-oep-dark-blue: #080840;
-  --color-oep-royal-blue: #08084c;
-  --color-oep-salmon: #ff4f58;
-
-  --color-mcf-blue: #082c43;
-  --color-mcf-iconGrey: #7a7a7a;
-  --color-mcf-blueOpacity64: rgba(8, 44, 67, 0.64);
-
   --color-blue-50: #e9f4ff;
   --color-blue-100: #d2e9ff;
   --color-blue-200: #a5d4ff;
@@ -97,12 +129,9 @@
   --color-blue-700: #0075e3;
   --color-blue-800: #005cb2;
   --color-blue-900: #00417d;
-
   --color-blueGray-700: #394b6e;
   --color-blueGray-800: #071e4a;
-
   --color-red-600: #d92d20;
-
   --color-green-50: #ecfdf3;
   --color-green-100: #d1fadf;
   --color-green-500: #6ce9a6;
@@ -111,18 +140,13 @@
 
   --color-cpr-blue: #005eeb;
 
-  --color-text-primary: #202020;
-  --color-text-secondary: #505050;
-  --color-text-tertiary: #707070;
   --color-text-quaternary: #858585;
   --color-text-light: #ffffff;
-  --color-text-brand: #005eeb;
   --color-text-brand-darker: #002ca3;
 
   --color-icon-standard: #707070;
 
   --color-border-lighter: #ececec;
-  --color-border-light: #e5e5e5;
   --color-border-brand: #005eeb;
   --color-border-mono: #202020;
   --color-border-semi-transparent: #0000001a;
@@ -139,44 +163,10 @@
   --color-surface-mono: #202020;
   --color-surface-mono-dark: #000000;
 
-  /* TEXT */
-
-  --font-inter:
-    "InterVariable", "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-tenez: "tenez", "system-ui", serif; /* OEP */
-  --font-greycliff:
-    "greycliff-cf", "InterVariable", "Inter", "ui-sans-serif", "system-ui", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    "Noto Color Emoji"; /* MCF */
-  --font-display--font-feature-settings: "ss03", "cv05";
-
-  /* SIZING */
-
-  --radius-4xl: 30px;
-
-  --spacing-maxSiteWidth: var(--MAX_SITE_WIDTH);
-  --spacing-maxContent: var(--MAX_CONTENT_WIDTH);
-  --spacing-maxSidebar: var(--MAX_SIDEBAR_WIDTH);
-  --spacing-max-cols: 1500px;
-
-  /* BREAKPOINTS - BASED ON OUR FiveColumns COMPONENT LAYOUT */
-
-  --breakpoint-cols-2: 500px;
-  --breakpoint-cols-3: 700px;
-  --breakpoint-cols-4: 900px;
-  --breakpoint-cols-5: 1100px;
-
-  /* MISC */
-
-  --shadow-lg: 0px 4px 48px 0px rgba(0, 0, 0, 0.08);
-  --shadow-md: 0px 4px 16px 0px rgba(0, 0, 0, 0.08);
-  --shadow-xs: 0px 2px 2px 0px rgba(0, 0, 0, 0.08);
-  --shadow-oep: 0px 8px 44px 0px rgba(32, 32, 32, 0.16);
-
+  /* Last TODO */
   --container-1/2-gap-4: calc(50% - (1 / 2 * 1rem));
   --container-1/3-gap-4: calc(33.3% - (2 / 3 * 1rem));
   --container-1/4-gap-4: calc(25% - (3 / 4 * 1rem));
   --container-1/6-gap-4: calc(16.6% - (5 / 6 * 1rem));
   --container-maxContent: var(--MAX_CONTENT_WIDTH);
-
-  --tracking-slight: 0.015em;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -27,7 +27,7 @@
   --color-text-tertiary: var(--color-neutral-500);
   --color-text-inverse: var(--color-white);
   --color-text-brand: var(--color-inky-blue);
-  --color-text-disabled: var(--color-neutral-400);
+  --color-text-disabled: #a3a3a3;
 
   /* Color / UI / Element */
   --color-elem-icon: var(--color-neutral-500);
@@ -91,22 +91,6 @@
 
   --tracking-slight: 0.015em;
 
-  /* DEPRECATED BELOW THIS LINE --------------- */
-
-  /* COLOURS */
-
-  --color-brand: #0038a9;
-  --color-gray-50: #f9fafb; /* Surfaces */
-  --color-gray-100: #f3f4f6;
-  --color-gray-300: #d1d5db; /* Borders */
-  --color-gray-500: #6b7280; /* Light text & icons */
-  --color-gray-700: #374151; /* Regular text */
-  --color-gray-800: #1d2939;
-  --color-gray-950: #030712; /* Dark text & headings */
-
-  --color-neutral-400: #a3a3a3; /* Muted / disabled label text */
-
-  /* Last TODO */
   --container-1/2-gap-4: calc(50% - (1 / 2 * 1rem));
   --container-1/3-gap-4: calc(33.3% - (2 / 3 * 1rem));
   --container-1/4-gap-4: calc(25% - (3 / 4 * 1rem));

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,19 +2,19 @@
   /* -- CPR Design System variables (June 2026) -- */
 
   /* Color / ID Core */
-  --color-white: #FFFFFF;
-  --color-paper: #FBFBF9;
-  --color-recycled-paper: #E5E3DC;
-  --color-inky-blue: #1A4F8C;
+  --color-white: #ffffff;
+  --color-paper: #fbfbf9;
+  --color-recycled-paper: #e5e3dc;
+  --color-inky-blue: #1a4f8c;
   --color-inky-navy: #133051;
-  --color-inky-black: #101A24;
+  --color-inky-black: #101a24;
 
   /* Color / ID Extended */
-  --color-light-blue: #C6DDE8;
-  --color-mustard: #C8B500;
-  --color-green: #A0AF54;
-  --color-forest: #164F4A;
-  --color-cardboard: #B7AE8E;
+  --color-light-blue: #c6dde8;
+  --color-mustard: #c8b500;
+  --color-green: #a0af54;
+  --color-forest: #164f4a;
+  --color-cardboard: #b7ae8e;
 
   /* Color / UI / Background */
   --color-bg-primary: var(--color-white);
@@ -34,9 +34,9 @@
   --color-elem-focus: var(--color-neutral-200);
 
   /* Color / UI / Border */
-  --color-border-normal: #101A2429;
-  --color-border-light: #101A241F;
-  --color-border-checkbox: #101A2452;
+  --color-border-normal: #101a2429;
+  --color-border-light: #101a241f;
+  --color-border-checkbox: #101a2452;
 
   /* Font / Weight */
   --font-weight-normal: 400;
@@ -105,63 +105,6 @@
   --color-gray-950: #030712; /* Dark text & headings */
 
   --color-neutral-400: #a3a3a3; /* Muted / disabled label text */
-
-  /* Deprecated colours */
-
-  --color-nearBlack: #101010;
-  --color-transparent: transparent;
-  --color-textDark: #202020;
-  --color-textNormal: #505050;
-  --color-borderNormal: #dedede;
-  --color-input: #f5f5f5;
-  --color-inputSelected: #005eeb;
-
-  --color-cpr-dark: #071e4a;
-  --color-cpr-banner: #00244d;
-
-  --color-blue-50: #e9f4ff;
-  --color-blue-100: #d2e9ff;
-  --color-blue-200: #a5d4ff;
-  --color-blue-300: #79beff;
-  --color-blue-400: #1f93ff;
-  --color-blue-500: #1f93ff;
-  --color-blue-600: #1f93ff;
-  --color-blue-700: #0075e3;
-  --color-blue-800: #005cb2;
-  --color-blue-900: #00417d;
-  --color-blueGray-700: #394b6e;
-  --color-blueGray-800: #071e4a;
-  --color-red-600: #d92d20;
-  --color-green-50: #ecfdf3;
-  --color-green-100: #d1fadf;
-  --color-green-500: #6ce9a6;
-  --color-green-600: #039855;
-  --color-green-700: #027a48;
-
-  --color-cpr-blue: #005eeb;
-
-  --color-text-quaternary: #858585;
-  --color-text-light: #ffffff;
-  --color-text-brand-darker: #002ca3;
-
-  --color-icon-standard: #707070;
-
-  --color-border-lighter: #ececec;
-  --color-border-brand: #005eeb;
-  --color-border-mono: #202020;
-  --color-border-semi-transparent: #0000001a;
-
-  --color-scrollbar: #e4e7ec;
-  --color-scrollbar-darker: #707070;
-
-  --color-surface-light: #ffffff;
-  --color-surface-ui: #f5f5f5;
-  --color-surface-heavy: #e5e5e5;
-  --color-surface-brand: #005eeb;
-  --color-surface-brand-dark: #0049b8;
-  --color-surface-brand-darker: #002ca3;
-  --color-surface-mono: #202020;
-  --color-surface-mono-dark: #000000;
 
   /* Last TODO */
   --container-1/2-gap-4: calc(50% - (1 / 2 * 1rem));

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,11 +16,6 @@
   --color-forest: #164f4a;
   --color-cardboard: #b7ae8e;
 
-  /* Color / UI / Background */
-  --color-bg-primary: var(--color-white);
-  --color-bg-inverse: var(--color-inky-black);
-  --color-bg-flat: var(--color-neutral-100);
-
   /* Color / UI / Text */
   --color-text-primary: var(--color-inky-black);
   --color-text-secondary: var(--color-neutral-600);
@@ -29,14 +24,19 @@
   --color-text-brand: var(--color-inky-blue);
   --color-text-disabled: #a3a3a3;
 
-  /* Color / UI / Element */
-  --color-elem-icon: var(--color-neutral-500);
-  --color-elem-focus: var(--color-neutral-200);
+  /* Color / UI / Background */
+  --color-bg-primary: var(--color-white);
+  --color-bg-inverse: var(--color-inky-black);
+  --color-bg-flat: var(--color-neutral-100);
 
   /* Color / UI / Border */
   --color-border-normal: #101a2429;
   --color-border-light: #101a241f;
   --color-border-checkbox: #101a2452;
+
+  /* Color / UI / Element */
+  --color-elem-icon: var(--color-neutral-500);
+  --color-elem-focus: var(--color-neutral-200);
 
   /* Font / Weight */
   --font-weight-normal: 400;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -32,7 +32,7 @@
   /* Color / UI / Border */
   --color-border-normal: #101a2429;
   --color-border-light: #101a241f;
-  --color-border-checkbox: #101a2452;
+  --color-border-input: #101a2452;
 
   /* Color / UI / Element */
   --color-elem-icon: var(--color-neutral-500);

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -44,7 +44,7 @@ const topicsColumnName = (
       openOnHover
       trigger={
         <button type="button">
-          <LucideInfo size={16} className="inline-block align-text-bottom text-gray-500 hover:text-gray-700 cursor-help" />
+          <LucideInfo size={16} className="inline-block align-text-bottom text-[#6b7280] hover:text-[#374151] cursor-help" />
         </button>
       }
       description="This table shows the most frequently mentioned topics in this document. Click to view the document and see the specific passages mentioning each topic highlighted. Accuracy is not 100%."
@@ -141,7 +141,7 @@ const getFamilyDocuments = (family: TFamilyPublic): TEventRowData[] =>
     .filter((document) => ["awaiting_source_file", "published"].includes(document.document_status))
     .map((document) => ({ family, document }));
 
-const linkClasses = "block text-brand underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500";
+const linkClasses = "block text-[#0038a9] underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]";
 
 const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, isMainDocument: boolean, isLitigation: boolean): React.ReactNode => {
   const canPreview = hasMatches || (!!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf"));
@@ -169,7 +169,7 @@ const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, i
       {document.title} <br />{" "}
       <span className="text-sm">
         (We do not have this document in our database.{" "}
-        <PageLink href="/contact" className="underline hover:text-brand">
+        <PageLink href="/contact" className="underline hover:text-[#0038a9]">
           Contact us
         </PageLink>{" "}
         if you can help us find it)
@@ -290,7 +290,7 @@ export const getEventTableRows = ({
             <button
               type="button"
               role="link"
-              className="p-2 hover:bg-gray-50 active:bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-700 leading-4 font-medium"
+              className="p-2 hover:bg-[#f9fafb] active:bg-[#f3f4f6] border border-[#d1d5db] rounded-md text-sm text-[#374151] leading-4 font-medium"
             >
               + {sortedTopics.length - MAX_TOPICS_PER_DOCUMENT} more
             </button>

--- a/src/utils/family-metadata/getTopicsMetadataItem.tsx
+++ b/src/utils/family-metadata/getTopicsMetadataItem.tsx
@@ -41,7 +41,7 @@ export const getTopicsMetadataItem = (familyTopics: IFamilyDocumentTopics): IMet
         &ensp;
         <button
           role="button"
-          className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500"
+          className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]"
           onClick={scrollToBlock("topics")}
         >
           +{hiddenTopicsCount} {pluralise(hiddenTopicsCount, ["other", "others"])}

--- a/src/utils/getGeographyMetadata.tsx
+++ b/src/utils/getGeographyMetadata.tsx
@@ -26,7 +26,7 @@ export const getGeographyMetaData = (stats: NonNullable<GeographyV2["statistics"
         <Popover
           openOnHover
           trigger={
-            <button className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500 cursor-help!">
+            <button className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280] cursor-help!">
               {stats.climate_risk_index}
             </button>
           }
@@ -71,7 +71,7 @@ export const getGeographyMetaData = (stats: NonNullable<GeographyV2["statistics"
         <Popover
           openOnHover
           trigger={
-            <button className="underline underline-offset-4 decoration-gray-300 hover:decoration-gray-500 cursor-help!">
+            <button className="underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280] cursor-help!">
               {stats.global_emissions_percent + "%"}
             </button>
           }

--- a/src/utils/tables/topic/documentDrawerTopicTable.tsx
+++ b/src/utils/tables/topic/documentDrawerTopicTable.tsx
@@ -14,7 +14,7 @@ export const DOCUMENT_DRAWER_TOPICS_TABLE_COLUMNS: TTableColumn<TTopicTableColum
     id: "topics",
     name: (
       <>
-        Topics <span className="text-gray-500 font-normal">(Most frequent)</span>
+        Topics <span className="text-[#6b7280] font-normal">(Most frequent)</span>
       </>
     ),
     fraction: 2,

--- a/src/utils/tables/topic/topicDrawerDocumentTable.tsx
+++ b/src/utils/tables/topic/topicDrawerDocumentTable.tsx
@@ -46,12 +46,12 @@ export const getTopicDrawerDocumentTableRows = (
                 <PageLink
                   href={"/documents/" + document.slug}
                   query={{ [QUERY_PARAMS.concept_name]: topic.preferred_label }}
-                  className="block text-brand font-medium hover:underline shrink"
+                  className="block text-[#0038a9] font-medium hover:underline shrink"
                 >
                   {document.title}
                 </PageLink>
                 {contextLines && (
-                  <div className="flex flex-col gap-1 text-sm text-gray-500 leading-4">
+                  <div className="flex flex-col gap-1 text-sm text-[#6b7280] leading-4">
                     {contextLines.map((line, lineIndex) => (
                       <span key={lineIndex} className="block">
                         {line}

--- a/themes/ccc/components/Feature.tsx
+++ b/themes/ccc/components/Feature.tsx
@@ -18,7 +18,7 @@ export const Feature = ({ heading, subheading, image, imageAlt, children }: IPro
     <Card
       heading={heading || ""}
       extraClasses="h-full w-full"
-      headingClasses="text-text-brand-darker text-2xl font-bold"
+      headingClasses="text-text-brand text-2xl font-bold"
       paddingClasses="p-4 md:p-6 lg:p-10"
     >
       {subheading && (

--- a/themes/ccc/components/FeatureDiscover.tsx
+++ b/themes/ccc/components/FeatureDiscover.tsx
@@ -11,7 +11,7 @@ export const FeatureDiscover = () => (
           The Sabin Center for Climate Change Law's Climate Litigation Database is the most comprehensive resource tracking climate change litigation
           worldwide. It contains more than 3,000 cases that address climate change law, policy, and science.
         </p>
-        <LinkWithQuery href="/about" className="text-text-brand-darker text-lg font-bold">
+        <LinkWithQuery href="/about" className="text-text-brand text-lg font-bold">
           Read more →
         </LinkWithQuery>
       </Feature>
@@ -20,7 +20,7 @@ export const FeatureDiscover = () => (
           Subscribe to the Sabin Center Climate Litigation Newsletter for monthly updates. Each issue includes the latest case updates, event
           announcements, and publication highlights.
         </p>
-        <ExternalLink url="https://mailchi.mp/law/sabin-center-litigation-newsletter" className="text-text-brand-darker text-lg font-bold">
+        <ExternalLink url="https://mailchi.mp/law/sabin-center-litigation-newsletter" className="text-text-brand text-lg font-bold">
           Subscribe →
         </ExternalLink>
       </Feature>

--- a/themes/ccc/components/LandingPageLinks.tsx
+++ b/themes/ccc/components/LandingPageLinks.tsx
@@ -17,8 +17,8 @@ const LandingPageLinks = () => {
   };
 
   return (
-    <section className="mt-10 text-textDark">
-      <div className="text-textDark font-medium text-2xl mb-5">Try these searches</div>
+    <section className="mt-10 text-text-primary">
+      <div className="font-medium text-2xl mb-5">Try these searches</div>
       <ul className="flex flex-col gap-2">
         {SUGGESTED_SEARCHES.map((suggestedSearch, searchIndex) => (
           <li key={searchIndex}>

--- a/themes/ccc/components/LandingSearchForm.tsx
+++ b/themes/ccc/components/LandingSearchForm.tsx
@@ -52,7 +52,7 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) =>
             data-analytics="landingPage-searchInput"
             data-cy="search-input"
             type="search"
-            className="text-base py-3 h-[48px] pl-12 pr-3 w-full rounded-lg border-0 placeholder:text-text-tertiary bg-surface-heavy text-text-primary"
+            className="text-base py-3 h-[48px] pl-12 pr-3 w-full rounded-lg border-0 placeholder:text-text-tertiary bg-[#e5e5e5] text-text-primary"
             value={term}
             onChange={onChange}
             placeholder={displayPlaceholder}

--- a/themes/ccc/pages/contact.tsx
+++ b/themes/ccc/pages/contact.tsx
@@ -40,7 +40,7 @@ const Contact = () => {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8 my-8">
                 <div className="space-y-3">
                   <h3 className="text-lg font-semibold mb-4">Address</h3>
-                  <ExternalLink url="https://climate.law.columbia.edu/" className="color-text-tertiary hover:color-text-quaternary">
+                  <ExternalLink url="https://climate.law.columbia.edu/" className="color-text-tertiary hover:color-text-tertiary">
                     Sabin Center for Climate Change Law
                   </ExternalLink>
                   <address className="color-text-secondary space-y-1">
@@ -58,13 +58,13 @@ const Contact = () => {
                   <ul className="space-y-3">
                     <li className="flex items-start">
                       <span className="font-semibold color-text-secondary min-w-[60px]">Phone:</span>
-                      <a href="tel:+12128548213" className="color-text-tertiary hover:color-text-quaternary underline ml-2">
+                      <a href="tel:+12128548213" className="color-text-tertiary hover:color-text-tertiary underline ml-2">
                         +1 212-854-8213
                       </a>
                     </li>
                     <li className="flex items-start">
                       <span className="font-semibold color-text-secondary min-w-[60px]">Fax:</span>
-                      <a href="tel:+12128547946" className="color-text-tertiary hover:color-text-quaternary underline ml-2">
+                      <a href="tel:+12128547946" className="color-text-tertiary hover:color-text-tertiary underline ml-2">
                         +1 212-854-7946
                       </a>
                     </li>
@@ -72,7 +72,7 @@ const Contact = () => {
                       <span className="font-semibold color-text-secondary min-w-[60px]">Email:</span>
                       <a
                         href="mailto:manager@climatecasechart.com"
-                        className="color-text-tertiary hover:color-text-quaternary underline ml-2 break-all"
+                        className="color-text-tertiary hover:color-text-tertiary underline ml-2 break-all"
                       >
                         manager@climatecasechart.com
                       </a>

--- a/themes/cpr/components/LandingSearchForm.tsx
+++ b/themes/cpr/components/LandingSearchForm.tsx
@@ -84,7 +84,7 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: IProps) =>
               content="icon"
               color="mono"
               variant="ghost"
-              className="!text-text-light !outline-surface-light hover:!bg-transparent"
+              className="!text-text-inverse !outline-surface-light hover:!bg-transparent"
               onClick={clearSearch}
               type="button"
             >


### PR DESCRIPTION
# What's changed

This is a very noisy PR that [finally] removes two generations of old Tailwind variables!  
In particular check out `theme.css`.

- Added all CPR-DS variables in the same format and with almost-identical names to Tailwind, categorised by the same headings. Many of these reference the default Tailwind colour palette.
- Removed old Tailwind variables following a set of principles:
  - App or third party brand specific colours are untouched.
  - Where possible and obvious, the newer equivalent variable is used. This can result in a small amount of difference versus prod but starts to bring our overall design up to standard.
  - All other variables are replaced with Tailwind escapes e.g. `bg-[#bada55]`. These should look exceptional at-a-glance and signal to developers that components/pages are "off brand", providing a drive-by opportunity to bring them in line.

## Why

- Satisfies [APP-2158](https://linear.app/climate-policy-radar/issue/APP-2158/set-design-system-variables-in-tailwind).

## AI attribution

Claude has been essential to analysing Tailwind variable use and mass updating values. This has been backed up by my manual side-by-side comparisons with prod on all 4 custom apps.