### PR TITLE
Replace reference to old surface colour with white

### DIFF
--- a/src/components/filters/SearchSettings.tsx
+++ b/src/components/filters/SearchSettings.tsx
@@ -81,7 +81,7 @@ export const SearchSettings = ({
 
   return (
     <div
-      className={`absolute top-full mt-1 right-0 p-3 w-[180px] max-w-[350px] bg-surface-light border border-border-light rounded-md shadow-md text-sm leading-normal select-none focus-visible:outline-0 ${extraClasses}`}
+      className={`absolute top-full mt-1 right-0 p-3 w-[180px] max-w-[350px] bg-white border border-border-light rounded-md shadow-md text-sm leading-normal select-none focus-visible:outline-0 ${extraClasses}`}
       ref={searchOptionsRef}
       data-cy="search-settings"
     >

--- a/themes/ccc/components/Header.tsx
+++ b/themes/ccc/components/Header.tsx
@@ -21,7 +21,7 @@ export const Header = () => {
   const showSearch = router.pathname !== "/";
   const isNotHome = router.pathname !== "/";
 
-  const headerClasses = joinTailwindClasses("bg-surface-light", isNotHome && "!bg-[#677787]");
+  const headerClasses = joinTailwindClasses("bg-white", isNotHome && "!bg-[#677787]");
   const menuIconClasses = router.pathname === "/" ? "text-gray-950" : "text-white";
 
   return (

--- a/themes/mcf/components/Header.tsx
+++ b/themes/mcf/components/Header.tsx
@@ -21,7 +21,7 @@ export const Header = () => {
 
   return (
     <NavBar
-      headerClasses={`bg-surface-light min-h-20 ${showBorder ? "border-b border-gray-300 border-solid" : ""}`}
+      headerClasses={`bg-white min-h-20 ${showBorder ? "border-b border-gray-300 border-solid" : ""}`}
       logo={MCFLogo}
       menu={<MainMenu icon={<LucideMenu size={24} className="text-gray-950" />} links={MENU_LINKS} />}
       showSearch={showSearch}


### PR DESCRIPTION
# What's changed
- Referencing the colour "bg-surface-light" which no longer exists within the theme replaced with "bg-white"

## Why
- See screenshot for bug with missing background colour

## Screenshots
Fixing this
<img width="1568" height="704" alt="image" src="https://github.com/user-attachments/assets/952e2bf0-6bfa-47f2-aff4-fb32a5224a14" />

