### PR TITLE
Chore: Bump version of amazon-ecs-deploy-express-service

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -61,7 +61,7 @@ jobs:
       # @see: https://github.com/marketplace/actions/amazon-ecs-deploy-express-service-action-for-github-actions#complete-example-with-all-options
       - name: Deploy to ECS (production)
         id: deploy-production
-        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1.2.1
         with:
           cluster: frontend-production
           service-name: ${{ inputs.theme }}-production-frontend

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,7 +57,7 @@ jobs:
       # @see: https://github.com/marketplace/actions/amazon-ecs-deploy-express-service-action-for-github-actions#complete-example-with-all-options
       - name: Deploy to ECS (staging)
         id: deploy-staging
-        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1.2.1
         with:
           cluster: frontend-staging
           service-name: ${{ matrix.theme }}-staging-frontend


### PR DESCRIPTION
# What's changed
- Bump version of amazon-ecs-deploy-express-service

## Why
- To use latest

## AI attribution
- Discovered we were some minor versions behind
