### PR TITLE
tags bot in waf and ingests signal into posthog

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -384,6 +384,7 @@ if not is_review_stack_or_template:
                     "Accept",
                     "Access-Control-Request-Method",
                     "Access-Control-Request-Headers",
+                    "x-amzn-waf-is-bot",
                 ],
             ),
             cookies=CookieConfig(
@@ -553,6 +554,8 @@ if not is_review_stack_or_template:
 
     frontend_web_acl = FrontendWebAcl(
         name=f"{theme}-{env}-frontend-waf",
+        # Bot Control is a paid add-on; only run it in production.
+        enable_bot_control=env == "production",
         tags={"CUSTOM_APP_THEME": theme, "Environment": env},
     )
 

--- a/infra/resources/waf.py
+++ b/infra/resources/waf.py
@@ -19,6 +19,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
     def __init__(
         self,
         name: str,
+        enable_bot_control: bool = False,
         tags: dict[str, str] | None = None,
         opts: pulumi.ResourceOptions | None = None,
     ):
@@ -77,6 +78,74 @@ class FrontendWebAcl(pulumi.ComponentResource):
             ),
         )
 
+        rules = [count_chrome_125]
+
+        # Bot Control is a paid managed rule group (~$10/mo per WebACL + a
+        # per-request fee), so only enable it in production.
+        if enable_bot_control:
+            # Common level, count-only: overriding to count still emits labels
+            # for later rules to match - it just never blocks or challenges.
+            bot_control = aws.wafv2.WebAclRuleArgs(
+                name="BotControlCommon",
+                priority=1,
+                override_action=aws.wafv2.WebAclRuleOverrideActionArgs(
+                    count=aws.wafv2.WebAclRuleOverrideActionCountArgs(),
+                ),
+                statement=aws.wafv2.WebAclRuleStatementArgs(
+                    managed_rule_group_statement=aws.wafv2.WebAclRuleStatementManagedRuleGroupStatementArgs(
+                        vendor_name="AWS",
+                        name="AWSManagedRulesBotControlRuleSet",
+                        managed_rule_group_configs=[
+                            aws.wafv2.WebAclRuleStatementManagedRuleGroupStatementManagedRuleGroupConfigArgs(
+                                aws_managed_rules_bot_control_rule_set=aws.wafv2.WebAclRuleStatementManagedRuleGroupStatementManagedRuleGroupConfigAwsManagedRulesBotControlRuleSetArgs(
+                                    inspection_level="COMMON",
+                                    # ML is Targeted-level only; off here avoids TGT_ML_* charges.
+                                    enable_machine_learning=False,
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+                visibility_config=aws.wafv2.WebAclRuleVisibilityConfigArgs(
+                    cloudwatch_metrics_enabled=True,
+                    metric_name="BotControlCommon",
+                    sampled_requests_enabled=True,
+                ),
+            )
+
+            # Flag bots for the origin. WAF prefixes inserted headers, so this
+            # arrives as `x-amzn-waf-is-bot: true`. Priority 2 runs after Bot
+            # Control so its labels exist.
+            flag_bot_traffic = aws.wafv2.WebAclRuleArgs(
+                name="FlagBotTraffic",
+                priority=2,
+                action=aws.wafv2.WebAclRuleActionArgs(
+                    count=aws.wafv2.WebAclRuleActionCountArgs(
+                        custom_request_handling=aws.wafv2.WebAclRuleActionCountCustomRequestHandlingArgs(
+                            insert_headers=[
+                                aws.wafv2.WebAclRuleActionCountCustomRequestHandlingInsertHeaderArgs(
+                                    name="is-bot",
+                                    value="true",
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+                statement=aws.wafv2.WebAclRuleStatementArgs(
+                    label_match_statement=aws.wafv2.WebAclRuleStatementLabelMatchStatementArgs(
+                        scope="NAMESPACE",
+                        key="awswaf:managed:aws:bot-control:",
+                    ),
+                ),
+                visibility_config=aws.wafv2.WebAclRuleVisibilityConfigArgs(
+                    cloudwatch_metrics_enabled=True,
+                    metric_name="FlagBotTraffic",
+                    sampled_requests_enabled=True,
+                ),
+            )
+
+            rules += [bot_control, flag_bot_traffic]
+
         self.web_acl = aws.wafv2.WebAcl(
             name,
             name=name,
@@ -85,7 +154,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
             default_action=aws.wafv2.WebAclDefaultActionArgs(
                 allow=aws.wafv2.WebAclDefaultActionAllowArgs(),
             ),
-            rules=[count_chrome_125],
+            rules=rules,
             visibility_config=aws.wafv2.WebAclVisibilityConfigArgs(
                 cloudwatch_metrics_enabled=True,
                 metric_name=f"{name}-web-acl",

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { trace } from "@opentelemetry/api";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export default function middleware() {
+export default function middleware(request: NextRequest) {
   const response = NextResponse.next();
   const current = trace.getActiveSpan();
 
@@ -9,5 +9,10 @@ export default function middleware() {
   if (current) {
     response.headers.set("server-timing", `traceparent;desc="00-${current.spanContext().traceId}-${current.spanContext().spanId}-01"`);
   }
+
+  // Surface WAF's bot signal as a client-readable cookie for posthog-js.
+  const isBot = request.headers.get("x-amzn-waf-is-bot") === "true";
+  response.cookies.set("is_bot", String(isBot), { httpOnly: false, path: "/", sameSite: "lax" });
+
   return response;
 }

--- a/src/context/PostHogInit.tsx
+++ b/src/context/PostHogInit.tsx
@@ -5,6 +5,8 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react";
 import { Suspense, useEffect } from "react";
 
+import { getCookie } from "@/utils/cookies";
+
 type TPostHogPageViewProps = {
   consent?: boolean;
   pageViewProps?: Record<string, unknown>;
@@ -75,6 +77,9 @@ export default function PostHogInit({ consent = false, pageViewProps = {} }: TPo
       capture_pageview: true,
       capture_pageleave: true,
     });
+    // Tag every event with the WAF bot signal (set as a cookie by middleware.ts)
+    // so suspected bot traffic can be filtered out in PostHog.
+    posthog.register({ is_bot: getCookie("is_bot") === "true" });
     window.sessionStorage.setItem("posthogLoaded", "true");
   }, []);
 


### PR DESCRIPTION
# What's changed

Enables AWS WAF Bot Control on the frontend WebACL (production only, count-only mode) and wires the signal through to PostHog so bot traffic can be filtered out of analytics.

- `infra/resources/waf.py`: adds an `enable_bot_control` flag to `FrontendWebAcl`. When it's on, WAF runs the standard `AWSManagedRulesBotControlRuleSet` (common inspection, ML off) purely to label traffic, then a second rule stamps an `x-amzn-waf-is-bot: true` header onto anything it flagged. Nothing here blocks, it just watches and tags.
- `infra/__main__.py`: enables Bot Control on only when env == "production", and adds `x-amzn-waf-is-bot` to the CloudFront origin request policy so the header actually makes it through to the app.
- `middleware.ts`: reads the header and writes a client-readable `is_bot` cookie.
- `src/context/PostHogInit.tsx`: registers `is_bot` as a super-property so every event is tagged.

Flow: WAF (count) → x-amzn-waf-is-bot header → CloudFront forwards → middleware sets is_bot cookie → PostHog tags events.

Bot Control runs in count-only mode - it never blocks, challenges, or slows any request; it only observes and labels. 
Gated to production because it's a paid add-on (~$10/mo per WebACL + ~$1/1M requests analysed)

## Costs
Bot Control subscription: 4 production themes (ccc, cclw, cpr, mcf) × $10/mo = $40/mo
Request analysis: ~$1.00 per 1M requests (common level; on top of the existing ~$0.60/1M WAF fee)
Staging and review stacks are unaffected (Bot Control is production-only).

## Why
Bot traffic inflates our PostHog pageview/event metrics and skews the numbers we rely on. Tagging suspected bot requests lets us filter them out in analytics without blocking any real users. (APP-2230)

## AI attribution
Written with help from Claude. Human reviewed.

## Screenshots
N/A - no UI changes