### PR TITLE
Add additional checks for unhandled API errors

### DIFF
--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -100,6 +100,12 @@ export const getFamilyData = async (slug: string, features: TFeatures, importId?
       .map(async (country) => {
         try {
           const { data: subDivisionResponse } = await apiClient.get<TApiGeographySubdivision[]>(`/geographies/subdivisions/${country}`);
+          // http-common's get() returns error.response rather than throwing for Axios errors,
+          // so a non-2xx response resolves here with an error body instead of an array.
+          if (!Array.isArray(subDivisionResponse)) {
+            errors.push(new Error(`Failed to fetch subdivisions data for country: ${country}`));
+            return [];
+          }
           return subDivisionResponse;
         } catch (error) {
           const status = axios.isAxiosError(error) ? error.response?.status : "unknown";

--- a/src/components/pages/geographyPage.tsx
+++ b/src/components/pages/geographyPage.tsx
@@ -44,7 +44,7 @@ export const GeographyPage = ({ geographyV2, parentGeographyV2, theme, themeConf
   /* Page header */
 
   const pageHeaderMetadata: IMetadata[] = [];
-  if (!isCountry) {
+  if (!isCountry && parentGeographyV2) {
     pageHeaderMetadata.push({
       label: "Part of",
       value: (

--- a/src/hooks/useFamilyPageHeaderData.test.tsx
+++ b/src/hooks/useFamilyPageHeaderData.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+
+import { TFamilyPublic, TGeography, TGeographySubdivision } from "@/types";
+
+import { useFamilyPageHeaderData } from "./useFamilyPageHeaderData";
+
+const baseFamily: TFamilyPublic = {
+  import_id: "test.family.1.0",
+  title: "Test Family",
+  summary: "Summary",
+  slug: "test-family",
+  geographies: ["USA", "US-OR"],
+  published_date: "2020-01-01T00:00:00Z",
+  last_updated_date: null,
+  attribution: {
+    category: "Litigation",
+    corpusImageAlt: "alt",
+    corpusNote: "note",
+    provider: "Sabin",
+    taxonomy: "Litigation",
+  },
+  collections: [],
+  concepts: [],
+  documents: [],
+  events: [],
+  metadata: {},
+};
+
+const countries: TGeography[] = [{ id: 1, display_value: "United States", value: "USA", type: "country", parent_id: null, slug: "united-states" }];
+
+describe("useFamilyPageHeaderData", () => {
+  it("resolves the parent country breadcrumb when the subdivision is present in the subdivisions list", () => {
+    const subdivisions: TGeographySubdivision[] = [{ code: "US-OR", name: "Oregon", type: "state", country_alpha_2: "US", country_alpha_3: "USA" }];
+
+    const { result } = renderHook(() => useFamilyPageHeaderData({ countries, family: baseFamily, subdivisions }));
+
+    expect(result.current.breadcrumbParentGeography).toEqual({ label: "United States", href: "/geographies/united-states" });
+  });
+
+  it("does not throw and omits the parent breadcrumb when the subdivision's code cannot be matched by exact string equality", () => {
+    // getSubdivisionName() matches case-insensitively (so the subdivision's name still resolves and it
+    // stays in geographiesDisplayData), but the strict `sub.code === subdivision.code` lookup below does
+    // not - reproducing the same "found the name, but the exact record lookup misses" shape as when an
+    // upstream `/geographies/subdivisions/{country}` fetch fails and the subdivision record is absent.
+    const subdivisions: TGeographySubdivision[] = [{ code: "us-or", name: "Oregon", type: "state", country_alpha_2: "US", country_alpha_3: "USA" }];
+
+    expect(() => renderHook(() => useFamilyPageHeaderData({ countries, family: baseFamily, subdivisions }))).not.toThrow();
+
+    const { result } = renderHook(() => useFamilyPageHeaderData({ countries, family: baseFamily, subdivisions }));
+    expect(result.current.breadcrumbParentGeography).toBeNull();
+  });
+});

--- a/src/hooks/useFamilyPageHeaderData.tsx
+++ b/src/hooks/useFamilyPageHeaderData.tsx
@@ -56,8 +56,8 @@ export const useFamilyPageHeaderData = ({ countries, family, subdivisions }: IPr
 
         // Get the subdivision's parent country
         const subdivisionData = subdivisions.find((sub) => sub.code === subdivision.code);
-        const parentCountryCode = subdivisionData.country_alpha_3;
         if (subdivisionData) {
+          const parentCountryCode = subdivisionData.country_alpha_3;
           const countryName = getCountryName(parentCountryCode, countries);
           const countrySlug = getCountrySlug(parentCountryCode, countries);
           if (countryName && countrySlug && !isSystemGeo(countryName)) {


### PR DESCRIPTION
# What's changed
- We were seeing errors logged in the our slack #citical-alerts channel which appeared to be originating in the FE code
- With the help of Claude we have isolated the 3 obvious errors where we were not catching API errors

## Why
- Handle API errors without crashing the app - better for users
- Avoid spam in our critical alerts monitoring channel - better for devs

## AI attribution
- Lots of Claude diagnosis and code suggestion
