### PR TITLE
Temporarily decrease page_size for demo

### DIFF
--- a/src/hooks/useLabelSearch.ts
+++ b/src/hooks/useLabelSearch.ts
@@ -93,7 +93,7 @@ export const loadLabels = async (query: string): Promise<TSearchLabel[]> => {
     ],
   };
   const response = await client.get<TLabelsResponse>(
-    `/search/labels?query=${encodeURIComponent(query)}&page_size=10000&filters=${encodeURIComponent(JSON.stringify(defaultFilter))}`,
+    `/search/labels?query=${encodeURIComponent(query)}&page_size=400&filters=${encodeURIComponent(JSON.stringify(defaultFilter))}`,
     null
   );
   return response.data.results || [];


### PR DESCRIPTION
# What's changed

Vespa is not letting us fetch more than [400 hits](https://docs.vespa.ai/en/reference/api/query.html#native-execution-parameters) all of a sudden because it sucks.

Cap page_size for labels at 400 until this is fixed so we at least return _something_
