### PR TITLE
Build and apply remaining filter components

### DIFF
--- a/src/components/atoms/checkbox/Checkbox.tsx
+++ b/src/components/atoms/checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { Checkbox as BaseCheckbox } from "@base-ui/react";
 import { Check, Minus } from "lucide-react";
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 
 import { TCheckboxState } from "@/types";
 import { joinTailwindClasses } from "@/utils/tailwind";
@@ -8,20 +8,26 @@ import { joinTailwindClasses } from "@/utils/tailwind";
 interface IProps extends BaseCheckbox.Root.Props {
   children: ReactNode;
   className?: string;
+  noClickLabel?: boolean;
   onCheckedChange: (value: TCheckboxState) => void;
 }
 
-export const Checkbox = ({ children: label, className, ...rootProps }: IProps) => {
-  const labelClasses = joinTailwindClasses(
+export const Checkbox = ({ children: label, className, noClickLabel, ...rootProps }: IProps) => {
+  const labelId = useId();
+
+  const wrapperClasses = joinTailwindClasses(
     "flex gap-3 items-center text-sm font-normal leading-5",
-    rootProps.disabled ? "text-text-tertiary cursor-not-allowed" : "text-text-primary cursor-pointer",
+    rootProps.disabled ? "text-text-tertiary cursor-not-allowed" : "text-text-primary",
+    !noClickLabel && !rootProps.disabled && "cursor-pointer",
+    noClickLabel && !rootProps.disabled && "select-none",
     className
   );
   const rootClasses = joinTailwindClasses(
     "box-border flex shrink-0 w-5 h-5 items-center justify-center border border-border-input rounded-xs outline-inky-blue focus-visible:outline-2 outline-offset-2",
     rootProps.disabled
       ? "data-checked:bg-text-tertiary data-indeterminate:bg-text-tertiary"
-      : "data-checked:bg-inky-blue data-indeterminate:bg-inky-blue"
+      : "data-checked:bg-inky-blue data-indeterminate:bg-inky-blue",
+    noClickLabel && !rootProps.disabled && "cursor-pointer"
   );
 
   const handleChange = (value: TCheckboxState) => {
@@ -30,15 +36,16 @@ export const Checkbox = ({ children: label, className, ...rootProps }: IProps) =
   };
 
   const IndicatorIcon = rootProps.indeterminate ? Minus : Check;
+  const Wrapper = noClickLabel ? "div" : "label";
 
   return (
-    <label className={labelClasses}>
-      <BaseCheckbox.Root className={rootClasses} {...rootProps} onCheckedChange={handleChange}>
+    <Wrapper className={wrapperClasses}>
+      <BaseCheckbox.Root className={rootClasses} aria-labelledby={noClickLabel ? labelId : undefined} {...rootProps} onCheckedChange={handleChange}>
         <BaseCheckbox.Indicator className="flex items-center justify-center text-white">
           <IndicatorIcon size={16} aria-hidden={true} />
         </BaseCheckbox.Indicator>
       </BaseCheckbox.Root>
-      {label}
-    </label>
+      {noClickLabel ? <span id={labelId}>{label}</span> : label}
+    </Wrapper>
   );
 };

--- a/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.stories.tsx
@@ -67,6 +67,7 @@ const useFiltersContext = (checkedLabelPaths: TFilterPathLabel[][]) => {
         checkedLabelPaths,
         // eslint-disable-next-line no-console
         clearFilters: () => console.info("clearFilters"),
+        labelValues: {},
         // eslint-disable-next-line no-console
         toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
       }}

--- a/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
@@ -16,7 +16,7 @@ const nestedPath: TFilterPathLabel[] = [
 const renderWithFiltersContext = (checkedLabelPaths: TFilterPathLabel[][], clearFilters = vi.fn(), toggleFilter = vi.fn()) =>
   render(
     <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters, labelValues: {}, toggleFilter }}>
-      <AppliedFilters />
+      <AppliedFilters showClearAll />
     </FiltersContext.Provider>
   );
 

--- a/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.test.tsx
@@ -15,7 +15,7 @@ const nestedPath: TFilterPathLabel[] = [
 
 const renderWithFiltersContext = (checkedLabelPaths: TFilterPathLabel[][], clearFilters = vi.fn(), toggleFilter = vi.fn()) =>
   render(
-    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters, toggleFilter }}>
+    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters, labelValues: {}, toggleFilter }}>
       <AppliedFilters />
     </FiltersContext.Provider>
   );

--- a/src/components/molecules/appliedFilters/AppliedFilters.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.tsx
@@ -2,20 +2,37 @@ import { LucideX } from "lucide-react";
 import { useContext, useMemo } from "react";
 
 import { FiltersContext } from "@/context/FiltersContext";
-import { sortFilterPathLabels } from "@/utils/filters/filterPaths";
+import { TFilterPathLabel } from "@/types";
+import { getLabelPathSignature, sortFilterPathLabels } from "@/utils/filters/filterPaths";
+import { joinTailwindClasses } from "@/utils/tailwind";
 
-export const AppliedFilters = () => {
+interface IProps {
+  ancestorPath?: TFilterPathLabel[];
+  className?: string;
+  showClearAll?: boolean;
+}
+
+export const AppliedFilters = ({ ancestorPath = [], className, showClearAll }: IProps) => {
   const { checkedLabelPaths, clearFilters, toggleFilter } = useContext(FiltersContext);
 
-  const labels = useMemo(() => sortFilterPathLabels(checkedLabelPaths), [checkedLabelPaths]);
+  const labels = useMemo(() => {
+    const ancestorSignature = getLabelPathSignature(ancestorPath);
+    const descendantLabelPaths = checkedLabelPaths.filter(
+      (labelPath) => labelPath.length > ancestorPath.length && getLabelPathSignature(labelPath).startsWith(ancestorSignature)
+    );
+
+    return sortFilterPathLabels(descendantLabelPaths);
+  }, [checkedLabelPaths, ancestorPath]);
 
   if (labels.length === 0) return null;
 
+  const allClasses = joinTailwindClasses(
+    "col-start-1 -col-end-1 cols-5:col-start-2 cols-5:-col-end-2 flex flex-wrap items-center gap-2 list-none",
+    className
+  );
+
   return (
-    <ul
-      className="col-start-1 -col-end-1 cols-5:col-start-2 cols-5:-col-end-2 flex flex-wrap items-center gap-2 list-none"
-      aria-label="Applied filters"
-    >
+    <ul className={allClasses} aria-label="Applied filters">
       {labels.map((labelPath) => {
         const label = labelPath[0];
 
@@ -33,16 +50,18 @@ export const AppliedFilters = () => {
           </li>
         );
       })}
-      <li>
-        <button
-          type="button"
-          className="px-3 py-1 text-sm text-text-primary font-normal leading-5"
-          aria-label="Clear all filters"
-          onClick={() => clearFilters()}
-        >
-          Clear all
-        </button>
-      </li>
+      {showClearAll && (
+        <li>
+          <button
+            type="button"
+            className="px-3 py-1 text-sm text-text-primary font-normal leading-5"
+            aria-label="Clear all filters"
+            onClick={() => clearFilters()}
+          >
+            Clear all
+          </button>
+        </li>
+      )}
     </ul>
   );
 };

--- a/src/components/molecules/appliedFilters/AppliedFilters.tsx
+++ b/src/components/molecules/appliedFilters/AppliedFilters.tsx
@@ -13,7 +13,7 @@ interface IProps {
 }
 
 export const AppliedFilters = ({ ancestorPath = [], className, showClearAll }: IProps) => {
-  const { checkedLabelPaths, clearFilters, toggleFilter } = useContext(FiltersContext);
+  const { checkedLabelPaths, clearFilters, labelValues, toggleFilter } = useContext(FiltersContext);
 
   const labels = useMemo(() => {
     const ancestorSignature = getLabelPathSignature(ancestorPath);
@@ -38,7 +38,7 @@ export const AppliedFilters = ({ ancestorPath = [], className, showClearAll }: I
 
         return (
           <li key={label.id} className="flex flex-nowrap gap-1 pl-3 pr-2 py-1 bg-bg-flat rounded-full">
-            <span className="block text-sm text-text-primary text-nowrap font-medium leading-5">{label.value}</span>
+            <span className="block text-sm text-text-primary text-nowrap font-medium leading-5">{labelValues[label.id] || label.value}</span>
             <button
               type="button"
               className="p-1 -m-1 text-inky-blue"

--- a/src/components/molecules/searchFilter/SearchFilter.stories.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
     };
 
     return (
-      <FiltersContext value={{ checkedLabelPaths, clearFilters: () => {}, toggleFilter }}>
+      <FiltersContext value={{ checkedLabelPaths, clearFilters: () => {}, labelValues: {}, toggleFilter }}>
         <ul className="list-none w-100">
           <SearchFilter {...props} />
         </ul>

--- a/src/components/molecules/searchFilter/SearchFilter.stories.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.stories.tsx
@@ -1,0 +1,86 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import uniqBy from "lodash/uniqBy";
+import { useState } from "react";
+
+import { FiltersContext, TToggleFilterCallback } from "@/context/FiltersContext";
+import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
+import { getLabelPathSignature, sortFilterPathLabels } from "@/utils/filters/filterPaths";
+
+import { SearchFilter } from "./SearchFilter";
+
+const meta = {
+  title: "Molecules/SearchFilter",
+  component: SearchFilter,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+  render: (props) => {
+    const [checkedLabelPaths, setCheckedLabelPaths] = useState<TFilterPathLabel[][]>([]);
+
+    const toggleFilter: TToggleFilterCallback = (labelPath, checked) => {
+      const updatedCheckedLabelPaths = sortFilterPathLabels(
+        checked === true // indeterminate is treated as unchecked
+          ? uniqBy([...checkedLabelPaths, labelPath], getLabelPathSignature)
+          : checkedLabelPaths.filter((labels) => getLabelPathSignature(labels) !== getLabelPathSignature(labelPath))
+      );
+
+      setCheckedLabelPaths(updatedCheckedLabelPaths);
+    };
+
+    return (
+      <FiltersContext value={{ checkedLabelPaths, clearFilters: () => {}, toggleFilter }}>
+        <ul className="list-none w-100">
+          <SearchFilter {...props} />
+        </ul>
+      </FiltersContext>
+    );
+  },
+} satisfies Meta<typeof SearchFilter>;
+type TStory = StoryObj<typeof SearchFilter>;
+
+const generateLabel = (value: string): TNestedSearchLabel => ({
+  id: `test::${value}`,
+  type: "test",
+  value,
+  children: [] as TNestedSearchLabel[],
+});
+
+export default meta;
+
+export const OneLevel: TStory = {
+  args: {
+    ancestorPath: [],
+    label: generateLabel("Filter"),
+  },
+};
+
+export const TwoLevels: TStory = {
+  args: {
+    ancestorPath: [],
+    label: {
+      ...generateLabel("Parent"),
+      children: ["Child 1", "Child 2", "Child 3"].map(generateLabel),
+    },
+  },
+};
+
+export const ThreeLevels: TStory = {
+  args: {
+    ancestorPath: [],
+    label: {
+      ...generateLabel("Grandparent"),
+      children: [
+        {
+          ...generateLabel("Parent A"),
+          children: ["Child A1", "Child A2", "Child A3"].map(generateLabel),
+        },
+        generateLabel("Parent B"),
+        {
+          ...generateLabel("Parent C"),
+          children: ["Child C1", "Child C2"].map(generateLabel),
+        },
+      ],
+    },
+  },
+};

--- a/src/components/molecules/searchFilter/SearchFilter.test.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.test.tsx
@@ -23,7 +23,7 @@ const renderWithFiltersContext = (
   toggleFilter = vi.fn()
 ) =>
   render(
-    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters: vi.fn(), toggleFilter }}>
+    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters: vi.fn(), labelValues: {}, toggleFilter }}>
       <ul>
         <SearchFilter ancestorPath={ancestorPath} label={label} />
       </ul>

--- a/src/components/molecules/searchFilter/SearchFilter.test.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FiltersContext } from "@/context/FiltersContext";
+import { TFilterPathLabel } from "@/types";
+import { getFilterPathLabel } from "@/utils/filters/filterPaths";
+
+import { SearchFilter } from "./SearchFilter";
+import { OneLevel, ThreeLevels, TwoLevels } from "./SearchFilter.stories";
+
+const oneLevelLabel = OneLevel.args!.label!;
+const twoLevelsLabel = TwoLevels.args!.label!;
+const threeLevelsLabel = ThreeLevels.args!.label!;
+
+const parentLabel = twoLevelsLabel;
+const childLabel = twoLevelsLabel.children[0];
+
+const renderWithFiltersContext = (
+  ancestorPath: TFilterPathLabel[],
+  label: typeof oneLevelLabel,
+  checkedLabelPaths: TFilterPathLabel[][],
+  toggleFilter = vi.fn()
+) =>
+  render(
+    <FiltersContext.Provider value={{ checkedLabelPaths, clearFilters: vi.fn(), toggleFilter }}>
+      <ul>
+        <SearchFilter ancestorPath={ancestorPath} label={label} />
+      </ul>
+    </FiltersContext.Provider>
+  );
+
+const getToggleButton = (name: string) => screen.getByRole("checkbox", { name }).closest("button") as HTMLButtonElement;
+
+describe("SearchFilter", () => {
+  it("calls toggleFilter when an unchecked filter is checked", async () => {
+    const toggleFilter = vi.fn();
+
+    renderWithFiltersContext([], oneLevelLabel, [], toggleFilter);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Filter" }));
+    expect(toggleFilter).toHaveBeenCalledWith([getFilterPathLabel(oneLevelLabel)], true);
+  });
+
+  it("calls toggleFilter when a checked filter is unchecked", async () => {
+    const toggleFilter = vi.fn();
+    const path = [getFilterPathLabel(oneLevelLabel)];
+
+    renderWithFiltersContext([], oneLevelLabel, [path], toggleFilter);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Filter" }));
+    expect(toggleFilter).toHaveBeenCalledWith(path, false);
+  });
+
+  it("reveals children when a filter dropdown is expanded", async () => {
+    renderWithFiltersContext([], parentLabel, []);
+
+    expect(screen.queryByText("Child 1")).not.toBeInTheDocument();
+    await userEvent.click(getToggleButton("Parent"));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+  });
+
+  it("reveals children when an unchecked filter is checked", async () => {
+    renderWithFiltersContext([], parentLabel, []);
+
+    expect(screen.queryByText("Child 1")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("checkbox", { name: "Parent" }));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+  });
+
+  it("hides children when a filter dropdown is collapsed", async () => {
+    renderWithFiltersContext([], parentLabel, []);
+
+    await userEvent.click(getToggleButton("Parent"));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+    await userEvent.click(getToggleButton("Parent"));
+    expect(screen.queryByText("Child 1")).not.toBeInTheDocument();
+  });
+
+  it("hides children when a checked filter is unchecked and no descendants are checked", async () => {
+    const parentPath = [getFilterPathLabel(parentLabel)];
+
+    renderWithFiltersContext([], parentLabel, [parentPath]);
+
+    await userEvent.click(getToggleButton("Parent"));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("checkbox", { name: "Parent" }));
+    expect(screen.queryByText("Child 1")).not.toBeInTheDocument();
+  });
+
+  it("keeps children revealed when a checked filter is unchecked and a child is checked", async () => {
+    const parentPath = [getFilterPathLabel(parentLabel)];
+    const childPath = [getFilterPathLabel(childLabel), ...parentPath];
+
+    renderWithFiltersContext([], parentLabel, [parentPath, childPath]);
+
+    await userEvent.click(getToggleButton("Parent"));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("checkbox", { name: "Parent" }));
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+  });
+
+  it("keeps children revealed when a checked filter is unchecked and a grandchild is checked", async () => {
+    const grandparentLabel = threeLevelsLabel;
+    const middleLabel = threeLevelsLabel.children[0];
+    const grandchildLabel = middleLabel.children[0];
+
+    const grandparentPath = [getFilterPathLabel(grandparentLabel)];
+    const grandchildPath = [getFilterPathLabel(grandchildLabel), getFilterPathLabel(middleLabel), ...grandparentPath];
+
+    renderWithFiltersContext([], grandparentLabel, [grandparentPath, grandchildPath]);
+
+    await userEvent.click(getToggleButton("Grandparent"));
+    expect(screen.getByText("Parent A")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("checkbox", { name: "Grandparent" }));
+    expect(screen.getByText("Parent A")).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/searchFilter/SearchFilter.tsx
+++ b/src/components/molecules/searchFilter/SearchFilter.tsx
@@ -1,11 +1,14 @@
-import { useContext } from "react";
+import { ChevronDown } from "lucide-react";
+import { MouseEvent, useContext, useState } from "react";
 
 import { Checkbox } from "@/components/atoms/checkbox/Checkbox";
 import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
 import { FiltersContext } from "@/context/FiltersContext";
-import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
+import { TCheckboxState, TFilterPathLabel, TNestedSearchLabel } from "@/types";
+import { filterHasSelectedChildren } from "@/utils/filters/filterHasSelectedChildren";
 import { getFilterPathLabel } from "@/utils/filters/filterPaths";
 import { getFilterStatus } from "@/utils/filters/getFilterStatus";
+import { joinTailwindClasses } from "@/utils/tailwind";
 import { firstCase } from "@/utils/text";
 
 interface IProps {
@@ -15,16 +18,44 @@ interface IProps {
 
 export const SearchFilter = ({ ancestorPath, label }: IProps) => {
   const { checkedLabelPaths, toggleFilter } = useContext(FiltersContext);
+  const [isOpen, setIsOpen] = useState(false);
 
   const pathLabels = [getFilterPathLabel(label), ...ancestorPath];
   const checked = getFilterStatus(pathLabels, checkedLabelPaths);
 
+  const hasChildren = label.children.length > 0;
+
+  const onCheckedChange = (value: TCheckboxState) => {
+    if (value === true) setIsOpen(true);
+    if (value === false) {
+      const hasCheckedChildren = filterHasSelectedChildren(checkedLabelPaths, ancestorPath, label);
+      if (!hasCheckedChildren) setIsOpen(false);
+    }
+
+    toggleFilter(pathLabels, value);
+  };
+
+  const onToggle = (event: MouseEvent<HTMLButtonElement>) => {
+    if (event.target instanceof HTMLInputElement) return; // Overrides Base UI's Checkbox click dispatcher
+    setIsOpen((current) => !current);
+  };
+
   return (
     <li>
-      <Checkbox checked={checked === true} indeterminate={checked === "indeterminate"} onCheckedChange={(value) => toggleFilter(pathLabels, value)}>
-        {firstCase(label.value)}
-      </Checkbox>
-      {label.children.length > 0 && <SearchFilterLevel ancestorPath={pathLabels} labels={label.children} indented />}
+      <button type="button" className="w-full flex flex-row items-center" onClick={onToggle}>
+        <Checkbox
+          checked={checked === true}
+          indeterminate={checked === "indeterminate"}
+          onCheckedChange={onCheckedChange}
+          onClick={(event) => event.stopPropagation()}
+          noClickLabel
+          className="flex-1"
+        >
+          {firstCase(label.value)}
+        </Checkbox>
+        {hasChildren && <ChevronDown size={16} className={joinTailwindClasses("text-elem-icon", isOpen && "rotate-180")} />}
+      </button>
+      {hasChildren && isOpen && <SearchFilterLevel ancestorPath={pathLabels} labels={label.children} indented />}
     </li>
   );
 };

--- a/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
+++ b/src/components/molecules/searchFilterGroups/SearchFilterGroups.stories.tsx
@@ -14,8 +14,13 @@ const meta = {
   argTypes: {},
   render: (props) => (
     <FiltersContext
-      // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{
+        checkedLabelPaths: [],
+        clearFilters: () => {},
+        labelValues: {},
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
     >
       <SearchFilterGroups {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
+++ b/src/components/molecules/searchFilterLookup/SearchFilterLookup.stories.tsx
@@ -14,8 +14,13 @@ const meta = {
   argTypes: {},
   render: (props) => (
     <FiltersContext
-      // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{
+        checkedLabelPaths: [],
+        clearFilters: () => {},
+        labelValues: {},
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
     >
       <SearchFilterLookup {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterParent/SearchFilterParent.stories.tsx
+++ b/src/components/molecules/searchFilterParent/SearchFilterParent.stories.tsx
@@ -14,8 +14,13 @@ const meta = {
   argTypes: {},
   render: (props) => (
     <FiltersContext
-      // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{
+        checkedLabelPaths: [],
+        clearFilters: () => {},
+        labelValues: {},
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
     >
       <SearchFilterParent {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFilterParent/SearchFilterParent.tsx
+++ b/src/components/molecules/searchFilterParent/SearchFilterParent.tsx
@@ -2,6 +2,7 @@ import { ChevronDown } from "lucide-react";
 import { MouseEvent, useContext, useState } from "react";
 
 import { Checkbox } from "@/components/atoms/checkbox/Checkbox";
+import { AppliedFilters } from "@/components/molecules/appliedFilters/AppliedFilters";
 import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
 import { FILTER_DISPLAY } from "@/constants/filters";
 import { FiltersContext } from "@/context/FiltersContext";
@@ -13,9 +14,10 @@ import { joinTailwindClasses } from "@/utils/tailwind";
 interface IProps {
   ancestorPath: TFilterPathLabel[];
   label: TNestedSearchLabel;
+  showAppliedFilters?: boolean;
 }
 
-export const SearchFilterParent = ({ ancestorPath, label }: IProps) => {
+export const SearchFilterParent = ({ ancestorPath, label, showAppliedFilters }: IProps) => {
   const { checkedLabelPaths, toggleFilter } = useContext(FiltersContext);
   const [expanded, setExpanded] = useState(false);
 
@@ -46,6 +48,7 @@ export const SearchFilterParent = ({ ancestorPath, label }: IProps) => {
           <div>
             <span className="text-base text-text-primary font-medium leading-5">{label.value}</span>
             {filterDescription && <span className="block mt-1 text-sm text-text-secondary font-normal leading-5">{filterDescription}</span>}
+            {showAppliedFilters && <AppliedFilters ancestorPath={pathLabels} className="mt-2" />}
           </div>
           <button role="button" onClick={onToggleAccordion} className="-m-1 p-1">
             <ChevronDown

--- a/src/components/molecules/searchFilterParent/SearchFilterParent.tsx
+++ b/src/components/molecules/searchFilterParent/SearchFilterParent.tsx
@@ -3,6 +3,7 @@ import { MouseEvent, useContext, useState } from "react";
 
 import { Checkbox } from "@/components/atoms/checkbox/Checkbox";
 import { SearchFilterLevel } from "@/components/organisms/searchFilterLevel/SearchFilterLevel";
+import { FILTER_DISPLAY } from "@/constants/filters";
 import { FiltersContext } from "@/context/FiltersContext";
 import { TCheckboxState, TFilterPathLabel, TNestedSearchLabel } from "@/types";
 import { getFilterPathLabel } from "@/utils/filters/filterPaths";
@@ -31,11 +32,21 @@ export const SearchFilterParent = ({ ancestorPath, label }: IProps) => {
     setExpanded((current) => !current);
   };
 
+  const filterDescription = FILTER_DISPLAY[label.id]?.description;
+
   return (
     <li className="py-4 group">
-      <Checkbox checked={checked === true} indeterminate={checked === "indeterminate"} onCheckedChange={onToggleCheckbox} className="flex-1 gap-4!">
-        <div className="w-full flex items-center justify-between gap-1">
-          <span className="text-base text-text-primary font-medium leading-5">{label.value}</span>
+      <Checkbox
+        checked={checked === true}
+        indeterminate={checked === "indeterminate"}
+        onCheckedChange={onToggleCheckbox}
+        className="flex-1 gap-4! items-start!"
+      >
+        <div className="w-full flex items-start justify-between gap-1">
+          <div>
+            <span className="text-base text-text-primary font-medium leading-5">{label.value}</span>
+            {filterDescription && <span className="block mt-1 text-sm text-text-secondary font-normal leading-5">{filterDescription}</span>}
+          </div>
           <button role="button" onClick={onToggleAccordion} className="-m-1 p-1">
             <ChevronDown
               size={16}

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.stories.tsx
@@ -15,8 +15,13 @@ const meta = {
   argTypes: {},
   render: (props) => (
     <FiltersContext
-      // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{
+        checkedLabelPaths: [],
+        clearFilters: () => {},
+        labelValues: {},
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
     >
       <SearchFiltersDrawer {...props} />
     </FiltersContext>

--- a/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
+++ b/src/components/molecules/searchFiltersDrawer/SearchFiltersDrawer.tsx
@@ -35,7 +35,7 @@ export const SearchFiltersDrawer = ({ filterGroup }: IProps) => {
           </>
         }
       >
-        <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} inDrawer />
+        <SearchFilterLevel ancestorPath={[]} labels={nestedLabels} renderParents showAppliedFilters={filterGroup.showAppliedFilters} />
       </Drawer>
     </>
   );

--- a/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.stories.tsx
+++ b/src/components/molecules/searchFiltersPopover/SearchFiltersPopover.stories.tsx
@@ -14,8 +14,13 @@ const meta = {
   argTypes: {},
   render: (props) => (
     <FiltersContext
-      // eslint-disable-next-line no-console
-      value={{ checkedLabelPaths: [], clearFilters: () => {}, toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }) }}
+      value={{
+        checkedLabelPaths: [],
+        clearFilters: () => {},
+        labelValues: {},
+        // eslint-disable-next-line no-console
+        toggleFilter: (labelPath, checked) => console.info({ labelPath, checked }),
+      }}
     >
       <SearchFiltersPopover {...props} />
     </FiltersContext>

--- a/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
+++ b/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
@@ -56,7 +56,7 @@ export const FiltersAndSort = ({ labels }: IProps) => {
           );
         })}
       </div>
-      <AppliedFilters />
+      <AppliedFilters showClearAll />
     </FiltersContext>
   );
 };

--- a/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
+++ b/src/components/organisms/filtersAndSort/FiltersAndSort.tsx
@@ -10,6 +10,7 @@ import { FiltersContext, TToggleFilterCallback } from "@/context/FiltersContext"
 import { FilterGroupSchema } from "@/schemas";
 import { TSearchLabel, TSearchQueryGroup } from "@/types";
 import { getLabelPathSignature, sortFilterPathLabels } from "@/utils/filters/filterPaths";
+import { getSearchLabelValues } from "@/utils/filters/getSearchLabelValues";
 import { groupSearchLabels } from "@/utils/filters/groupSearchLabels";
 import { nestSearchLabels } from "@/utils/filters/nestSearchLabels";
 import { DEFAULT_SEARCH_QUERY_GROUP, filterPathsToQueryGroup } from "@/utils/search/filterPathsToQueryGroup";
@@ -25,6 +26,7 @@ export const FiltersAndSort = ({ labels }: IProps) => {
     parseAsJson<TSearchQueryGroup>(FilterGroupSchema).withDefault(DEFAULT_SEARCH_QUERY_GROUP)
   );
 
+  const labelValues = useMemo(() => getSearchLabelValues(labels), [labels]);
   const checkedLabelPaths = useMemo(() => sortFilterPathLabels(queryGroupToFilterPaths(filterParam)), [filterParam]);
   const filterGroups = useMemo(() => groupSearchLabels(nestSearchLabels(labels), FILTER_GROUPS), [labels]);
 
@@ -43,7 +45,7 @@ export const FiltersAndSort = ({ labels }: IProps) => {
   };
 
   return (
-    <FiltersContext value={{ checkedLabelPaths, clearFilters, toggleFilter }}>
+    <FiltersContext value={{ checkedLabelPaths, clearFilters, labelValues, toggleFilter }}>
       <div className="col-start-1 -col-end-1 cols-5:col-start-2 cols-5:-col-end-2 flex flex-wrap gap-1">
         {filterGroups.map((group) => {
           const SearchFilters = group.container === "drawer" ? SearchFiltersDrawer : SearchFiltersPopover;

--- a/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
+++ b/src/components/organisms/searchFilterLevel/SearchFilterLevel.tsx
@@ -13,25 +13,26 @@ const LOOKUP_THRESHOLD = 8;
 interface IProps {
   ancestorPath: TFilterPathLabel[];
   indented?: boolean;
-  inDrawer?: boolean; // Top level SearchFilterLevel inside a drawer component
   labels: TNestedSearchLabel[];
+  renderParents?: boolean;
+  showAppliedFilters?: boolean;
 }
 
 // Render a set of label peers depending on content and composition
-export const SearchFilterLevel = ({ ancestorPath, indented, inDrawer, labels }: IProps) => {
+export const SearchFilterLevel = ({ ancestorPath, indented, labels, renderParents, showAppliedFilters }: IProps) => {
   const isLongShallowList = useMemo(() => labels.length > LOOKUP_THRESHOLD && labels.every((label) => label.children.length === 0), [labels]);
   const sortedLabels = useMemo(() => sortBy(labels, "value"), [labels]);
 
   const indentedClasses = indented && "ml-8 mt-2 not-last:mb-2";
   const labelTypes = new Set(labels.map((label) => label.type));
 
-  // Categories
-  const levelIsParents = inDrawer && ancestorPath.length === 0 && labelTypes.size === 1;
+  // Parents
+  const levelIsParents = renderParents && ancestorPath.length === 0 && labelTypes.size === 1;
   if (levelIsParents) {
     return (
       <ul className={joinTailwindClasses("list-none", indentedClasses)}>
         {sortedLabels.map((label) => (
-          <SearchFilterParent key={label.id} ancestorPath={ancestorPath} label={label} />
+          <SearchFilterParent key={label.id} ancestorPath={ancestorPath} label={label} showAppliedFilters={showAppliedFilters} />
         ))}
       </ul>
     );

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -24,3 +24,32 @@ export const FILTER_GROUPS: TFiltersGroupConfig[] = [
     afterPartition: true,
   },
 ];
+
+type TFilterDisplay = {
+  label?: string;
+  description?: string;
+};
+
+export const FILTER_DISPLAY: Record<string, TFilterDisplay> = {
+  "category::Corporate Disclosure": {
+    description: "Incl. type and author",
+  },
+  "category::Law": {
+    description: "Incl. response area and framework",
+  },
+  "category::Litigation": {
+    description: "Incl. case category, jurisdiction, and principal law",
+  },
+  "category::Multilateral Climate Fund project": {
+    description: "",
+  },
+  "category::Policy": {
+    description: "Incl. response area",
+  },
+  "category::Report": {
+    description: "Incl. climate council and industry reports",
+  },
+  "category::UN submission": {
+    description: "Incl. convention and type",
+  },
+};

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -16,6 +16,7 @@ export const FILTER_GROUPS: TFiltersGroupConfig[] = [
     Icon: Earth,
     container: "drawer",
     rootLabelTypes: ["region"],
+    showAppliedFilters: true,
   },
   {
     title: "Topic",
@@ -31,25 +32,13 @@ type TFilterDisplay = {
 };
 
 export const FILTER_DISPLAY: Record<string, TFilterDisplay> = {
-  "category::Corporate Disclosure": {
-    description: "Incl. type and author",
-  },
-  "category::Law": {
-    description: "Incl. response area and framework",
-  },
-  "category::Litigation": {
-    description: "Incl. case category, jurisdiction, and principal law",
-  },
-  "category::Multilateral Climate Fund project": {
-    description: "",
-  },
-  "category::Policy": {
-    description: "Incl. response area",
-  },
-  "category::Report": {
-    description: "Incl. climate council and industry reports",
-  },
-  "category::UN submission": {
-    description: "Incl. convention and type",
-  },
+  "category::Corporate Disclosure": { description: "Incl. type and author" },
+  "category::Law": { description: "Incl. response area and framework" },
+  "category::Litigation": { description: "Incl. case category, jurisdiction, and principal law" },
+  "category::Policy": { description: "Incl. response area" },
+  "category::Report": { description: "Incl. climate council and industry reports" },
+  "category::UN submission": { description: "Incl. convention and type" },
+  "region::LCN": { description: "Central America, South America and Caribbean islands" },
+  "region::MEA": { description: "Incl. Afghanistan and Pakistan" },
+  "region::NAC": { description: "Canada and the United States" },
 };

--- a/src/context/FiltersContext.ts
+++ b/src/context/FiltersContext.ts
@@ -7,11 +7,13 @@ export type TToggleFilterCallback = (labelPath: TFilterPathLabel[], checked: TCh
 interface IFiltersContext {
   checkedLabelPaths: TFilterPathLabel[][];
   clearFilters: () => void;
+  labelValues: Record<string, string>;
   toggleFilter: TToggleFilterCallback;
 }
 
 export const FiltersContext = createContext<IFiltersContext>({
   checkedLabelPaths: [],
   clearFilters: () => {},
+  labelValues: {},
   toggleFilter: () => {},
 });

--- a/src/types/search/filters.ts
+++ b/src/types/search/filters.ts
@@ -11,6 +11,7 @@ type TFiltersGroupDrawerConfig = {
   container: "drawer";
   rootLabelTypes: string[];
   afterPartition?: boolean;
+  showAppliedFilters?: boolean;
 };
 
 type TFiltersGroupPopoverConfig = {
@@ -20,6 +21,7 @@ type TFiltersGroupPopoverConfig = {
   container: "popover";
   rootLabelTypes: string[];
   afterPartition?: boolean;
+  showAppliedFilters?: never;
 };
 
 export type TFiltersGroupConfig = TFiltersGroupDrawerConfig | TFiltersGroupPopoverConfig;

--- a/src/utils/filters/filterHasSelectedChildren.test.ts
+++ b/src/utils/filters/filterHasSelectedChildren.test.ts
@@ -1,0 +1,65 @@
+import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
+
+import { filterHasSelectedChildren } from "./filterHasSelectedChildren";
+
+const createPathLabel = (value: string): TFilterPathLabel => ({
+  id: `test::${value}`,
+  type: "test",
+  value,
+});
+
+describe("filterHasSelectedChildren", () => {
+  const selfLabel: TNestedSearchLabel = {
+    id: "test::self",
+    type: "test",
+    value: "self",
+    children: [],
+  };
+
+  it("returns false with no selected filters", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [];
+    const ancestorPath: TFilterPathLabel[] = [];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(false);
+  });
+
+  it("returns false with only this filter selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [[createPathLabel("self")]];
+    const ancestorPath: TFilterPathLabel[] = [];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(false);
+  });
+
+  it("returns false with a peer filter selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [[createPathLabel("peer")]];
+    const ancestorPath: TFilterPathLabel[] = [];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(false);
+  });
+
+  it("returns false with a parent filter selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [[createPathLabel("parent")]];
+    const ancestorPath: TFilterPathLabel[] = [createPathLabel("parent")];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(false);
+  });
+
+  it("returns true with one child filter selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [[createPathLabel("child"), createPathLabel("self"), createPathLabel("parent")]];
+    const ancestorPath: TFilterPathLabel[] = [createPathLabel("parent")];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(true);
+  });
+
+  it("returns true with two child filters selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [
+      [createPathLabel("child 1"), createPathLabel("self"), createPathLabel("parent")],
+      [createPathLabel("child 2"), createPathLabel("self"), createPathLabel("parent")],
+    ];
+    const ancestorPath: TFilterPathLabel[] = [createPathLabel("parent")];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(true);
+  });
+
+  it("returns true with a grandchild filter selected", () => {
+    const checkedLabelPaths: TFilterPathLabel[][] = [
+      [createPathLabel("grandchild"), createPathLabel("child"), createPathLabel("self"), createPathLabel("parent")],
+    ];
+    const ancestorPath: TFilterPathLabel[] = [createPathLabel("parent")];
+    expect(filterHasSelectedChildren(checkedLabelPaths, ancestorPath, selfLabel)).toBe(true);
+  });
+});

--- a/src/utils/filters/filterHasSelectedChildren.ts
+++ b/src/utils/filters/filterHasSelectedChildren.ts
@@ -1,0 +1,12 @@
+import { TFilterPathLabel, TNestedSearchLabel } from "@/types";
+
+import { getFilterPathLabel, getLabelPathSignature } from "./filterPaths";
+
+export const filterHasSelectedChildren = (checkedLabelPaths: TFilterPathLabel[][], ancestorPath: TFilterPathLabel[], label: TNestedSearchLabel) => {
+  const pathLabels = [getFilterPathLabel(label), ...ancestorPath];
+  const pathSignature = getLabelPathSignature(pathLabels);
+
+  return checkedLabelPaths.some(
+    (checkedLabelPath) => checkedLabelPath.length > pathLabels.length && getLabelPathSignature(checkedLabelPath).startsWith(pathSignature)
+  );
+};

--- a/src/utils/filters/filterPaths.ts
+++ b/src/utils/filters/filterPaths.ts
@@ -11,7 +11,7 @@ export const getFilterPathLabel = (nestedSearchLabel: TNestedSearchLabel): TFilt
 
 export const getLabelPathSignature = (labelPath: TFilterPathLabel[]) =>
   labelPath
-    .map((label) => [label.type, label.value].join("+"))
+    .map((label) => label.id)
     .reverse()
     .join("/");
 

--- a/src/utils/filters/getSearchLabelValues.ts
+++ b/src/utils/filters/getSearchLabelValues.ts
@@ -1,0 +1,4 @@
+import { TSearchLabel } from "@/types";
+
+export const getSearchLabelValues = (labels: TSearchLabel[]): Record<string, string> =>
+  Object.fromEntries(labels.map(({ id, value }) => [id, value]));


### PR DESCRIPTION
# What's changed

- `SearchFilter`:
  - Now has an accordion for its children.
  - When unchecked, the accordion only closes if none of its children are checked: `filterHasSelectedChildren` util.
- `SearchFilterParent`
  - Added `showAppliedFilters` prop to render `AppliedFilters` if true. This value originates in the `FILTER_GROUPS` const. 
- `AppliedFilters`:
  - Includes a prop to show the "Clear all" button (not needed inside filter drawer).
- `FiltersContext`:
  - Stores a dictionary of label ID → value pairs so we can get a geography's proper name despite not storing it in the URL. (e.g. `country::USA` has a value of `United States of America`).
- `FILTER_DISPLAY`:
  - A new const object for storing alternative names and descriptions for any label.
  - Initially adds descriptions for top-level categories and regions per the designs.

## Why

Satisfies:
- [APP-2198 Build a child-level filter panel checkbox accordion component](https://linear.app/climate-policy-radar/issue/APP-2198/build-a-child-level-filter-panel-checkbox-accordion-component)
- [APP-2225 Build a top-level filter panel checkbox accordion component](https://linear.app/climate-policy-radar/issue/APP-2197/build-a-top-level-filter-panel-checkbox-accordion-component)

## AI attribution

Used for writing tests mostly, but everything has been hand-checked and tweaked.

## Screenshots

Applied geography filter showing the correct name:
<img width="396" height="255" alt="Screenshot 2026-07-15 at 11 46 25" src="https://github.com/user-attachments/assets/634e7c73-f338-4dfc-863c-9761128b4c70" />

Geography regions with labels showing selected children per group:
<img width="902" height="987" alt="Screenshot 2026-07-15 at 11 46 36" src="https://github.com/user-attachments/assets/6ca752f1-9b5a-4352-9b04-af7d3f74a7f6" />

Filters panel not showing selected children per group by comparison:
<img width="904" height="1086" alt="Screenshot 2026-07-15 at 11 47 13" src="https://github.com/user-attachments/assets/edd0445d-3f13-47ad-a47e-14794995835c" />