### PR TITLE
Fix/app 2095 fix non default date filter bug not triggering search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # Project Overview
 
+For dev setup, commands, testing, theming, and deployment see
+[README.md](README.md).
+
 This project is a web application that provides a user interface for searching
 and navigating through climate-related documentation and associated metadata,
 with support for various themes and configurations. The application is built
@@ -41,3 +44,60 @@ container.
 - When generating a new utility function for a component, keep the function in
   the same file as the component. Allow the developer to move the function if
   they feel it is necessary, but this should be the default behaviour.
+
+## Behavioral guidelines
+
+### Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+### Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+### Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```text
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```

--- a/src/components/_experiment/searchResults/SearchResults.test.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { Suspense } from "react";
+import { vi } from "vitest";
+
+vi.mock("@/api/search", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/api/search")>();
+  return {
+    ...mod,
+    fetchSearchDocuments: vi.fn().mockResolvedValue({
+      results: [],
+      total_size: 0,
+      page: 1,
+      page_size: 10,
+      total_pages: 0,
+      next_page: null,
+      previous_page: null,
+    }),
+  };
+});
+
+import { fetchSearchDocuments } from "@/api/search";
+import { createGroup } from "@/components/_experiment/advancedFilters/AdvancedFilters";
+import { upsertPublishedDateRangeRules } from "@/utils/_experiment/dateRangeFilters";
+
+import { SearchContainer } from "./SearchResults";
+
+describe("SearchContainer", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("triggers a search when only a date filter is applied with no text query", () => {
+    const filtersWithDate = upsertPublishedDateRangeRules(createGroup(), "2020:2025");
+
+    render(
+      <Suspense fallback={null}>
+        <SearchContainer filters={filtersWithDate} />
+      </Suspense>
+    );
+
+    expect(fetchSearchDocuments).toHaveBeenCalled();
+  });
+});

--- a/src/components/_experiment/searchResults/SearchResults.test.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.test.tsx
@@ -27,7 +27,7 @@ import { SearchContainer } from "./SearchResults";
 describe("SearchContainer", () => {
   afterEach(() => vi.clearAllMocks());
 
-  it("triggers a search when only a date filter is applied with no text query", () => {
+  it("triggers a search when only a date filter is applied with no text query or other filters", () => {
     const filtersWithDate = upsertPublishedDateRangeRules(createGroup(), "2020:2025");
 
     render(

--- a/src/components/_experiment/searchResults/SearchResults.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.tsx
@@ -3,9 +3,10 @@ import React, { Fragment, Suspense, use, useEffect, useMemo } from "react";
 
 import { fetchSearchDocuments, SearchDocument, SearchDocumentsResponse, SearchDocumentsSortKey } from "@/api/search";
 import { DocumentCard } from "@/components/molecules/documentCard/DocumentCard";
+import { stripEmptyValueRules } from "@/utils/filters/advancedFilters";
 
 import styles from "./SearchResults.module.css";
-import { TQueryGroup } from "../advancedFilters/AdvancedFilters";
+import { isFilterGroupEmpty, TQueryGroup } from "../advancedFilters/AdvancedFilters";
 import { EmptySearch } from "../emptySearch/EmptySearch";
 
 // Principal = Family in old model
@@ -52,18 +53,6 @@ function SearchResults({
   );
 }
 
-// If any of the values are empty strings, the filters are considered invalid and will not be sent to the API
-const filtersDoesNotContainEmptyRule = (filters: TQueryGroup): boolean => {
-  if (!filters || !filters.filters || filters.filters.length === 0) return false;
-
-  for (const filter of filters.filters) {
-    if ("value" in filter && filter.value.trim() === "") {
-      return false;
-    }
-  }
-  return true;
-};
-
 export function SearchContainer({
   query,
   filters,
@@ -82,7 +71,12 @@ export function SearchContainer({
   onTotalResultsChange?: (total: number | null) => void;
   onResultClicked?: (document: SearchDocument, event: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
-  const nonEmptyFilters = filtersDoesNotContainEmptyRule(filters) ? filters : undefined;
+  // Drop placeholder rules (e.g. default empty label row) so date-only filters still fetch.
+  const nonEmptyFilters = useMemo(() => {
+    if (!filters) return undefined;
+    const sanitised = stripEmptyValueRules(filters);
+    return isFilterGroupEmpty(sanitised) ? undefined : sanitised;
+  }, [filters]);
 
   const searchPromise = useMemo(() => {
     if (!query && !nonEmptyFilters) return null;


### PR DESCRIPTION
# What's changed

- Fix bug where if the user applies a non-default date filter with no other filters, a search wasn't being triggered
- Driveby update CLAUDE instructions with [Karpathy](https://github.com/multica-ai/andrej-karpathy-skills#) guidelines

## Why

Applying a date filter with no other filters wasn't triggering a search because the old filtersDoesNotContainEmptyRule function returned false whenever the default empty label placeholder was present, making the whole group appear empty.
