### PR TITLE
APP-2194: Build a filter panel component

### DIFF
--- a/src/components/atoms/drawer/Drawer.tsx
+++ b/src/components/atoms/drawer/Drawer.tsx
@@ -1,5 +1,6 @@
 import { Drawer as BaseDrawer, DrawerRootProps } from "@base-ui/react/drawer";
 import { LucideX } from "lucide-react";
+import { ReactNode } from "react";
 
 import { joinTailwindClasses } from "@/utils/tailwind";
 
@@ -8,10 +9,10 @@ import styles from "./Drawer.module.css";
 type TDirection = "left" | "right" | "top" | "bottom";
 
 type TProps = Omit<DrawerRootProps, "swipeDirection"> & {
-  children?: React.ReactNode;
+  children?: ReactNode;
   childrenClassName?: string;
-  title?: React.ReactNode;
-  titleExtras?: React.ReactNode;
+  title?: ReactNode;
+  titleExtras?: ReactNode;
   direction?: TDirection;
   wide?: boolean;
 };

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -26,7 +26,7 @@ export const Input = ({
   ...props
 }: IProps) => {
   const allContainerClasses = joinTailwindClasses(
-    "w-full px-2 flex flex-row justify-around items-center bg-bg-flat rounded-md outline-inky-blue focus-within:outline",
+    "w-full px-2 flex flex-row justify-around items-center bg-bg-flat rounded-md outline-inky-blue -outline-offset-1 focus-within:outline",
     containerClasses
   );
   const allInputClasses = joinTailwindClasses(

--- a/src/components/molecules/searchFilter/SearchFilter.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.tsx
@@ -6,6 +6,7 @@ import { FiltersContext } from "@/context/FiltersContext";
 import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
 import { getFilterPathLabel } from "@/utils/filters/filterPaths";
 import { getFilterStatus } from "@/utils/filters/getFilterStatus";
+import { firstCase } from "@/utils/text";
 
 interface IProps {
   ancestorPath: TFilterPathLabel[];
@@ -21,7 +22,7 @@ export const SearchFilter = ({ ancestorPath, label }: IProps) => {
   return (
     <li>
       <Checkbox checked={checked === true} indeterminate={checked === "indeterminate"} onCheckedChange={(value) => toggleFilter(pathLabels, value)}>
-        {label.value}
+        {firstCase(label.value)}
       </Checkbox>
       {label.children.length > 0 && <SearchFilterLevel ancestorPath={pathLabels} labels={label.children} indented />}
     </li>

--- a/src/components/molecules/searchFilterLookup/SearchFilterLookup.tsx
+++ b/src/components/molecules/searchFilterLookup/SearchFilterLookup.tsx
@@ -3,7 +3,6 @@ import { useMemo, useState } from "react";
 import { Input } from "@/components/atoms/input/Input";
 import { SearchFilter } from "@/components/molecules/searchFilter/SearchFilter";
 import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
-import { getFilterPathLabel } from "@/utils/filters/filterPaths";
 
 const MAX_OPTIONS = 8;
 
@@ -33,11 +32,9 @@ export const SearchFilterLookup = ({ ancestorPath, labels }: IProps) => {
         onClear={() => setSearchText("")}
       />
       <ul className="flex flex-col gap-2 list-none">
-        {clippedOptions.map((option) => {
-          const pathLabels = [getFilterPathLabel(option), ...ancestorPath];
-
-          return <SearchFilter key={option.id} ancestorPath={pathLabels} label={option} />;
-        })}
+        {clippedOptions.map((option) => (
+          <SearchFilter key={option.id} ancestorPath={ancestorPath} label={option} />
+        ))}
       </ul>
       {isOverflowing && (
         <button

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
@@ -41,6 +41,7 @@ export const Default: TStory = {
   args: {
     filterGroup: {
       title: "Category",
+      subtitle: "Choose themes and specific filters to refine your search",
       Icon: ListFilter,
       container: "drawer",
       rootLabelTypes: ["category"],

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ListFilter } from "lucide-react";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { TNestedSearchLabel } from "@/types";
+
+import { SearchFiltersDrawer } from "./SearchFiltersDrawer";
+
+const meta = {
+  title: "Molecules/SearchFiltersDrawer",
+  component: SearchFiltersDrawer,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+  render: (props) => (
+    <FiltersContext
+      // eslint-disable-next-line no-console
+      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+    >
+      <SearchFiltersDrawer {...props} />
+    </FiltersContext>
+  ),
+} satisfies Meta<typeof SearchFiltersDrawer>;
+type TStory = StoryObj<typeof SearchFiltersDrawer>;
+
+const generateLabel = (value: string): TNestedSearchLabel => ({
+  id: `category::${value}`,
+  type: "category",
+  value,
+  children: [],
+});
+
+const CATEGORY_LABELS = ["Corporate Disclosure", "Law", "Litigation", "Multilateral Climate Fund project", "Policy", "Report", "UN Submission"].map(
+  generateLabel
+);
+
+export default meta;
+
+export const Default: TStory = {
+  args: {
+    filterGroup: {
+      title: "Category",
+      Icon: ListFilter,
+      container: "drawer",
+      rootLabelTypes: ["category"],
+      nestedLabels: CATEGORY_LABELS,
+    },
+  },
+};

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
@@ -8,22 +8,22 @@ interface IProps {
   filterGroup: TFiltersGroup;
 }
 
-export const CategorySpecificFilters = ({ filterGroup }: IProps) => {
+export const SearchFiltersDrawer = ({ filterGroup }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { Icon, title, nestedLabels } = filterGroup;
+  const { Icon, nestedLabels, title } = filterGroup;
 
   return (
     <>
       <button
         type="button"
-        className="flex gap-2 items-center px-3 py-2 text-sm text-text-primary font-medium leading-5 border border-border-normal rounded-full"
+        className="flex gap-2 items-center px-3 py-2 bg-bg-primary text-sm text-text-primary font-medium leading-5 border border-border-normal rounded-full"
         onClick={() => setIsOpen((current) => !current)}
       >
         {Icon && <Icon size={16} className="text-elem-icon" />}
         <span>{title}</span>
       </button>
       <Drawer direction="left" open={isOpen} onOpenChange={(open) => setIsOpen(open)} title={title}>
-        <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} />
+        <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} inDrawer />
       </Drawer>
     </>
   );

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
@@ -10,7 +10,9 @@ interface IProps {
 
 export const SearchFiltersDrawer = ({ filterGroup }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { Icon, nestedLabels, title } = filterGroup;
+
+  if (filterGroup.container !== "drawer") return null;
+  const { Icon, nestedLabels, subtitle, title } = filterGroup;
 
   return (
     <>
@@ -22,7 +24,17 @@ export const SearchFiltersDrawer = ({ filterGroup }: IProps) => {
         {Icon && <Icon size={16} className="text-elem-icon" />}
         <span>{title}</span>
       </button>
-      <Drawer direction="left" open={isOpen} onOpenChange={(open) => setIsOpen(open)} title={title}>
+      <Drawer
+        direction="left"
+        open={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        title={
+          <>
+            <span>{title}</span>
+            {subtitle && <span className="block mt-3 text-base text-text-secondary font-normal leading-6">{subtitle}</span>}
+          </>
+        }
+      >
         <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} inDrawer />
       </Drawer>
     </>

--- a/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.stories.tsx
+++ b/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.stories.tsx
@@ -1,0 +1,59 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { TNestedSearchLabel } from "@/types";
+
+import { SearchFiltersPopover } from "./SearchFiltersPopover";
+
+const meta = {
+  title: "Molecules/SearchFiltersPopover",
+  component: SearchFiltersPopover,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+  render: (props) => (
+    <FiltersContext
+      // eslint-disable-next-line no-console
+      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+    >
+      <SearchFiltersPopover {...props} />
+    </FiltersContext>
+  ),
+} satisfies Meta<typeof SearchFiltersPopover>;
+type TStory = StoryObj<typeof SearchFiltersPopover>;
+
+const generateLabel = (value: string): TNestedSearchLabel => ({
+  id: `concept::${value}`,
+  type: "region",
+  value,
+  children: [],
+});
+
+const CONCEPT_LABELS = [
+  "Adaptation enabling factor",
+  "Adaptation finance",
+  "Adaptation/resilience",
+  "Agriculture sector",
+  "Air pollution risk",
+  "Aligning skills",
+  "Ban",
+  "Bioenergy",
+  "Carbon dioxide",
+  "Central bank",
+  "Chemical impact",
+  "Climate finance",
+].map(generateLabel);
+
+export default meta;
+
+export const Default: TStory = {
+  args: {
+    filterGroup: {
+      title: "Topics",
+      container: "popover",
+      rootLabelTypes: ["concept"],
+      nestedLabels: CONCEPT_LABELS,
+    },
+  },
+};

--- a/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
+++ b/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
@@ -1,0 +1,29 @@
+import { Popover as BasePopover } from "@base-ui/react/popover";
+import { ChevronDown } from "lucide-react";
+
+import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
+import { TFiltersGroup } from "@/types";
+
+interface IProps {
+  filterGroup: TFiltersGroup;
+}
+
+export const SearchFiltersPopover = ({ filterGroup }: IProps) => {
+  const { nestedLabels, title } = filterGroup;
+
+  return (
+    <BasePopover.Root>
+      <BasePopover.Trigger className="flex gap-2 items-center px-3 py-2 bg-bg-primary data-popup-open:bg-bg-flat text-sm text-text-primary font-medium leading-5 border border-border-normal rounded-full">
+        <span>{title}</span>
+        <ChevronDown size={16} className="text-elem-icon" />
+      </BasePopover.Trigger>
+      <BasePopover.Portal>
+        <BasePopover.Positioner positionMethod="fixed" side="bottom" sideOffset={8} align="start" className="">
+          <BasePopover.Popup className="w-83 max-h-[calc(100dvh-12px)] px-6 py-5 bg-bg-primary border border-border-normal rounded-xl shadow-2xl">
+            <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} />
+          </BasePopover.Popup>
+        </BasePopover.Positioner>
+      </BasePopover.Portal>
+    </BasePopover.Root>
+  );
+};

--- a/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
+++ b/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
@@ -9,6 +9,7 @@ interface IProps {
 }
 
 export const SearchFiltersPopover = ({ filterGroup }: IProps) => {
+  if (filterGroup.container !== "popover") return null;
   const { nestedLabels, title } = filterGroup;
 
   return (

--- a/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
+++ b/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.tsx
@@ -19,7 +19,7 @@ export const SearchFiltersPopover = ({ filterGroup }: IProps) => {
       </BasePopover.Trigger>
       <BasePopover.Portal>
         <BasePopover.Positioner positionMethod="fixed" side="bottom" sideOffset={8} align="start" className="">
-          <BasePopover.Popup className="w-83 max-h-[calc(100dvh-12px)] px-6 py-5 bg-bg-primary border border-border-normal rounded-xl shadow-2xl">
+          <BasePopover.Popup className="w-83 max-h-[calc(100dvh-12px)] px-6 py-5 bg-bg-primary border border-border-normal rounded-xl shadow-2xl overflow-y-auto">
             <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} />
           </BasePopover.Popup>
         </BasePopover.Positioner>

--- a/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
+++ b/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
@@ -1,9 +1,10 @@
 import uniqBy from "lodash/uniqBy";
 import { parseAsJson, useQueryState } from "nuqs";
-import { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 
-import { CategorySpecificFilters } from "@/components/_experiment/categorySpecificFilters/CategorySpecificFilters";
 import { AppliedFilters } from "@/components/molecules/appliedFilters/AppliedFilters";
+import { SearchFiltersDrawer } from "@/components/molecules/searchFiltersDrawer/SearchFiltersDrawer";
+import { SearchFiltersPopover } from "@/components/molecules/searchFiltersPopover/SearchFiltersPopover";
 import { FILTER_GROUPS } from "@/constants/filters";
 import { FiltersContext, TToggleFilterCallback } from "@/context/FiltersContext";
 import { FilterGroupSchema } from "@/schemas";
@@ -44,12 +45,16 @@ export const FiltersAndSort = ({ labels }: IProps) => {
   return (
     <FiltersContext value={{ checkedLabelPaths, clearFilters, toggleFilter }}>
       <div className="col-start-1 -col-end-1 cols-5:col-start-2 cols-5:-col-end-2 flex flex-wrap gap-1">
-        {filterGroups.map((group) => (
-          <>
-            {group.afterPartition && <div className="w-px h-full mx-3 bg-border-normal" />}
-            <CategorySpecificFilters key={group.title} filterGroup={group} />
-          </>
-        ))}
+        {filterGroups.map((group) => {
+          const SearchFilters = group.container === "drawer" ? SearchFiltersDrawer : SearchFiltersPopover;
+
+          return (
+            <Fragment key={group.title}>
+              {group.afterPartition && <div className="w-px h-full mx-3 bg-border-normal" />}
+              <SearchFilters filterGroup={group} />
+            </Fragment>
+          );
+        })}
       </div>
       <AppliedFilters />
     </FiltersContext>

--- a/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
+++ b/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
@@ -20,7 +20,7 @@ interface IProps {
 // Render a set of label peers depending on content and composition
 export const SearchFilterLevel = ({ ancestorPath, indented, inDrawer, labels }: IProps) => {
   const isLongShallowList = useMemo(() => labels.length > LOOKUP_THRESHOLD && labels.every((label) => label.children.length === 0), [labels]);
-  const sortedLabels = useMemo(() => sortBy(labels, "id"), [labels]);
+  const sortedLabels = useMemo(() => sortBy(labels, "value"), [labels]);
 
   const indentedClasses = indented && "ml-8 mt-2 not-last:mb-2";
   const labelTypes = new Set(labels.map((label) => label.type));

--- a/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
+++ b/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
@@ -13,19 +13,21 @@ const LOOKUP_THRESHOLD = 8;
 interface IProps {
   ancestorPath: TFilterPathLabel[];
   indented?: boolean;
+  inDrawer?: boolean; // Top level SearchFilterLevel inside a drawer component
   labels: TNestedSearchLabel[];
 }
 
 // Render a set of label peers depending on content and composition
-export const SearchFilterLevel = ({ ancestorPath, indented, labels }: IProps) => {
+export const SearchFilterLevel = ({ ancestorPath, indented, inDrawer, labels }: IProps) => {
   const isLongShallowList = useMemo(() => labels.length > LOOKUP_THRESHOLD && labels.every((label) => label.children.length === 0), [labels]);
   const sortedLabels = useMemo(() => sortBy(labels, "id"), [labels]);
 
   const indentedClasses = indented && "ml-8 mt-2 not-last:mb-2";
+  const labelTypes = new Set(labels.map((label) => label.type));
 
   // Categories
-  const labelsAreCategories = ancestorPath.length === 0 && labels.every((label) => label.type === "category");
-  if (labelsAreCategories) {
+  const levelIsParents = inDrawer && ancestorPath.length === 0 && labelTypes.size === 1;
+  if (levelIsParents) {
     return (
       <ul className={joinTailwindClasses("list-none", indentedClasses)}>
         {sortedLabels.map((label) => (
@@ -36,7 +38,6 @@ export const SearchFilterLevel = ({ ancestorPath, indented, labels }: IProps) =>
   }
 
   // Grouped by type
-  const labelTypes = new Set(labels.map((label) => label.type));
   if (labelTypes.size > 1) {
     return <SearchFilterGroups ancestorPath={ancestorPath} labels={labels} />;
   }
@@ -44,9 +45,9 @@ export const SearchFilterLevel = ({ ancestorPath, indented, labels }: IProps) =>
   // Searchable checkboxes
   if (isLongShallowList) {
     return (
-      <li className={indentedClasses}>
+      <div className={joinTailwindClasses(indentedClasses, "max-h-full overflow-y-auto")}>
         <SearchFilterLookup ancestorPath={ancestorPath} labels={sortedLabels} />
-      </li>
+      </div>
     );
   }
 

--- a/src/components/organisms/searchFilterPanel/SearchFilterPanel.tsx
+++ b/src/components/organisms/searchFilterPanel/SearchFilterPanel.tsx
@@ -1,0 +1,41 @@
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+import { FilterPopover } from "@/components/_experiment/searchFilters/FilterPopover";
+import { Drawer } from "@/components/atoms/drawer/Drawer";
+import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
+import { TFiltersGroup } from "@/types";
+
+interface IProps {
+  filterGroup: TFiltersGroup;
+}
+
+export const SearchFilterPanel = ({ filterGroup }: IProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { container, Icon, title, nestedLabels } = filterGroup;
+
+  return (
+    <>
+      {/* Button */}
+      <button
+        type="button"
+        className="flex gap-2 items-center px-3 py-2 text-sm text-text-primary font-medium leading-5 border border-border-normal rounded-full"
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        {container === "drawer" && Icon && <Icon size={16} className="text-elem-icon" />}
+        <span>{title}</span>
+        {container === "popover" && <ChevronDown size={16} className="text-elem-icon" />}
+      </button>
+      {/* Filters */}
+      {container === "drawer" ? (
+        <Drawer direction="left" open={isOpen} onOpenChange={(open) => setIsOpen(open)} title={title}>
+          <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} />
+        </Drawer>
+      ) : (
+        <FilterPopover>
+          <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} />
+        </FilterPopover>
+      )}
+    </>
+  );
+};

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -5,12 +5,14 @@ import { TFiltersGroupConfig } from "@/types";
 export const FILTER_GROUPS: TFiltersGroupConfig[] = [
   {
     title: "Filters",
+    subtitle: "Choose themes and specific filters to refine your search",
     Icon: ListFilter,
     container: "drawer",
     rootLabelTypes: ["category"],
   },
   {
     title: "Geography",
+    subtitle: "Publish location of main document",
     Icon: Earth,
     container: "drawer",
     rootLabelTypes: ["region"],

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -84,6 +84,7 @@
   --breakpoint-cols-4: 900px;
   --breakpoint-cols-5: 1100px;
 
+  --shadow-2xl: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   --shadow-lg: 0px 4px 48px 0px rgba(0, 0, 0, 0.08);
   --shadow-md: 0px 4px 16px 0px rgba(0, 0, 0, 0.08);
   --shadow-xs: 0px 2px 2px 0px rgba(0, 0, 0, 0.08);

--- a/src/types/search/filters.ts
+++ b/src/types/search/filters.ts
@@ -4,13 +4,25 @@ import { TNestedSearchLabel } from "./labels";
 
 export type TCheckboxState = boolean | "indeterminate";
 
-export type TFiltersGroupConfig = {
+type TFiltersGroupDrawerConfig = {
   title: string;
-  Icon?: LucideIcon;
-  container: "drawer" | "popover";
+  subtitle?: string;
+  Icon: LucideIcon;
+  container: "drawer";
   rootLabelTypes: string[];
   afterPartition?: boolean;
 };
+
+type TFiltersGroupPopoverConfig = {
+  title: string;
+  subtitle?: never;
+  Icon?: never;
+  container: "popover";
+  rootLabelTypes: string[];
+  afterPartition?: boolean;
+};
+
+export type TFiltersGroupConfig = TFiltersGroupDrawerConfig | TFiltersGroupPopoverConfig;
 
 export type TFiltersGroup = TFiltersGroupConfig & {
   nestedLabels: TNestedSearchLabel[];

--- a/src/utils/filters/filterPaths.ts
+++ b/src/utils/filters/filterPaths.ts
@@ -11,7 +11,7 @@ export const getFilterPathLabel = (nestedSearchLabel: TNestedSearchLabel): TFilt
 
 export const getLabelPathSignature = (labelPath: TFilterPathLabel[]) =>
   labelPath
-    .map((label) => label.id)
+    .map((label) => [label.type, label.value].join("+"))
     .reverse()
     .join("/");
 


### PR DESCRIPTION
# What's changed

- Replaced `CategorySpecificFilters`:
  - `SearchFiltersDrawer` for larger panels - categories (filters) and geographies.
  - `SearchFiltersPopover` for smaller panels - topics and [later on] dates.
- Fixed a few issues including label sorting and selecting a deeply nested filter.

## Why

Satisfies:
- APP-2194 Build a filter panel component
- APP-2193 Build a geography filter button component

## AI attribution

Claude used to analyse bugs and write Storybook story boilerplate.

## Screenshots

Drawer:
<img width="922" height="1352" alt="Screenshot 2026-07-01 at 15 24 17" src="https://github.com/user-attachments/assets/a70e865b-8b51-46f1-8625-6cddcbec05c7" />

Popover:
<img width="390" height="446" alt="Screenshot 2026-07-01 at 15 24 20" src="https://github.com/user-attachments/assets/868f1775-e084-4cc9-81c5-692f5c7fabef" />
