### PR TITLE
Fix incorrect CSS rule for applying highlight style

### DIFF
--- a/src/components/_experiment/searchResults/SearchResults.module.css
+++ b/src/components/_experiment/searchResults/SearchResults.module.css
@@ -1,7 +1,0 @@
-@reference "tailwindcss";
-
-.highlights {
-  :global(hi) {
-    @apply bg-yellow-200;
-  }
-}

--- a/src/components/_experiment/searchResults/SearchResults.tsx
+++ b/src/components/_experiment/searchResults/SearchResults.tsx
@@ -6,7 +6,6 @@ import { DocumentCard } from "@/components/molecules/documentCard/DocumentCard";
 import { TSearchQueryGroup } from "@/types";
 import { stripEmptyValueRules } from "@/utils/filters/advancedFilters";
 
-import styles from "./SearchResults.module.css";
 import { isFilterGroupEmpty } from "../advancedFilters/AdvancedFilters";
 import { EmptySearch } from "../emptySearch/EmptySearch";
 
@@ -37,13 +36,13 @@ function SearchResults({
         {data.results.map((result) => (
           <Fragment key={result.id}>
             {isPrincipal(result) && (
-              <li className={`flex flex-col ${styles["highlights"]}`}>
+              <li className={`flex flex-col highlights`}>
                 <DocumentCard document={result} onClick={onResultClicked} />
               </li>
             )}
             {/* TODO: remove non-principal results */}
             {!isPrincipal(result) && (
-              <li className={`flex gap-2 border border-transparent rounded-md py-2 pr-6 ${styles["highlights"]}`}>
+              <li className={`flex gap-2 border border-transparent rounded-md py-2 pr-6 highlights`}>
                 <p>Shouldn't be showing a non-principle doc here</p>
               </li>
             )}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -40,8 +40,6 @@
   }
 }
 
-.highlights {
-  ::global(hi) {
-    @apply bg-yellow-200;
-  }
+.highlights:has(hi) hi {
+  @apply bg-yellow-200;
 }


### PR DESCRIPTION
# What's changed
- Fixing a bug with how we have the css for highlights
- Simplify the use-case so that we can just add the class of "highlights" to places we want to have them

## Why
- Triggering an error in the logs due to invalid CSS

## AI attribution
- Advising on a fix
