### PR TITLE
APP-2205: Build an applied filters component

### DIFF
--- a/src/components/_experiment/categorySpecificFilters/CategorySpecificFilters.tsx
+++ b/src/components/_experiment/categorySpecificFilters/CategorySpecificFilters.tsx
@@ -3,9 +3,11 @@ import { ListFilter } from "lucide-react";
 import { useState } from "react";
 
 import { Drawer } from "@/components/atoms/drawer/Drawer";
+import { AppliedFilters } from "@/components/molecules/appliedFilters/AppliedFilters";
 import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
 import { FiltersContext, TToggleFilterCallback } from "@/context/FiltersContext";
 import { TFilterPathLabel, TNestedSearchLabel, TSearchLabel, TSearchQueryGroup } from "@/types";
+import { getLabelPathSignature } from "@/utils/filters/filterPaths";
 import { buildFilterGroup } from "@/utils/search/buildFilterGroup";
 
 const nestSearchLabels = (labels: TSearchLabel[]): TNestedSearchLabel[] => {
@@ -37,8 +39,6 @@ const nestSearchLabels = (labels: TSearchLabel[]): TNestedSearchLabel[] => {
   return rootLabels;
 };
 
-const getLabelPathSignature = (labelPath: TFilterPathLabel[]) => labelPath.map((label) => label.id).join("/");
-
 interface IProps {
   labels: TSearchLabel[];
   onFiltersChange: (group: TSearchQueryGroup) => void;
@@ -64,6 +64,11 @@ export const CategorySpecificFilters = ({ labels, onFiltersChange }: IProps) => 
     });
   };
 
+  const resetFilters = () => {
+    setCheckedLabelPaths([]);
+    onFiltersChange(null);
+  };
+
   return (
     <>
       <button
@@ -75,7 +80,8 @@ export const CategorySpecificFilters = ({ labels, onFiltersChange }: IProps) => 
         <span>Filters</span>
       </button>
       <Drawer direction="left" open={isOpen} onOpenChange={(open) => setIsOpen(open)} title="Filters">
-        <FiltersContext value={{ checkedLabelPaths, toggleFilter }}>
+        <FiltersContext value={{ checkedLabelPaths, resetFilters, toggleFilter }}>
+          <AppliedFilters />
           <SearchFilterLevel ancestorPath={[]} labels={labelsToDisplay} />
         </FiltersContext>
       </Drawer>

--- a/src/components/_experiment/categorySpecificFilters/CategorySpecificFilters.tsx
+++ b/src/components/_experiment/categorySpecificFilters/CategorySpecificFilters.tsx
@@ -64,7 +64,7 @@ export const CategorySpecificFilters = ({ labels, onFiltersChange }: IProps) => 
     });
   };
 
-  const resetFilters = () => {
+  const clearFilters = () => {
     setCheckedLabelPaths([]);
     onFiltersChange(null);
   };
@@ -80,7 +80,7 @@ export const CategorySpecificFilters = ({ labels, onFiltersChange }: IProps) => 
         <span>Filters</span>
       </button>
       <Drawer direction="left" open={isOpen} onOpenChange={(open) => setIsOpen(open)} title="Filters">
-        <FiltersContext value={{ checkedLabelPaths, resetFilters, toggleFilter }}>
+        <FiltersContext value={{ checkedLabelPaths, clearFilters, toggleFilter }}>
           <AppliedFilters />
           <SearchFilterLevel ancestorPath={[]} labels={labelsToDisplay} />
         </FiltersContext>

--- a/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { TFilterPathLabel } from "@/types";
+
+import { AppliedFilters } from "./AppliedFilters";
+
+const CHECKED_LABEL_PATHS: TFilterPathLabel[][] = [
+  [
+    {
+      id: "author_type::Non-Party",
+      type: "author_type",
+      value: "Non-Party",
+    },
+    {
+      id: "category::UN submission",
+      type: "category",
+      value: "UN submission",
+    },
+  ],
+  [
+    {
+      id: "un_convention::UNCCD",
+      type: "un_convention",
+      value: "UNCCD",
+    },
+    {
+      id: "category::UN submission",
+      type: "category",
+      value: "UN submission",
+    },
+  ],
+  [
+    {
+      id: "entity_type::National Adaptation Plan (NAP)",
+      type: "entity_type",
+      value: "National Adaptation Plan (NAP)",
+    },
+    {
+      id: "un_convention::UNFCCC",
+      type: "un_convention",
+      value: "UNFCCC",
+    },
+    {
+      id: "category::UN submission",
+      type: "category",
+      value: "UN submission",
+    },
+  ],
+];
+
+const meta = {
+  title: "Molecules/AppliedFilters",
+  component: AppliedFilters,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof AppliedFilters>;
+type TStory = StoryObj<typeof AppliedFilters>;
+
+export default meta;
+
+const useFiltersContext = (checkedLabelPaths: TFilterPathLabel[][]) => {
+  return (
+    <FiltersContext
+      value={{
+        checkedLabelPaths,
+        // eslint-disable-next-line no-console
+        resetFilters: () => console.info("resetFilters"),
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
+    >
+      <AppliedFilters />
+    </FiltersContext>
+  );
+};
+
+export const Default: TStory = {
+  render: () => useFiltersContext(CHECKED_LABEL_PATHS),
+};
+
+export const SingleFilter: TStory = {
+  render: () => useFiltersContext([[{ id: "region::Europe", type: "region", value: "Europe" }]]),
+};

--- a/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
@@ -66,7 +66,7 @@ const useFiltersContext = (checkedLabelPaths: TFilterPathLabel[][]) => {
       value={{
         checkedLabelPaths,
         // eslint-disable-next-line no-console
-        resetFilters: () => console.info("resetFilters"),
+        clearFilters: () => console.info("clearFilters"),
         // eslint-disable-next-line no-console
         toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
       }}

--- a/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { TFilterPathLabel } from "@/types";
+
+import { AppliedFilters } from "./AppliedFilters";
+
+const topLevelPath: TFilterPathLabel[] = [{ id: "france", type: "country", value: "France" }];
+const nestedPath: TFilterPathLabel[] = [
+  { id: "paris", type: "city", value: "Paris" },
+  { id: "france", type: "country", value: "France" },
+];
+
+const renderWithFiltersContext = (checkedLabelPaths: TFilterPathLabel[][], resetFilters = vi.fn(), toggleFilter = vi.fn()) =>
+  render(
+    <FiltersContext.Provider value={{ checkedLabelPaths, resetFilters, toggleFilter }}>
+      <AppliedFilters />
+    </FiltersContext.Provider>
+  );
+
+describe("AppliedFilters", () => {
+  it("renders a top-level label", () => {
+    renderWithFiltersContext([topLevelPath]);
+    expect(screen.getByText("France")).toBeInTheDocument();
+  });
+
+  it("renders a nested label", () => {
+    renderWithFiltersContext([nestedPath]);
+    expect(screen.getByText("Paris")).toBeInTheDocument();
+  });
+
+  it("calls toggleFilter when removing an applied filter", async () => {
+    const toggleFilter = vi.fn();
+    renderWithFiltersContext([topLevelPath], vi.fn(), toggleFilter);
+    await userEvent.click(screen.getByRole("button", { name: "Remove France" }));
+    expect(toggleFilter).toHaveBeenCalledWith(topLevelPath, false);
+  });
+
+  it("calls resetFilters when clicking 'Clear all'", async () => {
+    const resetFilters = vi.fn();
+    renderWithFiltersContext([topLevelPath], resetFilters);
+    await userEvent.click(screen.getByRole("button", { name: "Clear all filters" }));
+    expect(resetFilters).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
@@ -13,9 +13,9 @@ const nestedPath: TFilterPathLabel[] = [
   { id: "france", type: "country", value: "France" },
 ];
 
-const renderWithFiltersContext = (checkedLabelPaths: TFilterPathLabel[][], resetFilters = vi.fn(), toggleFilter = vi.fn()) =>
+const renderWithFiltersContext = (checkedLabelPaths: TFilterPathLabel[][], clearFilters = vi.fn(), toggleFilter = vi.fn()) =>
   render(
-    <FiltersContext.Provider value={{ checkedLabelPaths, resetFilters, toggleFilter }}>
+    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters, toggleFilter }}>
       <AppliedFilters />
     </FiltersContext.Provider>
   );
@@ -38,10 +38,10 @@ describe("AppliedFilters", () => {
     expect(toggleFilter).toHaveBeenCalledWith(topLevelPath, false);
   });
 
-  it("calls resetFilters when clicking 'Clear all'", async () => {
-    const resetFilters = vi.fn();
-    renderWithFiltersContext([topLevelPath], resetFilters);
+  it("calls clearFilters when clicking 'Clear all'", async () => {
+    const clearFilters = vi.fn();
+    renderWithFiltersContext([topLevelPath], clearFilters);
     await userEvent.click(screen.getByRole("button", { name: "Clear all filters" }));
-    expect(resetFilters).toHaveBeenCalledOnce();
+    expect(clearFilters).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/molecules/appliedFilters/AppliedFilters.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.tsx
@@ -1,0 +1,49 @@
+import sortBy from "lodash/sortBy";
+import { LucideX } from "lucide-react";
+import { useContext, useMemo } from "react";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { getLabelPathSignature } from "@/utils/filters/filterPaths";
+
+export const AppliedFilters = () => {
+  const { checkedLabelPaths, resetFilters, toggleFilter } = useContext(FiltersContext);
+
+  const labels = useMemo(
+    () =>
+      sortBy(
+        checkedLabelPaths.map((labelPath) => ({ label: labelPath[0], labelPath, sortSignature: getLabelPathSignature([...labelPath].reverse()) })),
+        "sortSignature" // sort by the order that filters appear in the list
+      ),
+    [checkedLabelPaths]
+  );
+
+  if (labels.length === 0) return null;
+
+  return (
+    <ul className="flex flex-wrap gap-2 list-none" aria-label="Applied filters">
+      {labels.map(({ label, labelPath }) => (
+        <li key={label.id} className="flex flex-nowrap gap-1 pl-3 pr-2 py-1 bg-[#0050911a] rounded-full">
+          <span className="text-sm text-text-primary font-medium leading-5">{label.value}</span>
+          <button
+            type="button"
+            className="p-1 -m-1 text-inky-blue"
+            aria-label={`Remove ${label.value}`}
+            onClick={() => toggleFilter(labelPath, false)}
+          >
+            <LucideX size={16} aria-hidden={true} />
+          </button>
+        </li>
+      ))}
+      <li>
+        <button
+          type="button"
+          className="px-3 py-1 text-sm text-text-primary font-normal leading-5"
+          aria-label="Clear all filters"
+          onClick={() => resetFilters()}
+        >
+          Clear all
+        </button>
+      </li>
+    </ul>
+  );
+};

--- a/src/components/molecules/appliedFilters/AppliedFilters.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.tsx
@@ -6,7 +6,7 @@ import { FiltersContext } from "@/context/FiltersContext";
 import { getLabelPathSignature } from "@/utils/filters/filterPaths";
 
 export const AppliedFilters = () => {
-  const { checkedLabelPaths, resetFilters, toggleFilter } = useContext(FiltersContext);
+  const { checkedLabelPaths, clearFilters, toggleFilter } = useContext(FiltersContext);
 
   const labels = useMemo(
     () =>
@@ -39,7 +39,7 @@ export const AppliedFilters = () => {
           type="button"
           className="px-3 py-1 text-sm text-text-primary font-normal leading-5"
           aria-label="Clear all filters"
-          onClick={() => resetFilters()}
+          onClick={() => clearFilters()}
         >
           Clear all
         </button>

--- a/src/components/molecules/searchFilterCategory/SearchFilterCategory.stories.tsx
+++ b/src/components/molecules/searchFilterCategory/SearchFilterCategory.stories.tsx
@@ -13,8 +13,10 @@ const meta = {
   },
   argTypes: {},
   render: (props) => (
-    // eslint-disable-next-line no-console
-    <FiltersContext value={{ checkedLabelPaths: [], toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}>
+    <FiltersContext
+      // eslint-disable-next-line no-console
+      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+    >
       <SearchFilterCategory {...props} />
     </FiltersContext>
   ),

--- a/src/components/molecules/searchFilterCategory/SearchFilterCategory.stories.tsx
+++ b/src/components/molecules/searchFilterCategory/SearchFilterCategory.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   render: (props) => (
     <FiltersContext
       // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
     >
       <SearchFilterCategory {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
+++ b/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   render: (props) => (
     <FiltersContext
       // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
     >
       <SearchFilterGroups {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
+++ b/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
@@ -13,8 +13,10 @@ const meta = {
   },
   argTypes: {},
   render: (props) => (
-    // eslint-disable-next-line no-console
-    <FiltersContext value={{ checkedLabelPaths: [], toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}>
+    <FiltersContext
+      // eslint-disable-next-line no-console
+      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+    >
       <SearchFilterGroups {...props} />
     </FiltersContext>
   ),

--- a/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
+++ b/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   render: (props) => (
     <FiltersContext
       // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
     >
       <SearchFilterLookup {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
+++ b/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
@@ -13,8 +13,10 @@ const meta = {
   },
   argTypes: {},
   render: (props) => (
-    // eslint-disable-next-line no-console
-    <FiltersContext value={{ checkedLabelPaths: [], toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}>
+    <FiltersContext
+      // eslint-disable-next-line no-console
+      value={{ checkedLabelPaths: [], resetFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+    >
       <SearchFilterLookup {...props} />
     </FiltersContext>
   ),

--- a/src/context/FiltersContext.ts
+++ b/src/context/FiltersContext.ts
@@ -6,10 +6,12 @@ export type TToggleFilterCallback = (labelPath: TFilterPathLabel[], checked: boo
 
 interface IFiltersContext {
   checkedLabelPaths: TFilterPathLabel[][];
+  resetFilters: () => void;
   toggleFilter: TToggleFilterCallback;
 }
 
 export const FiltersContext = createContext<IFiltersContext>({
   checkedLabelPaths: [],
+  resetFilters: () => {},
   toggleFilter: () => {},
 });

--- a/src/context/FiltersContext.ts
+++ b/src/context/FiltersContext.ts
@@ -6,12 +6,12 @@ export type TToggleFilterCallback = (labelPath: TFilterPathLabel[], checked: boo
 
 interface IFiltersContext {
   checkedLabelPaths: TFilterPathLabel[][];
-  resetFilters: () => void;
+  clearFilters: () => void;
   toggleFilter: TToggleFilterCallback;
 }
 
 export const FiltersContext = createContext<IFiltersContext>({
   checkedLabelPaths: [],
-  resetFilters: () => {},
+  clearFilters: () => {},
   toggleFilter: () => {},
 });

--- a/src/utils/filters/filterPaths.ts
+++ b/src/utils/filters/filterPaths.ts
@@ -5,3 +5,5 @@ export const getFilterPathLabel = (nestedSearchLabel: TNestedSearchLabel): TFilt
   type: nestedSearchLabel.type,
   value: nestedSearchLabel.value,
 });
+
+export const getLabelPathSignature = (labelPath: TFilterPathLabel[]) => labelPath.map((label) => label.id).join("/");


### PR DESCRIPTION
# What's changed

- Added `AppliedFilters` molecule component:
  - Uses `FiltersContext` to render a pill for each selected filter.
  - Functional remove filter and clear all buttons.
  - Currently resides within the modal rendered by `CategorySpecificFilters` but will be moved out in the next ticket.
- Unit tests and Storybook stories.

## Why

Satisfies [APP-2205](https://linear.app/climate-policy-radar/issue/APP-2205/build-an-applied-filters-component)

## AI attribution

Claude used to generate Storybook stories and tests but both verified and tweaked by hand.

## Screenshots

<img width="897" height="1336" alt="Screenshot 2026-06-22 at 16 08 31" src="https://github.com/user-attachments/assets/2a80a11b-67f7-43a3-bf00-c34804c2539c" />
