### PR TITLE
Feature/app 2048 topic label in applied filters should include topic name

### DIFF
--- a/src/components/_experiment/appliedLabels/AppliedLabels.test.tsx
+++ b/src/components/_experiment/appliedLabels/AppliedLabels.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { createGroup } from "@/components/_experiment/advancedFilters/AdvancedFilters";
+import { TLabelResult } from "@/hooks/useLabelSearch";
+import { addLabelRule } from "@/utils/filters/advancedFilters";
+
+import { AppliedLabels } from "./AppliedLabels";
+
+const conceptLabel: TLabelResult = {
+  id: "concept::Q567",
+  type: "concept",
+  value: "renewable energy",
+};
+
+const filters = addLabelRule(createGroup(), "concept::Q567");
+const availableFilters = [conceptLabel];
+const labels = ["concept::Q567"];
+
+describe("AppliedLabels", () => {
+  it("displays the human-readable concept name instead of the Wikibase ID", () => {
+    render(<AppliedLabels filters={filters} availableFilters={availableFilters} labels={labels} />);
+
+    expect(screen.getByText("renewable energy")).toBeInTheDocument();
+    expect(screen.queryByText("Q567")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the id suffix when no match found in availableFilters", () => {
+    render(<AppliedLabels filters={addLabelRule(createGroup(), "concept::Q567")} availableFilters={[]} labels={["concept::Q567"]} />);
+
+    expect(screen.getByText("Q567")).toBeInTheDocument();
+  });
+});

--- a/src/components/_experiment/appliedLabels/AppliedLabels.tsx
+++ b/src/components/_experiment/appliedLabels/AppliedLabels.tsx
@@ -9,6 +9,11 @@ function getTypeOfLabel(label: string, availableFilters: TLabelResult[]): string
   return found ? found.type : null;
 }
 
+function getLabelDisplayName(label: string, availableFilters: TLabelResult[]): string {
+  const found = availableFilters.find((f) => f.id === label);
+  return found ? found.value : (label.split("::")?.[1] ?? label);
+}
+
 // determine if any of the current filters contain any groups, or have any of the settings set to "or", or contain a "not_contains" op rule
 function isFilterComplex(filters: TQueryGroup | null | undefined): boolean {
   if (!filters) return false;
@@ -19,14 +24,14 @@ function isFilterComplex(filters: TQueryGroup | null | undefined): boolean {
   return filters.filters.some((f) => "filters" in f && isFilterComplex(f));
 }
 
-function AppliedLabel({ label, type, onSelect, onRemove }: { label: string; type?: string; onSelect: () => void; onRemove: () => void }) {
+function AppliedLabel({ displayName, type, onSelect, onRemove }: { displayName: string; type?: string; onSelect: () => void; onRemove: () => void }) {
   return (
     <span className="bg-white rounded-lg inline-flex items-center border border-[#d1d5db] hover:bg-[#f9fafb]">
       <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
         <span>{type.slice(0, 1).toUpperCase() + type.replace("_", " ").slice(1)}</span>
       </button>
       <button className="py-1 px-2 border-r border-[#d1d5db]" onClick={onSelect}>
-        <span>{label.split("::")?.[1]}</span>
+        <span>{displayName}</span>
       </button>
       <button className="px-2 rounded-r-lg h-7 hover:bg-gray-200" onClick={onRemove}>
         <LucideX width={16} height={16} />
@@ -91,10 +96,11 @@ export function AppliedLabels({
       ) : (
         labels.map((label, i) => {
           const type = getTypeOfLabel(label, availableFilters);
+          const displayName = getLabelDisplayName(label, availableFilters);
           return (
             <AppliedLabel
               key={i}
-              label={label}
+              displayName={displayName}
               type={type || ""}
               onSelect={() => onSelectLabel?.(label, type || "")}
               onRemove={() => onRemoveLabel?.(label)}

--- a/src/hooks/useLabelSearch.ts
+++ b/src/hooks/useLabelSearch.ts
@@ -69,7 +69,7 @@ export const loadLabels = async (query: string): Promise<TLabelResult[]> => {
     ],
   };
   const response = await client.get<TLabelsResponse>(
-    `/search/labels?query=${encodeURIComponent(query)}&page_size=5000&filters=${encodeURIComponent(JSON.stringify(defaultFilter))}`,
+    `/search/labels?query=${encodeURIComponent(query)}&page_size=10000&filters=${encodeURIComponent(JSON.stringify(defaultFilter))}`,
     null
   );
   return response.data.results || [];


### PR DESCRIPTION
# What's changed

- Changed the UI to show the concept display name instead of the Wikibase ID, where an available filter exists
- Fall back to showing the Wikibase ID instead of the display name where it isn't possible to get the display name
- Add regression tests

## Why

We were seeing the Wikibase ID instead of the concept name in the frontend UI which is confusing for users
