### PR TITLE
fix: error when runnign pulumi up as this stack was incorrect

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -247,7 +247,7 @@ jobs:
             echo "environment=${environment}" >> "$GITHUB_OUTPUT"
           elif [[ "$project" =~ ^(staging|production)-shared-resources$ ]]; then
             environment="${BASH_REMATCH[1]}"
-            echo "value=platform/${environment}" >> "$GITHUB_OUTPUT"
+            echo "value=frontend-platform/${environment}" >> "$GITHUB_OUTPUT"
             echo "environment=${environment}" >> "$GITHUB_OUTPUT"
           else
             echo "Unsupported project format: ${project}" >&2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -380,7 +380,7 @@ jobs:
             echo "value=frontend/${theme}-${environment}" >> "$GITHUB_OUTPUT"
           elif [[ "$project" =~ ^(staging|production)-shared-resources$ ]]; then
             environment="${BASH_REMATCH[1]}"
-            echo "value=platform/${environment}" >> "$GITHUB_OUTPUT"
+            echo "value=frontend-platform/${environment}" >> "$GITHUB_OUTPUT"
           else
             echo "Unsupported project format: ${project}" >&2
             exit 1


### PR DESCRIPTION
# What's changed

We were referring to the wrong stack. 

This is the one we want.


<img width="1436" height="234" alt="Screenshot 2026-06-17 at 11 59 19" src="https://github.com/user-attachments/assets/234ec8fe-71c2-40a4-b701-463afe89f77d" />




## Why


error in the ci

```
Run pulumi up --yes --skip-preview --stack climatepolicyradar/platform/staging
  pulumi up --yes --skip-preview --stack climatepolicyradar/platform/staging
shell: /usr/bin/bash -e {0}
env:
  UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
  UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
  AWS_DEFAULT_REGION: eu-west-1
  AWS_REGION: eu-west-1
  AWS_ACCESS_KEY_ID: ***
  AWS_SECRET_ACCESS_KEY: ***
  AWS_SESSION_TOKEN: ***
  PULUMI_ACCESS_TOKEN: ***
  DEPLOY_TO_PROD_STACK_ALLOWED: true
Logging in using access token from PULUMI_ACCESS_TOKEN
error: no stack named 'climatepolicyradar/platform/staging' found

```

