### PR TITLE
FUS-21 passage block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,13 @@ container.
 - When generating code keep all code within the same file unless specifically
   instructed not to.
 
+### Styling and CSS
+
+- We use Tailwind and our file: styles/theme.css contains our theme colours. Use
+  the colours and styles defined in this file. Flag to the user if there are
+  styles that we need that are not defined in this file. Do not update this
+  file.
+
 ### Components
 
 - Use the appropriate Base-UI component where necessary, see here for a list of

--- a/src/components/molecules/passageBlock/PassageBlock.stories.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.stories.tsx
@@ -1,0 +1,68 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { PassageBlock, TPassage } from "./PassageBlock";
+
+const meta = {
+  title: "Molecules/PassageBlock",
+  component: PassageBlock,
+  parameters: { layout: "centered" },
+  args: { onCopyClick: () => {}, onDocumentLinkClick: () => {} },
+} satisfies Meta<typeof PassageBlock>;
+type TStory = StoryObj<typeof PassageBlock>;
+
+export default meta;
+
+const basePassage: TPassage = {
+  id: "passage-1",
+  document_id: "doc-1",
+  idx: 12,
+  content:
+    "Certain ecological and other requirements for geohazards and for the areas used by cultivation or toxic waste, in particular for the destruction of grassland with high biological diversity within the meaning of Directive (EU) 2018/2001 and areas with high carbon stocks.",
+  pages: [{ page_number: 16 }],
+  heading_id: "heading-1",
+  documentTitle: "Law for the expansion of renewable energies (Renewable Energy Sources Act - EEG 2023; consolidated version)",
+  headingText: "Section 4: National Target 16. Mainstreaming Biodiversity into National Development",
+};
+
+export const Default: TStory = {
+  args: {
+    passage: basePassage,
+  },
+};
+
+export const Clickable: TStory = {
+  args: {
+    passage: basePassage,
+    onPassageClick: () => {},
+  },
+};
+
+export const MinimalData: TStory = {
+  args: {
+    passage: {
+      id: "passage-2",
+      document_id: "doc-2",
+      idx: 0,
+      content: "A short passage with only a document name — no page or section heading available.",
+      documentTitle: "National Climate Change Adaptation Strategy",
+    },
+  },
+};
+
+export const NoHeading: TStory = {
+  args: {
+    passage: {
+      ...basePassage,
+      headingText: undefined,
+    },
+  },
+};
+
+export const NoPage: TStory = {
+  args: {
+    passage: {
+      ...basePassage,
+      pages: undefined,
+    },
+  },
+};

--- a/src/components/molecules/passageBlock/PassageBlock.test.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { PassageBlock, TPassage } from "./PassageBlock";
+
+const basePassage: TPassage = {
+  id: "passage-1",
+  document_id: "doc-1",
+  idx: 12,
+  content: "Certain ecological and other requirements for geohazards.",
+  pages: [{ page_number: 16 }],
+  heading_id: "heading-1",
+  documentTitle: "Renewable Energy Sources Act",
+  headingText: "Section 4: National Target 16",
+};
+
+describe("PassageBlock", () => {
+  beforeEach(() => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+  });
+
+  it("renders the passage content", () => {
+    render(<PassageBlock passage={basePassage} />);
+    expect(screen.getByText(basePassage.content)).toBeInTheDocument();
+  });
+
+  it("renders the document title", () => {
+    render(<PassageBlock passage={basePassage} />);
+    expect(screen.getByText("Renewable Energy Sources Act")).toBeInTheDocument();
+  });
+
+  it("renders the page number when present", () => {
+    render(<PassageBlock passage={basePassage} />);
+    expect(screen.getByText("Pg. 16")).toBeInTheDocument();
+  });
+
+  it("does not render a page number when absent", () => {
+    const passage: TPassage = { ...basePassage, pages: undefined };
+    render(<PassageBlock passage={passage} />);
+    expect(screen.queryByText(/^Pg\./)).not.toBeInTheDocument();
+  });
+
+  it("renders the heading text when present", () => {
+    render(<PassageBlock passage={basePassage} />);
+    expect(screen.getByText("Section 4: National Target 16")).toBeInTheDocument();
+  });
+
+  it("does not render heading text when absent", () => {
+    const passage: TPassage = { ...basePassage, headingText: undefined };
+    render(<PassageBlock passage={passage} />);
+    expect(screen.queryByText("Section 4: National Target 16")).not.toBeInTheDocument();
+  });
+
+  it("renders the passage text as plain text when onPassageClick is not provided", () => {
+    render(<PassageBlock passage={basePassage} />);
+    expect(screen.queryByRole("button", { name: basePassage.content })).not.toBeInTheDocument();
+  });
+
+  it("renders the passage text as a button and calls onPassageClick when provided", () => {
+    const handlePassageClick = vi.fn();
+    render(<PassageBlock passage={basePassage} onPassageClick={handlePassageClick} />);
+    fireEvent.click(screen.getByRole("button", { name: basePassage.content }));
+    expect(handlePassageClick).toHaveBeenCalledTimes(1);
+    expect(handlePassageClick).toHaveBeenCalledWith(basePassage);
+  });
+
+  it("calls onDocumentLinkClick when the document link icon is clicked", () => {
+    const handleDocumentLinkClick = vi.fn();
+    render(<PassageBlock passage={basePassage} onDocumentLinkClick={handleDocumentLinkClick} />);
+    fireEvent.click(screen.getByRole("button", { name: "View document" }));
+    expect(handleDocumentLinkClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("copies the passage content and calls onCopyClick when the copy icon is clicked", () => {
+    const handleCopyClick = vi.fn();
+    render(<PassageBlock passage={basePassage} onCopyClick={handleCopyClick} />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy passage text" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(basePassage.content);
+    expect(handleCopyClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/molecules/passageBlock/PassageBlock.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.tsx
@@ -1,0 +1,103 @@
+import { Check, Copy, ExternalLink, File, LocateFixed } from "lucide-react";
+import { useEffect, useState } from "react";
+
+const COPY_FEEDBACK_TIMEOUT = 1000;
+
+type TPassagePage = {
+  page_number: number;
+};
+
+export type TPassage = {
+  id: string;
+  document_id: string;
+  idx: number;
+  content: string;
+  language?: string;
+  content_type?: string;
+  type_confidence?: number;
+  pages?: TPassagePage[];
+  heading_id?: string;
+  tokens?: string[];
+  serialised_text?: string;
+  topics?: unknown[];
+  // Resolved display fields, denormalised onto the passage by the caller
+  documentTitle: string;
+  documentUrl?: string;
+  headingText?: string;
+};
+
+type TProps = {
+  passage: TPassage;
+  onCopyClick?: () => void;
+  onDocumentLinkClick?: () => void;
+  onPassageClick?: (passage: TPassage) => void;
+};
+
+export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPassageClick }: TProps) => {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  useEffect(() => {
+    if (!hasCopied) return;
+    const timeout = setTimeout(() => setHasCopied(false), COPY_FEEDBACK_TIMEOUT);
+    return () => clearTimeout(timeout);
+  }, [hasCopied]);
+
+  const isClickable = !!onPassageClick;
+  const pageNumber = passage.pages?.[0]?.page_number;
+
+  const handleCopyClick = () => {
+    navigator.clipboard.writeText(passage.content);
+    setHasCopied(true);
+    onCopyClick?.();
+  };
+
+  return (
+    <div
+      className={`bg-bg-primary border border-border-normal rounded-xl overflow-clip transition ${
+        isClickable ? "hover:shadow-md hover:bg-bg-flat/60 focus-within:shadow-md focus-within:bg-bg-flat/60" : "shadow-xs"
+      }`}
+    >
+      <div className="px-8 py-7">
+        {isClickable ? (
+          <button type="button" onClick={() => onPassageClick(passage)} className="text-left w-full text-base text-text-primary hocus:underline">
+            {passage.content}
+          </button>
+        ) : (
+          <p className="text-base text-text-primary">{passage.content}</p>
+        )}
+      </div>
+      <div className="bg-bg-flat px-8 py-3 flex gap-16 items-start">
+        <div className="flex-1 min-w-0 flex flex-col gap-2.5">
+          <div className="flex gap-2 items-center">
+            <File size={16} className="text-elem-icon shrink-0" />
+            <p className="text-sm text-text-primary truncate">{passage.documentTitle}</p>
+          </div>
+          {(pageNumber !== undefined || passage.headingText) && (
+            <div className="flex gap-4 items-center">
+              {pageNumber !== undefined && (
+                <div className="flex gap-2 items-center shrink-0">
+                  <LocateFixed size={16} className="text-elem-icon" />
+                  <p className="text-sm text-text-primary whitespace-nowrap">Pg. {pageNumber}</p>
+                </div>
+              )}
+              {passage.headingText && (
+                <>
+                  {pageNumber !== undefined && <span className="w-px h-3 bg-border-normal shrink-0" />}
+                  <p className="text-sm text-text-primary truncate">{passage.headingText}</p>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex gap-3 items-center shrink-0">
+          <button type="button" onClick={onDocumentLinkClick} aria-label="View document" className="text-elem-icon hocus:text-inky-blue">
+            <ExternalLink size={16} />
+          </button>
+          <button type="button" onClick={handleCopyClick} aria-label="Copy passage text" className="text-elem-icon hocus:text-inky-blue">
+            {hasCopied ? <Check size={16} /> : <Copy size={16} />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/molecules/passageBlock/PassageBlock.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.tsx
@@ -54,7 +54,7 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
   return (
     <div
       className={`bg-bg-primary border border-border-normal rounded-xl overflow-clip transition ${
-        isClickable ? "hover:shadow-md hover:bg-bg-flat/60 focus-within:shadow-md focus-within:bg-bg-flat/60" : "shadow-xs"
+        isClickable ? "hocus:shadow-sm hocus:bg-paper" : "shadow-xs"
       }`}
     >
       <div className="px-8 py-7">
@@ -66,7 +66,7 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
           <p className="text-base text-text-primary">{passage.content}</p>
         )}
       </div>
-      <div className="bg-bg-flat px-8 py-3 flex gap-16 items-start">
+      <div className="bg-paper px-8 py-3 flex gap-16 items-start">
         <div className="flex-1 min-w-0 flex flex-col gap-2.5">
           <div className="flex gap-2 items-center">
             <File size={16} className="text-elem-icon shrink-0" />
@@ -94,7 +94,7 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
             <ExternalLink size={16} />
           </button>
           <button type="button" onClick={handleCopyClick} aria-label="Copy passage text" className="text-elem-icon hocus:text-inky-blue">
-            {hasCopied ? <Check size={16} /> : <Copy size={16} />}
+            {hasCopied ? <Check size={16} className="text-inky-blue" /> : <Copy size={16} />}
           </button>
         </div>
       </div>


### PR DESCRIPTION
# What's changed
- Adding a new component for PassageBlock (molecule)
- Updating some of the Claude instructions based on how it performed

## Why
- Be ready to support new passage search output

## AI attribution
- Experimenting with AI reading the Linear ticket and Figma to generate an initial version of the component, storybook and unit tests

## Screenshots
Storybook for the PassageBlock:
<img width="1063" height="423" alt="Screenshot 2026-07-20 at 15 18 31" src="https://github.com/user-attachments/assets/697f2723-0f56-4d3d-bd99-a10d5d672f8b" />

