### PR TITLE
FUS-28 Tabs

### DIFF
--- a/src/components/atoms/tabs/Tabs.stories.tsx
+++ b/src/components/atoms/tabs/Tabs.stories.tsx
@@ -1,0 +1,84 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Search } from "lucide-react";
+import { useState } from "react";
+
+import { Tabs } from "./Tabs";
+
+const meta = {
+  title: "Atoms/Tabs",
+  component: Tabs,
+  argTypes: {
+    onValueChange: { control: false },
+    value: { control: false },
+  },
+} satisfies Meta<typeof Tabs>;
+type TStory<TabId extends string> = StoryObj<typeof Tabs<TabId>>;
+
+export default meta;
+
+const useTabsRender = <TabId extends string>({ tabs, ...props }: React.ComponentProps<typeof Tabs<TabId>>) => {
+  const [value, setValue] = useState<TabId>(tabs[0].id);
+  const changeValue = (newValue: TabId) => setValue(newValue);
+
+  return <Tabs {...props} tabs={tabs} onValueChange={changeValue} value={value} />;
+};
+
+type TPrincipalPageTabId = "about" | "search";
+
+export const Default: TStory<TPrincipalPageTabId> = {
+  args: {
+    tabs: [
+      { id: "about", label: "About" },
+      {
+        id: "search",
+        label: (
+          <>
+            <Search size={20} />
+            Search in documents
+          </>
+        ),
+      },
+    ],
+  },
+  render: useTabsRender,
+};
+
+export const WithCount: TStory<TPrincipalPageTabId> = {
+  args: {
+    tabs: [
+      { id: "about", label: "About" },
+      {
+        id: "search",
+        count: 23,
+        label: (
+          <>
+            <Search size={20} />
+            Search in documents
+          </>
+        ),
+      },
+    ],
+  },
+  render: useTabsRender,
+};
+
+export const WithPanels: TStory<TPrincipalPageTabId> = {
+  args: {
+    panelClassName: "px-8 py-6",
+    tabs: [
+      { id: "about", label: "About", panel: "About panel content." },
+      {
+        id: "search",
+        count: 23,
+        label: (
+          <>
+            <Search size={20} />
+            Search in documents
+          </>
+        ),
+        panel: "Search in documents panel content.",
+      },
+    ],
+  },
+  render: useTabsRender,
+};

--- a/src/components/atoms/tabs/Tabs.test.tsx
+++ b/src/components/atoms/tabs/Tabs.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { Tabs, TTabsTab } from "./Tabs";
+
+type TTabId = "about" | "search";
+
+const baseTabs: TTabsTab<TTabId>[] = [
+  { id: "about", label: "About" },
+  { id: "search", label: "Search in documents" },
+];
+
+describe("Tabs", () => {
+  it("renders a tab for each item", () => {
+    render(<Tabs tabs={baseTabs} value="about" onValueChange={() => {}} />);
+    expect(screen.getByRole("tab", { name: "About" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Search in documents" })).toBeInTheDocument();
+  });
+
+  it("marks the tab matching value as selected", () => {
+    render(<Tabs tabs={baseTabs} value="search" onValueChange={() => {}} />);
+    expect(screen.getByRole("tab", { name: "Search in documents" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "About" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onValueChange with the id of the clicked tab", () => {
+    const handleValueChange = vi.fn();
+    render(<Tabs tabs={baseTabs} value="about" onValueChange={handleValueChange} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Search in documents" }));
+    expect(handleValueChange).toHaveBeenCalledTimes(1);
+    expect(handleValueChange).toHaveBeenCalledWith("search");
+  });
+
+  it("renders a count badge when count is provided", () => {
+    const tabs: TTabsTab<TTabId>[] = [baseTabs[0], { ...baseTabs[1], count: 23 }];
+    render(<Tabs tabs={tabs} value="about" onValueChange={() => {}} />);
+    expect(screen.getByText("23")).toBeInTheDocument();
+  });
+
+  it("does not render a count badge when count is absent", () => {
+    render(<Tabs tabs={baseTabs} value="about" onValueChange={() => {}} />);
+    expect(screen.queryByText(/^\d+$/)).not.toBeInTheDocument();
+  });
+
+  it("renders a count badge of zero", () => {
+    const tabs: TTabsTab<TTabId>[] = [baseTabs[0], { ...baseTabs[1], count: 0 }];
+    render(<Tabs tabs={tabs} value="about" onValueChange={() => {}} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders the panel content for the active tab", () => {
+    const tabs: TTabsTab<TTabId>[] = [
+      { ...baseTabs[0], panel: "About panel content" },
+      { ...baseTabs[1], panel: "Search panel content" },
+    ];
+    render(<Tabs tabs={tabs} value="about" onValueChange={() => {}} />);
+    expect(screen.getByText("About panel content")).toBeInTheDocument();
+  });
+
+  it("does not render panel content for an inactive tab", () => {
+    const tabs: TTabsTab<TTabId>[] = [
+      { ...baseTabs[0], panel: "About panel content" },
+      { ...baseTabs[1], panel: "Search panel content" },
+    ];
+    render(<Tabs tabs={tabs} value="about" onValueChange={() => {}} />);
+    expect(screen.queryByText("Search panel content")).not.toBeInTheDocument();
+  });
+
+  it("does not render a panel for a tab with no panel content", () => {
+    render(<Tabs tabs={baseTabs} value="about" onValueChange={() => {}} />);
+    expect(screen.queryByRole("tabpanel")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/tabs/Tabs.tsx
+++ b/src/components/atoms/tabs/Tabs.tsx
@@ -1,0 +1,54 @@
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import { ReactNode } from "react";
+
+import { joinTailwindClasses } from "@/utils/tailwind";
+
+export type TTabsTab<TabId extends string> = {
+  id: TabId;
+  label: ReactNode;
+  count?: number;
+  panel?: ReactNode;
+};
+
+interface IProps<TabId extends string> {
+  className?: string;
+  onValueChange: (value: TabId) => void;
+  panelClassName?: string;
+  tabs: TTabsTab<TabId>[];
+  value: TabId;
+}
+
+export const Tabs = <TabId extends string>({ className, onValueChange, panelClassName, tabs, value }: IProps<TabId>) => {
+  const allHeaderClasses = joinTailwindClasses("border-b border-border-light", className);
+
+  return (
+    <BaseTabs.Root value={value} onValueChange={(newValue) => onValueChange(newValue as TabId)}>
+      <div className={allHeaderClasses}>
+        <BaseTabs.List className="flex gap-1 pl-8 -mb-px">
+          {tabs.map(({ id, label, count }) => (
+            <BaseTabs.Tab
+              key={id}
+              value={id}
+              className="flex items-center justify-center gap-2 rounded-t-lg border border-transparent px-6 py-4 text-lg text-text-tertiary hocus:text-text-primary data-active:border-border-light data-active:border-b-bg-primary data-active:bg-bg-primary data-active:font-heavy data-active:text-text-primary"
+            >
+              {label}
+              {typeof count === "number" && (
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-inky-blue text-xs text-text-inverse font-heavy">
+                  {count}
+                </span>
+              )}
+            </BaseTabs.Tab>
+          ))}
+        </BaseTabs.List>
+      </div>
+      {tabs.map(
+        ({ id, panel }) =>
+          panel !== undefined && (
+            <BaseTabs.Panel key={id} value={id} className={panelClassName}>
+              {panel}
+            </BaseTabs.Panel>
+          )
+      )}
+    </BaseTabs.Root>
+  );
+};


### PR DESCRIPTION
# What's changed
- Adding new `Tabs` component

## Why
- New component needed for the new passage search functionality

## AI attribution
- Experimenting with Claude and MCP Linear and Figma
- Creating initial component, storybook and unit tests

## Screenshots
<img width="1063" height="597" alt="Screenshot 2026-07-20 at 16 59 55" src="https://github.com/user-attachments/assets/28d267d6-4b7a-4445-b723-00dc9011a1cf" />
