### PR TITLE
APP 2145 :: quick search component

### DIFF
--- a/src/components/atoms/input/Input.stories.tsx
+++ b/src/components/atoms/input/Input.stories.tsx
@@ -60,3 +60,17 @@ export const IconLeft: TStory = {
   },
   render: useInputContext,
 };
+
+export const Sizes: TStory = {
+  args: {
+    clearable: true,
+    placeholder: "Type something",
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      <Input {...args} size="small" placeholder="Small size" />
+      <Input {...args} size="medium" placeholder="Medium size" />
+      <Input {...args} size="large" placeholder="Large size" />
+    </div>
+  ),
+};

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { Input } from "./Input";
+
+describe("Input", () => {
+  it("renders an input element", () => {
+    render(<Input />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("passes props through to the input element", () => {
+    render(<Input placeholder="Search..." disabled />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("placeholder", "Search...");
+    expect(input).toBeDisabled();
+  });
+
+  it("does not render a clear button when clearable is false", () => {
+    render(<Input clearable={false} value="some text" onChange={vi.fn()} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("hides the clear button when clearable is true but value is empty", () => {
+    render(<Input clearable value="" onChange={vi.fn()} />);
+    expect(screen.getByRole("button")).toHaveClass("hidden");
+  });
+
+  it("shows the clear button when clearable is true and value is set", () => {
+    render(<Input clearable value="some text" onChange={vi.fn()} />);
+    expect(screen.getByRole("button")).not.toHaveClass("hidden");
+  });
+
+  it("calls onClear when the clear button is clicked", async () => {
+    const onClear = vi.fn();
+    render(<Input clearable value="some text" onChange={vi.fn()} onClear={onClear} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders icon after the input by default", () => {
+    const icon = <span data-cy="icon">icon</span>;
+    render(<Input icon={icon} />);
+    const input = screen.getByRole("textbox");
+    const renderedIcon = screen.getByTestId("icon");
+    expect(input.compareDocumentPosition(renderedIcon)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("renders icon before the input when iconOnLeft is true", () => {
+    const icon = <span data-cy="icon">icon</span>;
+    render(<Input icon={icon} iconOnLeft />);
+    const input = screen.getByRole("textbox");
+    const renderedIcon = screen.getByTestId("icon");
+    expect(input.compareDocumentPosition(renderedIcon)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+  });
+
+  it("calls onChange when the user types", async () => {
+    const onChange = vi.fn();
+    render(<Input onChange={onChange} />);
+    await userEvent.type(screen.getByRole("textbox"), "hello");
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/components/atoms/select/Select.stories.tsx
+++ b/src/components/atoms/select/Select.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Select } from "./Select";
+
+const OPTIONS = [
+  { label: "Option A", value: "a" },
+  { label: "Option B", value: "b" },
+  { label: "Option C", value: "c" },
+];
+
+const meta = {
+  title: "Atoms/Select",
+  component: Select,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Select>;
+type TStory = StoryObj<typeof Select>;
+
+export default meta;
+
+export const Default: TStory = {
+  args: {
+    options: OPTIONS,
+  },
+};
+
+export const WithDefaultValue: TStory = {
+  args: {
+    options: OPTIONS,
+    defaultValue: "b",
+  },
+};
+
+export const Empty: TStory = {
+  args: {
+    options: [],
+  },
+};
+
+export const WithPlaceholder: TStory = {
+  args: {
+    options: OPTIONS,
+    placeholder: "Placeholder example",
+  },
+};

--- a/src/components/atoms/select/Select.test.tsx
+++ b/src/components/atoms/select/Select.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { Select } from "./Select";
+
+const OPTIONS = [
+  { label: "Option A", value: "a" },
+  { label: "Option B", value: "b" },
+  { label: "Option C", value: "c" },
+];
+
+describe("Select", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, "innerWidth", { value: 0, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 0, configurable: true });
+  });
+
+  it("renders the trigger", () => {
+    render(<Select options={OPTIONS} />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("shows the default value in the trigger", () => {
+    render(<Select options={OPTIONS} defaultValue="b" />);
+    // Base UI renders the raw value in the trigger until the popup mounts its items
+    expect(screen.getByDisplayValue("b")).toBeInTheDocument();
+  });
+
+  it("opens the popup and shows options when the trigger is clicked", async () => {
+    render(<Select options={OPTIONS} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(OPTIONS.length);
+  });
+
+  it("does not render options when the options list is empty", async () => {
+    render(<Select options={[]} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+
+  /*
+    TODO: add test for the onChange callback when an option is selected
+    Currently running into an issue with how base-ui uses portals to render the select options
+  */
+});

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -23,7 +23,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
 
   return (
     <BaseSelect.Root defaultValue={defaultValue} onValueChange={handleValueChange} value={value} id={id}>
-      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-[30px] rounded-sm text-sm text-text-primary m-0 outline-0 select-none cursor-default hover:border-[#005eeb] active:bg-[#f5f5f5] data-popup-open:bg-[#f5f5f5] focus:border-[#005eeb]">
+      <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-7.5 rounded-sm text-sm text-text-primary m-0 select-none cursor-default border border-transparent active:bg-[#f5f5f5] data-popup-open:bg-[#f5f5f5] data-highlighted:outline-[#005eeb]">
         <BaseSelect.Value />
         <BaseSelect.Icon className="flex">
           <ChevronsUpDown height="12" width="12" />
@@ -40,7 +40,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
                 <BaseSelect.Item
                   key={option.value}
                   value={option.value}
-                  className="text-text-primary bg-white-ui p-1 rounded-sm cursor-default data-highlighted:bg-surface-mono data-highlighted:text-white data-highlighted:outline-[#005eeb]"
+                  className="text-text-primary bg-white p-1 rounded-sm cursor-default data-highlighted:bg-bg-flat data-highlighted:outline-[#005eeb]"
                 >
                   <BaseSelect.ItemText className="">{option.label}</BaseSelect.ItemText>
                 </BaseSelect.Item>

--- a/src/components/atoms/select/Select.tsx
+++ b/src/components/atoms/select/Select.tsx
@@ -14,9 +14,10 @@ interface IProps {
   onValueChange?: (value: string) => void;
   options?: TSelectOption[];
   value?: string;
+  placeholder?: string;
 }
 
-export function Select({ defaultValue, value, options, onValueChange, container, id }: IProps) {
+export function Select({ defaultValue, value, options, onValueChange, container, id, placeholder }: IProps) {
   const handleValueChange = (value: string) => {
     onValueChange?.(value);
   };
@@ -24,7 +25,7 @@ export function Select({ defaultValue, value, options, onValueChange, container,
   return (
     <BaseSelect.Root defaultValue={defaultValue} onValueChange={handleValueChange} value={value} id={id}>
       <BaseSelect.Trigger className="flex items-center justify-between gap-1 px-1 h-7.5 rounded-sm text-sm text-text-primary m-0 select-none cursor-default border border-transparent active:bg-[#f5f5f5] data-popup-open:bg-[#f5f5f5] data-highlighted:outline-[#005eeb]">
-        <BaseSelect.Value />
+        <BaseSelect.Value placeholder={placeholder || "Select an option..."} />
         <BaseSelect.Icon className="flex">
           <ChevronsUpDown height="12" width="12" />
         </BaseSelect.Icon>

--- a/src/components/organisms/ConceptPicker.tsx
+++ b/src/components/organisms/ConceptPicker.tsx
@@ -1,10 +1,11 @@
 import { TextSearch } from "lucide-react";
 import { NextRouter, useRouter } from "next/router";
-import { useContext, useRef, useState } from "react";
+import { useContext, useState } from "react";
 
 import { ExternalLink } from "@/components/ExternalLink";
 import { Accordion } from "@/components/accordion/Accordion";
 import { Badge } from "@/components/atoms/badge/Badge";
+import { Input } from "@/components/atoms/input/Input";
 import { Select } from "@/components/atoms/select/Select";
 import { InputCheck } from "@/components/forms/Checkbox";
 import { TutorialCard } from "@/components/molecules/tutorials/TutorialCard";
@@ -92,7 +93,6 @@ const onConceptChange = (router: NextRouter, concept: TTopic) => {
 
 export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped", showBadge = false, showSearch = true, title }: IProps) => {
   const router = useRouter();
-  const ref = useRef(null);
 
   const { completedTutorials } = useContext(TutorialContext);
   const { theme, themeConfig } = useContext(ThemeContext);
@@ -101,6 +101,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<TSort>(startingSort);
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
   const rootTopics = removeUnusableConcepts(allRootTopics, theme);
   const topics = removeUnusableConcepts(allTopics, theme);
@@ -114,7 +115,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
   const showKnowledgeGraphTutorial = getIncompleteTutorialNames(completedTutorials, themeConfig, features).includes("knowledgeGraph");
 
   return (
-    <div className={`relative flex flex-col gap-5 max-h-full pb-5 ${containerClasses}`} ref={ref}>
+    <div className={`relative flex flex-col gap-5 max-h-full pb-5 ${containerClasses}`}>
       {/* HEADER */}
       {showKnowledgeGraphTutorial && <TutorialCard name="knowledgeGraph" card={TUTORIALS.knowledgeGraph.card} />}
       <span className="text-base font-semibold text-text-primary">
@@ -135,17 +136,18 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
         )}
         <div className="flex gap-2 items-center justify-between">
           {showSearch && (
-            <input
+            <Input
+              clearable
               name="Topic quick search"
-              type="text"
               placeholder="Quick search"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="py-1 text-xs h-[30px]"
+              onChange={(e) => setSearch(e.currentTarget.value)}
+              onClear={() => setSearch("")}
+              size="small"
             />
           )}
-          <div className="basis-3/10 shrink-0 relative flex items-center">
-            <label className="text-sm text-text-tertiary" htmlFor="sort-select">
+          <div className="basis-3/10 shrink-0 relative flex items-center" ref={setContainer}>
+            <label className="text-sm text-text-tertiary mr-0.5" htmlFor="sort-select">
               Sort:
             </label>
             <Select
@@ -153,7 +155,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
               value={sort}
               onValueChange={(value) => setSort(value as TSort)}
               options={selectOptions}
-              container={ref.current}
+              container={container}
               id="sort-select"
             />
           </div>
@@ -216,7 +218,7 @@ export const ConceptPicker = ({ containerClasses = "", startingSort = "Grouped",
                 />
               ))}
 
-          <div className="h-[34px] sticky block bottom-0 w-full bg-linear-to-b from-transparent to-white">&nbsp;</div>
+          <div className="h-8.5 sticky block bottom-0 w-full bg-linear-to-b from-transparent to-white">&nbsp;</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# What's changed
- Utilise the existing `Input` component for the QuickSearch, add corresponding unit tests and update Storybook
- Drive-by fix bug with the `Select` component and componentise this also

## Why
- Standardising use of components of core interactive elements

## AI attribution
- Writing a v1 of unit tests
- Helping diagnose issue with `Select` box - using State to store the container, not `useRefs`
