### PR TITLE
APP 2155 :: remove targets block

### DIFF
--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -14,7 +14,6 @@ import {
   TApiItemResponse,
   TApiSearchResponse,
   TApiSlugResponse,
-  TApiTarget,
   TCorpusTypeDictionary,
   TFamilyPresentationalResponse,
   TFeatures,
@@ -121,18 +120,6 @@ export const getFamilyData = async (slug: string, features: TFeatures): Promise<
   );
   const collections = allCollections.flat().filter((collection) => collection !== undefined);
 
-  let targets: TApiTarget[] = [];
-  try {
-    const targetsRaw = await axios.get<TApiTarget[]>(`${process.env.TARGETS_URL}/families/${family.import_id}.json`);
-    targets = targetsRaw.data;
-  } catch (error) {
-    // Targets store in S3 are not available for the majority of families, so we fail silently
-    // Otherwise the logs are flooded with 404s and 403s
-    if (axios.isAxiosError(error) && error.response?.status === 500) {
-      errors.push(new Error("Failed to fetch target data", error));
-    }
-  }
-
   // Check the family is in the "allowed_corpora"
   if (family.corpus_id && !isCorpusIdAllowed(process.env.BACKEND_API_TOKEN, family.corpus_id)) {
     errors.push(new Error("Family is not in an allowed corpora"));
@@ -149,7 +136,6 @@ export const getFamilyData = async (slug: string, features: TFeatures): Promise<
       family,
       familyTopics: familyTopics || null,
       subdivisions,
-      targets,
       vespaFamilyData: vespaFamilyData || null,
     },
     dataInDocument,

--- a/src/components/pages/familyPage.tsx
+++ b/src/components/pages/familyPage.tsx
@@ -7,7 +7,6 @@ import { CollectionsBlock } from "@/components/blocks/collectionsBlock/Collectio
 import { DocumentsBlock } from "@/components/blocks/documentsBlock/DocumentsBlock";
 import { MetadataBlock } from "@/components/blocks/metadataBlock/MetadataBlock";
 import { NoteBlock } from "@/components/blocks/noteBlock/NoteBlock";
-import { TargetsBlock } from "@/components/blocks/targetsBlock/TargetsBlock";
 import { TextBlock } from "@/components/blocks/textBlock/TextBlock";
 import { TopicsBlock } from "@/components/blocks/topicsBlock/TopicsBlock";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
@@ -32,7 +31,6 @@ import {
   TGeography,
   TGeographySubdivision,
   TSearchResponse,
-  TTarget,
   TTheme,
   TThemeConfig,
   TFeatures,
@@ -43,7 +41,6 @@ import { getFamilyMetadata } from "@/utils/family-metadata/getFamilyMetadata";
 import { getFamilyMetaDescription } from "@/utils/getFamilyMetaDescription";
 import { getLitigationCaseJSONLD } from "@/utils/json-ld/getLitigationCaseJSONLD";
 import { pluralise } from "@/utils/pluralise";
-import { sortFilterTargets } from "@/utils/sortFilterTargets";
 import { familyTopicsHasTopics } from "@/utils/topics/processFamilyTopics";
 
 export interface IProps {
@@ -54,7 +51,6 @@ export interface IProps {
   familyTopics: IFamilyDocumentTopics | null;
   features: TFeatures;
   subdivisions: TGeographySubdivision[];
-  targets: TTarget[];
   theme: TTheme;
   themeConfig: TThemeConfig;
   vespaFamilyData?: TSearchResponse | null;
@@ -65,19 +61,7 @@ export interface IProps {
   };
 }
 
-export const FamilyPage = ({
-  collections,
-  countries,
-  debug,
-  errors,
-  family,
-  familyTopics,
-  features,
-  targets,
-  subdivisions,
-  theme,
-  themeConfig,
-}: IProps) => {
+export const FamilyPage = ({ collections, countries, debug, errors, family, familyTopics, features, subdivisions, theme, themeConfig }: IProps) => {
   const configQuery = useConfig();
   const { data: { languages = {} } = {} } = configQuery;
   const { getCategoryTextLookup } = useText();
@@ -169,12 +153,6 @@ export const FamilyPage = ({
         if (!familyTopicsHasTopics(familyTopics)) return null;
         return <TopicsBlock key="topics" family={family} familyTopics={familyTopics} getCategoryText={getCategoryText} />;
       }, [family, familyTopics, getCategoryText]),
-    },
-    targets: {
-      render: useCallback(() => {
-        const publishedTargets = sortFilterTargets(targets);
-        return <TargetsBlock key="targets" targets={publishedTargets} />;
-      }, [targets]),
     },
   };
 

--- a/src/components/pages/geographyPage.tsx
+++ b/src/components/pages/geographyPage.tsx
@@ -1,5 +1,5 @@
 import sortBy from "lodash/fp/sortBy";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { ApiClient } from "@/api/http-common";
 import { LinkWithQuery } from "@/components/LinkWithQuery";
@@ -8,7 +8,6 @@ import { INTRO_BLOCK_TITLE, IntroBlock } from "@/components/blocks/introBlock/In
 import { MetadataBlock } from "@/components/blocks/metadataBlock/MetadataBlock";
 import { RecentFamiliesBlock } from "@/components/blocks/recentFamiliesBlock/RecentFamiliesBlock";
 import { SubDivisionBlock } from "@/components/blocks/subDivisionBlock/SubDivisionBlock";
-import { TargetsBlock } from "@/components/blocks/targetsBlock/TargetsBlock";
 import { TextBlock } from "@/components/blocks/textBlock/TextBlock";
 import { BreadCrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import Layout from "@/components/layouts/Main";
@@ -19,23 +18,21 @@ import { TPublicEnvConfig } from "@/context/EnvConfig";
 import { FeaturesContext } from "@/context/FeaturesContext";
 import { GeographiesContext } from "@/context/GeographiesContext";
 import { useText } from "@/hooks/useText";
-import { TSearch, TGeographyPageBlock, IMetadata, GeographyV2, TTheme, TThemeConfig, TTarget, TFeatures, TApiSearch } from "@/types";
+import { TSearch, TGeographyPageBlock, IMetadata, GeographyV2, TTheme, TThemeConfig, TFeatures, TApiSearch } from "@/types";
 import buildSearchQuery from "@/utils/buildSearchQuery";
 import { getGeographyMetaData } from "@/utils/getGeographyMetadata";
-import { sortFilterTargets } from "@/utils/sortFilterTargets";
 
 export interface IProps {
   features: TFeatures;
   geographyV2: GeographyV2;
   parentGeographyV2?: GeographyV2;
-  targets: TTarget[];
   theme: string;
   themeConfig: TThemeConfig;
   vespaSearchResults?: TSearch;
   envConfig: TPublicEnvConfig;
 }
 
-export const GeographyPage = ({ geographyV2, parentGeographyV2, targets, theme, themeConfig, features, vespaSearchResults, envConfig }: IProps) => {
+export const GeographyPage = ({ geographyV2, parentGeographyV2, theme, themeConfig, features, vespaSearchResults, envConfig }: IProps) => {
   const { getAppText } = useText();
 
   const isCountry = geographyV2.type === "country";
@@ -63,11 +60,6 @@ export const GeographyPage = ({ geographyV2, parentGeographyV2, targets, theme, 
   const [searchResultsByCategory, setSearchResultsByCategory] = useState<{ [categorySlug: string]: TSearch }>({
     All: vespaSearchResults,
   });
-  useEffect(() => {
-    setSearchResultsByCategory({
-      All: vespaSearchResults,
-    });
-  }, [vespaSearchResults]);
 
   /* Blocks */
 
@@ -79,7 +71,6 @@ export const GeographyPage = ({ geographyV2, parentGeographyV2, targets, theme, 
           <div className="col-start-1 -col-end-1">
             <Debug data={geographyV2} title="Geography V2" />
             <Debug data={parentGeographyV2} title="Parent geography V2" />
-            <Debug data={targets} title="Targets" />
           </div>
         </Section>
       ),
@@ -183,12 +174,6 @@ export const GeographyPage = ({ geographyV2, parentGeographyV2, targets, theme, 
         return <SubDivisionBlock key="subdivisions" subdivisions={subdivisions} title={subdivisionsTitle} />;
       }, [geographyV2, isCountry, parentGeographyV2, subdivisionsTitle]),
       sideBarItem: { display: subdivisionsTitle },
-    },
-    targets: {
-      render: useCallback(() => {
-        const publishedTargets = sortFilterTargets(targets);
-        return <TargetsBlock key="targets" targets={publishedTargets} />;
-      }, [targets]),
     },
   };
 

--- a/src/pages/document/[id].tsx
+++ b/src/pages/document/[id].tsx
@@ -18,7 +18,7 @@ import { getFamilyData } from "../../bff/methods/getFamilyData";
 */
 
 const FamilyPage = ({ ...props }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  return <FamilyPageUI {...props} />;
+  return <FamilyPageUI key={props.family.slug} {...props} />;
 };
 
 export default FamilyPage;

--- a/src/pages/geographies/[id].tsx
+++ b/src/pages/geographies/[id].tsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import { ApiClient } from "@/api/http-common";
@@ -6,7 +5,7 @@ import { GeographyPage } from "@/components/pages/geographyPage";
 import { SYSTEM_GEO_NAMES } from "@/constants/systemGeos";
 import { withEnvConfig } from "@/context/EnvConfig";
 import { getCountryCode, getCountryName } from "@/helpers/getCountryFields";
-import { TApiItemResponse, GeographyV2, TSearch, TTarget, TGeography } from "@/types";
+import { TApiItemResponse, GeographyV2, TSearch, TGeography } from "@/types";
 import buildSearchQuery from "@/utils/buildSearchQuery";
 import { extractNestedData } from "@/utils/extractNestedData";
 import { getFeatureFlags } from "@/utils/featureFlags";
@@ -14,7 +13,7 @@ import { getFeatures } from "@/utils/features";
 import { readConfigFile } from "@/utils/readConfigFile";
 
 const CountryPage = ({ ...props }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  return <GeographyPage {...props} />;
+  return <GeographyPage key={props.geographyV2.slug} {...props} />;
 };
 
 export default CountryPage;
@@ -38,8 +37,6 @@ export const getServerSideProps = (async (context) => {
   const backendApiClient = new ApiClient();
   const apiClient = new ApiClient(process.env.CONCEPTS_API_URL);
 
-  let targetsData: TTarget[] = [];
-
   let countryNameFromConfig;
   try {
     let geographies: TGeography[] = [];
@@ -50,8 +47,6 @@ export const getServerSideProps = (async (context) => {
     const geography = getCountryCode(id as string, geographies);
 
     if (geography) {
-      const targetsRaw = await axios.get<TTarget[]>(`${process.env.TARGETS_URL}/geographies/${geography.toLowerCase()}.json`);
-      targetsData = targetsRaw.data;
       countryNameFromConfig = getCountryName(id as string, geographies);
     }
   } catch {
@@ -115,7 +110,6 @@ export const getServerSideProps = (async (context) => {
       features,
       geographyV2,
       parentGeographyV2,
-      targets: targetsData,
       theme,
       themeConfig,
       vespaSearchResults: vespaSearchResults,

--- a/src/types/bff/family.ts
+++ b/src/types/bff/family.ts
@@ -8,10 +8,9 @@ import {
   TApiGeography,
   TApiGeographySubdivision,
   TApiSearchResponse,
-  TApiTarget,
 } from "../api";
 import { IFamilyDocumentTopics } from "../tables/familyDocumentTopics";
-import { TCollectionPublicWithFamilies, TFamilyPublic, TGeography, TGeographySubdivision, TSearchResponse, TTarget } from "../types";
+import { TCollectionPublicWithFamilies, TFamilyPublic, TGeography, TGeographySubdivision, TSearchResponse } from "../types";
 
 export type TFamilyApiOldData = {
   collections: TApiCollectionPublicWithFamilies[];
@@ -20,7 +19,6 @@ export type TFamilyApiOldData = {
   family: TApiFamilyPublic;
   familyTopics: IApiFamilyDocumentTopics | null;
   subdivisions: TApiGeographySubdivision[];
-  targets: TApiTarget[];
   vespaFamilyData: TApiSearchResponse | null;
 };
 
@@ -32,7 +30,6 @@ export type TFamilyPresentationalData = {
   family: TFamilyPublic;
   familyTopics: IFamilyDocumentTopics | null;
   subdivisions: TGeographySubdivision[];
-  targets: TTarget[];
   vespaFamilyData: TSearchResponse | null;
   debug?: {
     usesDataIn: boolean;

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -12,7 +12,9 @@ type TPartialRecord<Key extends string, Value> = Partial<Record<Key, Value>>;
 export type TFamilyPageBlock = "collections" | "debug" | "documents" | "metadata" | "note" | "summary" | "topics";
 type TCollectionPageBlock = "events";
 export type TGeographyPageBlock = "debug" | "intro" | "legislativeProcess" | "recents" | "statistics" | "subdivisions";
-export type TBlock = TFamilyPageBlock | TCollectionPageBlock | TGeographyPageBlock;
+// blocks that are currently only used on any page but may be added to the theme config in future
+type TOtherBlocks = "targets";
+export type TBlock = TFamilyPageBlock | TCollectionPageBlock | TGeographyPageBlock | TOtherBlocks;
 
 type TThemePageBlocks = {
   family: TFamilyPageBlock[];

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -11,7 +11,7 @@ type TPartialRecord<Key extends string, Value> = Partial<Record<Key, Value>>;
 // Adding a new block to a page? Add a new string to the page's type here, then add the new key to the TBlockDefinitions declaration on the page
 export type TFamilyPageBlock = "collections" | "debug" | "documents" | "metadata" | "note" | "summary" | "topics" | "targets";
 type TCollectionPageBlock = "events";
-export type TGeographyPageBlock = "debug" | "intro" | "legislativeProcess" | "recents" | "statistics" | "subdivisions" | "targets";
+export type TGeographyPageBlock = "debug" | "intro" | "legislativeProcess" | "recents" | "statistics" | "subdivisions";
 export type TBlock = TFamilyPageBlock | TCollectionPageBlock | TGeographyPageBlock;
 
 type TThemePageBlocks = {

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -9,7 +9,7 @@ type TPartialRecord<Key extends string, Value> = Partial<Record<Key, Value>>;
 
 // All of the possible block names used in TThemeConfig.pageBlocks to specify which blocks to render on each page
 // Adding a new block to a page? Add a new string to the page's type here, then add the new key to the TBlockDefinitions declaration on the page
-export type TFamilyPageBlock = "collections" | "debug" | "documents" | "metadata" | "note" | "summary" | "topics" | "targets";
+export type TFamilyPageBlock = "collections" | "debug" | "documents" | "metadata" | "note" | "summary" | "topics";
 type TCollectionPageBlock = "events";
 export type TGeographyPageBlock = "debug" | "intro" | "legislativeProcess" | "recents" | "statistics" | "subdivisions";
 export type TBlock = TFamilyPageBlock | TCollectionPageBlock | TGeographyPageBlock;

--- a/src/utils/blocks/getFamilyBlocks.test.ts
+++ b/src/utils/blocks/getFamilyBlocks.test.ts
@@ -3,7 +3,7 @@ import { TFamilyPageBlock, TFeatures, TTheme } from "@/types";
 import { getFamilyBlocks } from "./getFamilyBlocks";
 
 describe("getFamilyBlocks", () => {
-  const familyBlocks: TFamilyPageBlock[] = ["summary", "documents", "metadata", "topics", "collections", "targets", "note"];
+  const familyBlocks: TFamilyPageBlock[] = ["summary", "documents", "metadata", "topics", "collections", "note"];
   const features = {
     "ab-family-topic-block": false,
   } as TFeatures;
@@ -26,14 +26,6 @@ describe("getFamilyBlocks", () => {
       "ab-family-topic-block": true,
     };
 
-    expect(getFamilyBlocks(familyBlocks, featuresWithABTest, "cclw")).toEqual([
-      "summary",
-      "topics",
-      "documents",
-      "metadata",
-      "collections",
-      "targets",
-      "note",
-    ]);
+    expect(getFamilyBlocks(familyBlocks, featuresWithABTest, "cclw")).toEqual(["summary", "topics", "documents", "metadata", "collections", "note"]);
   });
 });

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -179,7 +179,7 @@ const config: TThemeConfig = {
   defaultDocumentCategory: "All",
   pageBlocks: {
     family: ["summary", "documents", "metadata", "topics", "collections", "targets", "note"],
-    geography: ["recents", "targets", "statistics", "legislativeProcess"],
+    geography: ["recents", "statistics", "legislativeProcess"],
   },
   tutorials: ["knowledgeGraph"],
   features: {

--- a/themes/cclw/config.ts
+++ b/themes/cclw/config.ts
@@ -178,7 +178,7 @@ const config: TThemeConfig = {
   documentCategories: ["All", "UN Submissions", "Laws", "Policies", "Litigation"],
   defaultDocumentCategory: "All",
   pageBlocks: {
-    family: ["summary", "documents", "metadata", "topics", "collections", "targets", "note"],
+    family: ["summary", "documents", "metadata", "topics", "collections", "note"],
     geography: ["recents", "statistics", "legislativeProcess"],
   },
   tutorials: ["knowledgeGraph"],

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -431,7 +431,7 @@ const config: TThemeConfig = {
   documentCategories: ["All", "UN Submissions", "Laws", "Policies", "Climate Finance Projects", "Offshore Wind Reports", "Litigation"],
   defaultDocumentCategory: "Laws",
   pageBlocks: {
-    family: ["documents", "summary", "metadata", "topics", "collections", "targets", "note"],
+    family: ["documents", "summary", "metadata", "topics", "collections", "note"],
     geography: ["recents", "intro", "statistics", "legislativeProcess"],
   },
   tutorials: ["knowledgeGraph"],

--- a/themes/cpr/config.ts
+++ b/themes/cpr/config.ts
@@ -432,7 +432,7 @@ const config: TThemeConfig = {
   defaultDocumentCategory: "Laws",
   pageBlocks: {
     family: ["documents", "summary", "metadata", "topics", "collections", "targets", "note"],
-    geography: ["recents", "intro", "targets", "statistics", "legislativeProcess"],
+    geography: ["recents", "intro", "statistics", "legislativeProcess"],
   },
   tutorials: ["knowledgeGraph"],
   features: {


### PR DESCRIPTION
# What's changed
- Removed the targets block from the Geography pages and the Family pages

## Why
- Data was legacy manually curated targets from pre-KG era
- We will be using the passages classified with "Target" in future