### PR TITLE
FUS-121 Update frontend ECS scaling

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -251,6 +251,8 @@ if not is_review_template:
         name=name_prefix,
         config=ExpressGatewayConfig(
             health_check_path="/",
+            min_task_count=3 if env == "production" else 1,
+            max_task_count=8 if env == "production" else 4,
         ),
         image_identifier=cast(str, image_identifier),
         cluster_arn=shared_resources_stack.get_output("frontend_ecs_cluster_arn"),

--- a/infra/resources/ecs_express_service.py
+++ b/infra/resources/ecs_express_service.py
@@ -19,6 +19,8 @@ class ExpressGatewayConfig:
     health_check_path: str = "/"
     cpu: str = "4096"
     memory: str = "8192"
+    min_task_count: int = 1
+    max_task_count: int = 4
 
 
 def prefix_name() -> str:
@@ -91,10 +93,10 @@ class ExpressGatewayServiceComponent(pulumi.ComponentResource):
             memory=config.memory,
             scaling_targets=[
                 ExpressGatewayServiceScalingTargetArgs(
-                    auto_scaling_metric="AVERAGE_CPU",
-                    auto_scaling_target_value=70,
-                    min_task_count=1,
-                    max_task_count=4,
+                    auto_scaling_metric="REQUEST_COUNT_PER_TARGET",  # Average over 60s interval
+                    auto_scaling_target_value=500,  # Requests per target per minute
+                    min_task_count=config.min_task_count,
+                    max_task_count=config.max_task_count,
                 ),
             ],
             network_configurations=[


### PR DESCRIPTION
# What's changed

Updates the ECS auto-scaling to use request count per target, with scaling triggered by 500 requests to a service in previous 60s. Minimum tasks updated to 3 and max to 8. 

Task counts taken from config so that prod has the updated counts, and ephemeral environments remain on 1 min. 

## Why
Previously 1 task was minimum. Traffic peaks (free load test by the bots!) demonstrated (1) request threads got blocked waiting on I/O for long periods, resulting in massive latency spikes; (2) the autoscaling policy based on 70% CPU didn't trigger, since it wasn't CPU under contention. 

ECS express only allows one autoscaling target rule, so we can't stack CPU, memory, and request counts. I've chosen request counts as a tunable parameter that can proxy CPU/mem usage as well as I/O contention.  

## AI attribution
Claude's my bestie

## NB
I can't recall the processes around deployment etc. I haven't tested this locally, and can't recall if we need to pulumi up locally for staging or if everything is handled by CI now? Plz advise.
