### PR TITLE
fix: fix pull_request pulumi-preview step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -315,21 +315,21 @@ jobs:
             staging-shared-resources:
               - 'infra/platform/**'
 
-            production-frontend-cpr:
-              - 'infra/Pulumi.cpr-production.yaml'
-              - 'infra/__main__.py'
+            # production-frontend-cpr:
+            #   - 'infra/Pulumi.cpr-production.yaml'
+            #   - 'infra/__main__.py'
 
-            production-frontend-mcf:
-              - 'infra/Pulumi.mcf-production.yaml'
-              - 'infra/__main__.py'
+            # production-frontend-mcf:
+            #   - 'infra/Pulumi.mcf-production.yaml'
+            #   - 'infra/__main__.py'
 
-            production-frontend-cclw:
-              - 'infra/Pulumi.cclw-production.yaml'
-              - 'infra/__main__.py'
+            # production-frontend-cclw:
+            #   - 'infra/Pulumi.cclw-production.yaml'
+            #   - 'infra/__main__.py'
 
-            production-frontend-ccc:
-              - 'infra/Pulumi.ccc-production.yaml'
-              - 'infra/__main__.py'
+            # production-frontend-ccc:
+            #   - 'infra/Pulumi.ccc-production.yaml'
+            #   - 'infra/__main__.py'
       - id: parse
         run: |
           CHANGES='${{ steps.filter.outputs.changes }}'
@@ -340,10 +340,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.pulumi_projects != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         project: ${{ fromJSON(needs.changes.outputs.pulumi_projects) }}
-    environment: staging
+    environment: ${{ startsWith(matrix.project, 'production-') && 'production' || 'staging' }}
     env:
       DEPLOY_FROM_MAIN_BRANCH_ONLY: false
       AWS_REGION: eu-west-1

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -251,6 +251,8 @@ if not is_review_template:
         name=name_prefix,
         config=ExpressGatewayConfig(
             health_check_path="/",
+            min_task_count=3 if env == "production" else 1,
+            max_task_count=8 if env == "production" else 4,
         ),
         image_identifier=cast(str, image_identifier),
         cluster_arn=shared_resources_stack.get_output("frontend_ecs_cluster_arn"),

--- a/infra/resources/ecs_express_service.py
+++ b/infra/resources/ecs_express_service.py
@@ -19,6 +19,8 @@ class ExpressGatewayConfig:
     health_check_path: str = "/"
     cpu: str = "4096"
     memory: str = "8192"
+    min_task_count: int = 1
+    max_task_count: int = 4
 
 
 def prefix_name() -> str:


### PR DESCRIPTION
- adds correct permissions for `pulumi-preview`
- removes previewing production stacks as there is branch protection on the `production` environment in GitHub
- adds a small change from [here](https://github.com/climatepolicyradar/navigator-frontend/pull/1435) to validate the changes