### PR TITLE
Allow no items when document status is awaiting_source_file

### DIFF
--- a/src/bff/transformers/partials/transformDocument.ts
+++ b/src/bff/transformers/partials/transformDocument.ts
@@ -20,7 +20,9 @@ export const transformDocument = (document: TDataInDocument, events: TFamilyEven
   if (!displayAllowed) return null;
 
   const groupedLabels = groupByType<TDataInLabel, TDataInLabelType>(document.labels, LABEL_TYPES, MANDATORY_DOCUMENT_LABEL_TYPES);
-  const groupedItems = groupByType<TDataInItem, TDataInItemType>(document.items ?? [], ITEM_TYPES, MANDATORY_ITEM_TYPES);
+
+  const itemsMandatory = documentAttributes.status === "awaiting_source_file" ? [] : MANDATORY_ITEM_TYPES;
+  const groupedItems = groupByType<TDataInItem, TDataInItemType>(document.items ?? [], ITEM_TYPES, itemsMandatory);
 
   const languages = groupedLabels.language.map((label) => label.value.value);
 


### PR DESCRIPTION
# What's changed

- Allow document items to be empty when the `document.attributes.status` is `awaiting_source_file`

## Why

- Sabin docs that are `awaiting_source_file` will not have file urls - this is expected but we still want to include them in the document table.
<img width="834" height="491" alt="Screenshot 2026-06-18 at 14 52 44" src="https://github.com/user-attachments/assets/affcb86f-3e2f-49b4-aee5-666558db34a6" />

## AI attribution

Syntax help.

## Screenshots
