### PR TITLE
Move country name assert to after the existince checks

### DIFF
--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -74,10 +74,6 @@ export const getServerSideProps = (async (context) => {
     // Do nothing
   }
 
-  if (countryNameFromConfig) {
-    geographyV2.name = countryNameFromConfig;
-  }
-
   // If we don't have a geography - 404
   if (!geographyV2) {
     return { notFound: true };
@@ -86,6 +82,10 @@ export const getServerSideProps = (async (context) => {
   // We don't currently support regions - 404
   if (geographyV2.type === "region") {
     return { notFound: true };
+  }
+
+  if (countryNameFromConfig) {
+    geographyV2.name = countryNameFromConfig;
   }
 
   let vespaSearchResults: TSearch = null;


### PR DESCRIPTION
# What's changed
- Due to the API returning a 404 for certain geos (Kosovo) the front-end app is crashing out and returning an internal server error
- I've moved the line that was causing the crash to after we check for the existence of data from the API, so when it has no data it will return a 404 instead.

## Why
- Avoid triggering an "Internal server error" to the user
