### PR TITLE
Add the negative margen / padding effect to incorporate the overlay without adding more spacing

### DIFF
--- a/src/components/molecules/navSearch/NavSearch.tsx
+++ b/src/components/molecules/navSearch/NavSearch.tsx
@@ -135,7 +135,7 @@ export const NavSearch = () => {
   };
 
   return (
-    <div className="relative flex-1 -mx-2" ref={ref}>
+    <div className="relative flex-1 -m-2 p-2" ref={ref}>
       <div className="relative z-21">
         <form onSubmit={handleSubmit} className="flex flex-row gap-2" data-ph-capture-attribute-form-type="search">
           {/* Search field */}


### PR DESCRIPTION
# What's changed
- I removed the padding from the NavSearch in the previous changes, I had not checked the search overlay which was then broken because the padding was reserving the space for the overlay that appears when the user interacts with the search box in the header

## Why
- Fix a bug I introduced