### PR TITLE
APP-2213 :: Principle slide-out header

### DIFF
--- a/src/components/_experiment/documentDrawer/DocumentDrawer.tsx
+++ b/src/components/_experiment/documentDrawer/DocumentDrawer.tsx
@@ -1,4 +1,4 @@
-import { LucideFileText } from "lucide-react";
+import { LucideExternalLink, LucideFileText } from "lucide-react";
 import { useState } from "react";
 
 import { SearchDocument } from "@/api/search";
@@ -33,14 +33,23 @@ export function DocumentDrawer({ document, open, onOpenChange }: TDocumentDrawer
       title={
         document ? (
           linkHref(document) ? (
-            <a
-              href={linkHref(document)!}
-              className="text-inky-blue underline-offset-5 hover:underline"
-              dangerouslySetInnerHTML={{ __html: document.title }}
-            />
+            <span className="block pt-5">
+              <a
+                href={linkHref(document)!}
+                className="text-3xl text-inky-blue underline-offset-5 hover:underline"
+                dangerouslySetInnerHTML={{ __html: document.title }}
+              />
+            </span>
           ) : (
             <span dangerouslySetInnerHTML={{ __html: document.title }} />
           )
+        ) : undefined
+      }
+      titleExtras={
+        document && linkHref(document) ? (
+          <a target="_blank" href={linkHref(document)!} className="text-neutral-500 hover:text-neutral-800 justify-end">
+            <LucideExternalLink width={20} height={20} />
+          </a>
         ) : undefined
       }
     >

--- a/src/components/atoms/drawer/Drawer.module.css
+++ b/src/components/atoms/drawer/Drawer.module.css
@@ -42,10 +42,7 @@
   /* how much the current drawer has shrunk compared to its original size, used to further offset the drawer as it scales down to maintain the visual gap between stacked drawers */
   --stack-shrink: calc(1 - var(--stack-scale));
 
-  @apply box-border relative bg-white overflow-y-auto overscroll-contain will-change-transform flex flex-col rounded-2xl p-4;
-
-  /* Accounts for iOS safe area on the right edge */
-  padding-right: calc(1.5rem + env(safe-area-inset-right, 0px));
+  @apply box-border relative bg-white overflow-y-auto overscroll-contain will-change-transform flex flex-col gap-10 rounded-2xl;
 
   transition:
     transform 250ms cubic-bezier(0.32, 0.72, 0, 1),

--- a/src/components/atoms/drawer/Drawer.tsx
+++ b/src/components/atoms/drawer/Drawer.tsx
@@ -9,8 +9,9 @@ type TDirection = "left" | "right" | "top" | "bottom";
 
 type TProps = Omit<DrawerRootProps, "swipeDirection"> & {
   children?: React.ReactNode;
+  childrenClassName?: string;
   title?: React.ReactNode;
-  className?: string;
+  titleExtras?: React.ReactNode;
   direction?: TDirection;
 };
 
@@ -21,24 +22,27 @@ const swipeDirectionMap: Record<TDirection, "left" | "right" | "up" | "down"> = 
   bottom: "down",
 };
 
-export const Drawer = ({ children, title, className, direction = "right", ...rootProps }: TProps) => {
+export const Drawer = ({ children, childrenClassName, title, titleExtras, direction = "right", ...rootProps }: TProps) => {
   return (
     <BaseDrawer.Root {...rootProps} swipeDirection={swipeDirectionMap[direction]}>
       <BaseDrawer.Portal>
         <BaseDrawer.Backdrop className="fixed inset-0 bg-inky-black duration-200 [--backdrop-opacity:0.2] min-h-dvh opacity-[calc(var(--backdrop-opacity)*(1-var(--drawer-swipe-progress)))] transition-opacity ease-[cubic-bezier(0.32,0.72,0,1)] data-swiping:duration-0 data-ending-style:opacity-0 data-starting-style:opacity-0" />
-        <BaseDrawer.Viewport className={joinTailwindClasses(styles.DrawerViewport, className)} data-direction={direction}>
+        <BaseDrawer.Viewport className={styles.DrawerViewport} data-direction={direction}>
           <BaseDrawer.Popup className={styles.DrawerContent} data-direction={direction}>
-            <div className="flex items-start justify-between mb-2 pb-2 border-b border-neutral-200">
+            <div className="flex items-start justify-between p-7 pb-0">
               {!!title && (
-                <BaseDrawer.Title className="text-xl font-semibold flex-1 mr-4" data-base-ui-swipe-ignore>
+                <BaseDrawer.Title className="text-xl font-semibold flex-1" data-base-ui-swipe-ignore>
                   {title}
                 </BaseDrawer.Title>
               )}
-              <BaseDrawer.Close className="text-neutral-500 hover:text-neutral-800 shrink-0 justify-end">
-                <LucideX width={20} height={20} />
-              </BaseDrawer.Close>
+              <div data-base-ui-swipe-ignore className="flex items-center gap-4 shrink-0">
+                {titleExtras}
+                <BaseDrawer.Close className="text-neutral-500 hover:text-neutral-800 justify-end">
+                  <LucideX width={20} height={20} />
+                </BaseDrawer.Close>
+              </div>
             </div>
-            <div data-base-ui-swipe-ignore className="overflow-y-auto">
+            <div data-base-ui-swipe-ignore className={joinTailwindClasses("overflow-y-auto p-7 pt-0", childrenClassName)}>
               {children}
             </div>
           </BaseDrawer.Popup>


### PR DESCRIPTION
# What's change
- Add more control for a custom header in the Drawer component, as well as space for extras in the title
- There are default styles for the `Drawer` that covers us for a typical use-case, but for the principle slide-out there was a need for more controls, such as a link and icon

## Why
- The principle slide-out/drawer content has some particular functionalities which the default drawer header did not support

## AI attribution
- None

## Screenshot
- Custom classNames and jsx:
<img width="818" height="163" alt="Screenshot 2026-06-24 at 12 11 41" src="https://github.com/user-attachments/assets/a07371c4-3e96-4b7d-98c8-59d8c2e6e7f6" />

- Default drawer header:
<img width="818" height="163" alt="Screenshot 2026-06-24 at 12 18 37" src="https://github.com/user-attachments/assets/e9a166c3-fa89-4e9d-9cb0-1fd1be294ab0" />


