### PR TITLE
fixes is_waf_bot posthog delivery and renames it from is_bot

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,8 +11,8 @@ export default function middleware(request: NextRequest) {
   }
 
   // Surface WAF's bot signal as a client-readable cookie for posthog-js.
-  const isBot = request.headers.get("x-amzn-waf-is-bot") === "true";
-  response.cookies.set("is_bot", String(isBot), { httpOnly: false, path: "/", sameSite: "lax" });
+  const isWafBot = request.headers.get("x-amzn-waf-is-bot") === "true";
+  response.cookies.set("is_waf_bot", String(isWafBot), { httpOnly: false, path: "/", sameSite: "lax" });
 
   return response;
 }

--- a/src/context/PostHogInit.tsx
+++ b/src/context/PostHogInit.tsx
@@ -43,7 +43,15 @@ function PostHogPageView({ consent, pageViewProps }: TPostHogPageViewProps): nul
         geographyType = subdivisionMatcher.test(pathParts[2]) ? "subdivision" : "country";
       }
 
-      posthog.capture("$pageview", { $current_url: url, consent, geographyType, pageType, pageTypeSlug, ...pageViewProps });
+      posthog.capture("$pageview", {
+        $current_url: url,
+        consent,
+        is_waf_bot: getCookie("is_waf_bot") === "true",
+        geographyType,
+        pageType,
+        pageTypeSlug,
+        ...pageViewProps,
+      });
     }
   }, [pathname, searchParams, posthog, consent, pageViewProps]);
 
@@ -77,9 +85,6 @@ export default function PostHogInit({ consent = false, pageViewProps = {} }: TPo
       capture_pageview: true,
       capture_pageleave: true,
     });
-    // Tag every event with the WAF bot signal (set as a cookie by middleware.ts)
-    // so suspected bot traffic can be filtered out in PostHog.
-    posthog.register({ is_bot: getCookie("is_bot") === "true" });
     window.sessionStorage.setItem("posthogLoaded", "true");
   }, []);
 
@@ -91,6 +96,9 @@ export default function PostHogInit({ consent = false, pageViewProps = {} }: TPo
     } else {
       posthog.set_config({ persistence: "memory" });
     }
+    // Register after persistence is set: switching persistence clears super
+    // properties, so `is_waf_bot` was being dropped for non-consented users.
+    posthog.register({ is_waf_bot: getCookie("is_waf_bot") === "true" });
   }, [consent]);
 
   return (


### PR DESCRIPTION
# What's changed
- Renamed the WAF bot cookie and PostHog property from `is_bot` to `is_waf_bot` as it was getting confusing with PostHogs `is bot` property.
- Register the property after persistence is configured (and re-register on consent change) so it survives the persistence switch.
- Also set `is_waf_bot` directly on the `$pageview` capture as a safety net.

## Why
The WAF bot signal (from the `x-amzn-waf-is-bot` header, surfaced via a cookie) was only showing up for internal traffic in PostHog. The cause on the client was that `register()` ran at init, before the consent-driven `set_config({ persistence })`, and switching persistence for non-consented (public) sessions cleared the super property. 

Separately, the name `is_bot` collided conceptually with PostHog's own built-in bot detection, which caused a lot of confusion, so it is renamed to make the source explicit.

## Screenshots
n/a