### PR TITLE
Add missing status to Valibot schema and make slug optional based on status

### DIFF
--- a/src/schemas/attributesSchema.ts
+++ b/src/schemas/attributesSchema.ts
@@ -27,13 +27,22 @@ export const FamilyAttributesSchema = v.object({
 export type TDataInFamilyAttributes = v.InferOutput<typeof FamilyAttributesSchema>;
 export const validateFamilyAttributes = (attributes: TDataInAttributes): TDataInFamilyAttributes => v.parse(FamilyAttributesSchema, attributes);
 
-export const DocumentAttributesSchema = v.object({
-  action_taken: v.optional(v.string()),
-  deprecated_slug: v.string(),
-  md5_sum: v.optional(v.string()),
-  variant: v.optional(v.string()),
-  status: toLiteralUnion(["created", "deleted", "published"]),
-});
+export const DocumentAttributesSchema = v.pipe(
+  v.object({
+    action_taken: v.optional(v.string()),
+    deprecated_slug: v.optional(v.string()),
+    md5_sum: v.optional(v.string()),
+    variant: v.optional(v.string()),
+    status: toLiteralUnion(["created", "deleted", "published", "awaiting_source_file"]),
+  }),
+  v.forward(
+    v.check(
+      (input) => input.status === "awaiting_source_file" || input.deprecated_slug !== undefined,
+      "deprecated_slug is required unless status is 'awaiting_source_file'."
+    ),
+    ["deprecated_slug"]
+  )
+);
 export type TDataInDocumentAttributes = v.InferOutput<typeof DocumentAttributesSchema>;
 export const validateDocumentAttributes = (attributes: TDataInAttributes): TDataInDocumentAttributes => v.parse(DocumentAttributesSchema, attributes);
 


### PR DESCRIPTION
# What's changed

- Adds a missing new document status `awaiting_source_file` to the `DocumentAttributesSchema`
- Makes the `deprecated_slug` field `DocumentAttributesSchema` optional if the `status` is `awaiting_source_file` as documents with this status will not have a slug (they are mapped from events because there is no file available yet but we have data we still want to surface on the FE in the documents table) [Applies to Sabin documents only]

## Why

Fixes:
<img width="817" height="547" alt="Screenshot 2026-06-18 at 11 17 02" src="https://github.com/user-attachments/assets/bbdc7ab2-6740-46a6-a7a7-016ed17e342d" />

## AI attribution

Syntax lookup for conditional Valibot field validation


