### PR TITLE
FUS 125 document page with new passage search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ container.
   definition if they feel it is necessary, but this should be the default
   behaviour.
 - If creating any new Interfaces prefix the name of the Interface with `I`, e.g.
-  `IInterfaceName`
+  `IInterfaceName`, or for new Types us `T`, e.g. `TTypeName`
 
 ### Utilities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ container.
   [Base UI components](https://base-ui.com/react/components)
 - When generating new components, do not apply too many tailwind classes, allow
   for developer discretion.
+- When composition React components, adhere to this order of declarations:
+  hooks, variables, event handlers, return (component render)
 
 ### Types
 

--- a/src/api/passages.ts
+++ b/src/api/passages.ts
@@ -59,6 +59,10 @@ interface SearchPassagesParams {
   query: string;
   documentId: string;
   pageSize?: number;
+  // 1-indexed page number. The API's `page` parameter is currently ignored, and its
+  // `next_page` / `total_pages` fields come back null, so callers page by incrementing
+  // this and comparing the running result count against `total_size`.
+  pageToken?: number;
   signal?: AbortSignal;
 }
 
@@ -75,12 +79,13 @@ function configurePassagesFilters(documentId: string): IPassageFilterGroup {
   };
 }
 
-export async function fetchSearchPassages({ query, documentId, pageSize, signal }: SearchPassagesParams): Promise<SearchPassagesResponse> {
+export async function fetchSearchPassages({ query, documentId, pageSize, pageToken, signal }: SearchPassagesParams): Promise<SearchPassagesResponse> {
   const url = new URL(searchPassagesUrl());
 
   url.searchParams.set("query", query);
   url.searchParams.set("filters", JSON.stringify(configurePassagesFilters(documentId)));
   if (pageSize !== undefined) url.searchParams.set("page_size", String(pageSize));
+  if (pageToken !== undefined) url.searchParams.set("page_token", String(pageToken));
 
   const res = await fetch(url, { signal });
   if (!res.ok) throw new Error(`Passage search API error: ${res.status}`);

--- a/src/api/passages.ts
+++ b/src/api/passages.ts
@@ -4,25 +4,25 @@
 
 import { ISearchPassagesParams, ISearchPassagesResponse, TSearchQueryGroup } from "@/types";
 
-function searchPassagesUrl(): string {
+const searchPassagesUrl = (): string => {
   const origin = (process.env.NEXT_PUBLIC_API_URL || "https://api.climatepolicyradar.org").replace(/\/$/, "");
   return `${origin}/search/passages`;
-}
+};
 
-function configurePassagesFilters(documents: string[]): TSearchQueryGroup {
+const configurePassagesFilters = (documents: string[]): TSearchQueryGroup => {
   return {
     op: "or",
     filters: documents.map((documentId) => ({ field: "document_id", op: "contains", value: documentId })),
   };
-}
+};
 
-export async function fetchSearchPassages({
+export const fetchSearchPassages = async ({
   query,
   documents,
   pageSize,
   pageToken,
   signal,
-}: ISearchPassagesParams): Promise<ISearchPassagesResponse> {
+}: ISearchPassagesParams): Promise<ISearchPassagesResponse> => {
   const url = new URL(searchPassagesUrl());
 
   url.searchParams.set("query", query);
@@ -33,4 +33,4 @@ export async function fetchSearchPassages({
   const res = await fetch(url, { signal });
   if (!res.ok) throw new Error(`Passage search API error: ${res.status}`);
   return res.json() as Promise<ISearchPassagesResponse>;
-}
+};

--- a/src/api/passages.ts
+++ b/src/api/passages.ts
@@ -2,57 +2,7 @@
 // native fetch, `NEXT_PUBLIC_API_URL` with a public fallback, and throwing on a
 // non-2xx so react-query can surface the error.
 
-import { TSearchQueryGroup } from "@/types";
-
-export interface IPassageBoundingBox {
-  coordinates: { x: number; y: number }[];
-}
-
-export interface IPassagePageWithBoundingBoxes {
-  number: number;
-  bounding_boxes: IPassageBoundingBox[];
-}
-
-export interface ISearchPassage {
-  id: string;
-  text_block_id: string;
-  idx: number;
-  text: string;
-  language: string | null;
-  type: string;
-  type_confidence: number;
-  page_number: number;
-  pages: number[];
-  pages_with_bounding_boxes: IPassagePageWithBoundingBoxes[];
-  concepts: unknown[];
-  heading_id: string | null;
-  heading_text: string | null;
-  document_id: string;
-  principal_id: string;
-  tokens: string[];
-}
-
-export interface ISearchPassagesResponse {
-  took_ms: number | null;
-  total_size: number | null;
-  page: number;
-  page_size: number;
-  total_pages: number | null;
-  next_page: string | null;
-  previous_page: string | null;
-  results: ISearchPassage[];
-}
-
-interface ISearchPassagesParams {
-  query: string;
-  documents: string[];
-  pageSize?: number;
-  // 1-indexed page number. The API's `page` parameter is currently ignored, and its
-  // `next_page` / `total_pages` fields come back null, so callers page by incrementing
-  // this and comparing the running result count against `total_size`.
-  pageToken?: number;
-  signal?: AbortSignal;
-}
+import { ISearchPassagesParams, ISearchPassagesResponse, TSearchQueryGroup } from "@/types";
 
 function searchPassagesUrl(): string {
   const origin = (process.env.NEXT_PUBLIC_API_URL || "https://api.climatepolicyradar.org").replace(/\/$/, "");

--- a/src/api/passages.ts
+++ b/src/api/passages.ts
@@ -1,0 +1,88 @@
+// Passage search against the v2 API. Mirrors the conventions in `./search.ts`:
+// native fetch, `NEXT_PUBLIC_API_URL` with a public fallback, and throwing on a
+// non-2xx so react-query can surface the error.
+
+export interface PassageBoundingBox {
+  coordinates: { x: number; y: number }[];
+}
+
+export interface PassagePageWithBoundingBoxes {
+  number: number;
+  bounding_boxes: PassageBoundingBox[];
+}
+
+export interface SearchPassage {
+  id: string;
+  text_block_id: string;
+  idx: number;
+  text: string;
+  language: string | null;
+  type: string;
+  type_confidence: number;
+  page_number: number;
+  pages: number[];
+  pages_with_bounding_boxes: PassagePageWithBoundingBoxes[];
+  concepts: unknown[];
+  heading_id: string | null;
+  heading_text: string | null;
+  document_id: string;
+  principal_id: string;
+  tokens: string[];
+}
+
+export interface SearchPassagesResponse {
+  took_ms: number | null;
+  total_size: number | null;
+  page: number;
+  page_size: number;
+  total_pages: number | null;
+  next_page: string | null;
+  previous_page: string | null;
+  results: SearchPassage[];
+}
+
+// The passages endpoint has its own field vocabulary (`document_id` today, topics to
+// follow), so it cannot reuse TSearchQueryGroup, whose fields are typed to the
+// documents endpoint.
+interface IPassageFilterRule {
+  field: "document_id";
+  op: "contains";
+  value: string;
+}
+
+interface IPassageFilterGroup {
+  op: "and" | "or";
+  filters: (IPassageFilterGroup | IPassageFilterRule)[];
+}
+
+interface SearchPassagesParams {
+  query: string;
+  documentId: string;
+  pageSize?: number;
+  signal?: AbortSignal;
+}
+
+function searchPassagesUrl(): string {
+  const origin = (process.env.NEXT_PUBLIC_API_URL || "https://api.climatepolicyradar.org").replace(/\/$/, "");
+  return `${origin}/search/passages`;
+}
+
+// Passage search is always scoped to a single document.
+function configurePassagesFilters(documentId: string): IPassageFilterGroup {
+  return {
+    op: "and",
+    filters: [{ field: "document_id", op: "contains", value: documentId }],
+  };
+}
+
+export async function fetchSearchPassages({ query, documentId, pageSize, signal }: SearchPassagesParams): Promise<SearchPassagesResponse> {
+  const url = new URL(searchPassagesUrl());
+
+  url.searchParams.set("query", query);
+  url.searchParams.set("filters", JSON.stringify(configurePassagesFilters(documentId)));
+  if (pageSize !== undefined) url.searchParams.set("page_size", String(pageSize));
+
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`Passage search API error: ${res.status}`);
+  return res.json() as Promise<SearchPassagesResponse>;
+}

--- a/src/api/passages.ts
+++ b/src/api/passages.ts
@@ -2,16 +2,18 @@
 // native fetch, `NEXT_PUBLIC_API_URL` with a public fallback, and throwing on a
 // non-2xx so react-query can surface the error.
 
-export interface PassageBoundingBox {
+import { TSearchQueryGroup } from "@/types";
+
+export interface IPassageBoundingBox {
   coordinates: { x: number; y: number }[];
 }
 
-export interface PassagePageWithBoundingBoxes {
+export interface IPassagePageWithBoundingBoxes {
   number: number;
-  bounding_boxes: PassageBoundingBox[];
+  bounding_boxes: IPassageBoundingBox[];
 }
 
-export interface SearchPassage {
+export interface ISearchPassage {
   id: string;
   text_block_id: string;
   idx: number;
@@ -21,7 +23,7 @@ export interface SearchPassage {
   type_confidence: number;
   page_number: number;
   pages: number[];
-  pages_with_bounding_boxes: PassagePageWithBoundingBoxes[];
+  pages_with_bounding_boxes: IPassagePageWithBoundingBoxes[];
   concepts: unknown[];
   heading_id: string | null;
   heading_text: string | null;
@@ -30,7 +32,7 @@ export interface SearchPassage {
   tokens: string[];
 }
 
-export interface SearchPassagesResponse {
+export interface ISearchPassagesResponse {
   took_ms: number | null;
   total_size: number | null;
   page: number;
@@ -38,26 +40,12 @@ export interface SearchPassagesResponse {
   total_pages: number | null;
   next_page: string | null;
   previous_page: string | null;
-  results: SearchPassage[];
+  results: ISearchPassage[];
 }
 
-// The passages endpoint has its own field vocabulary (`document_id` today, topics to
-// follow), so it cannot reuse TSearchQueryGroup, whose fields are typed to the
-// documents endpoint.
-interface IPassageFilterRule {
-  field: "document_id";
-  op: "contains";
-  value: string;
-}
-
-interface IPassageFilterGroup {
-  op: "and" | "or";
-  filters: (IPassageFilterGroup | IPassageFilterRule)[];
-}
-
-interface SearchPassagesParams {
+interface ISearchPassagesParams {
   query: string;
-  documentId: string;
+  documents: string[];
   pageSize?: number;
   // 1-indexed page number. The API's `page` parameter is currently ignored, and its
   // `next_page` / `total_pages` fields come back null, so callers page by incrementing
@@ -71,23 +59,28 @@ function searchPassagesUrl(): string {
   return `${origin}/search/passages`;
 }
 
-// Passage search is always scoped to a single document.
-function configurePassagesFilters(documentId: string): IPassageFilterGroup {
+function configurePassagesFilters(documents: string[]): TSearchQueryGroup {
   return {
-    op: "and",
-    filters: [{ field: "document_id", op: "contains", value: documentId }],
+    op: "or",
+    filters: documents.map((documentId) => ({ field: "document_id", op: "contains", value: documentId })),
   };
 }
 
-export async function fetchSearchPassages({ query, documentId, pageSize, pageToken, signal }: SearchPassagesParams): Promise<SearchPassagesResponse> {
+export async function fetchSearchPassages({
+  query,
+  documents,
+  pageSize,
+  pageToken,
+  signal,
+}: ISearchPassagesParams): Promise<ISearchPassagesResponse> {
   const url = new URL(searchPassagesUrl());
 
   url.searchParams.set("query", query);
-  url.searchParams.set("filters", JSON.stringify(configurePassagesFilters(documentId)));
+  url.searchParams.set("filters", JSON.stringify(configurePassagesFilters(documents)));
   if (pageSize !== undefined) url.searchParams.set("page_size", String(pageSize));
   if (pageToken !== undefined) url.searchParams.set("page_token", String(pageToken));
 
   const res = await fetch(url, { signal });
   if (!res.ok) throw new Error(`Passage search API error: ${res.status}`);
-  return res.json() as Promise<SearchPassagesResponse>;
+  return res.json() as Promise<ISearchPassagesResponse>;
 }

--- a/src/components/EmbeddedPDF.tsx
+++ b/src/components/EmbeddedPDF.tsx
@@ -2,14 +2,15 @@ import Script from "next/script";
 import { useRef, useMemo, useEffect, useContext } from "react";
 
 import { AdobeContext } from "@/context/AdobeContext";
-import usePDFPreview from "@/hooks/usePDFPreview";
-import { TFamilyDocumentPublic, TLoadingStatus, TPassage } from "@/types";
+import usePDFPreview, { TViewerPassage } from "@/hooks/usePDFPreview";
+import { TFamilyDocumentPublic, TLoadingStatus } from "@/types";
 
 import Loader from "./Loader";
 
 interface IProps {
   document: TFamilyDocumentPublic;
-  documentPassageMatches?: TPassage[];
+  // Accepts passages from either the legacy Vespa search or the v2 passages endpoint.
+  documentPassageMatches?: TViewerPassage[];
   pageNumber?: number;
   startingPageNumber?: number;
   searchStatus?: TLoadingStatus;

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -208,12 +208,17 @@ describe("DocumentPassageViewer", () => {
     });
 
     it("moves the preview to the passage page when a passage is clicked", async () => {
+      // A second passage well away from the first, so the click is what moves the reader
+      // rather than the jump to the first result.
+      mockFetchSearchPassages.mockResolvedValue({
+        total_size: 2,
+        results: [buildPassage(), buildPassage({ id: "passage-2", text: "A later passage", pages: [40] })],
+      });
       renderViewer("renewable");
-      const passage = await screen.findByRole("button", { name: /Certain ecological/ });
 
-      await userEvent.click(passage);
+      await userEvent.click(await screen.findByRole("button", { name: /A later passage/ }));
 
-      expect(await screen.findByText("page:17")).toBeInTheDocument();
+      expect(await screen.findByText("page:41")).toBeInTheDocument();
     });
 
     it("shows the no results state when nothing matches", async () => {
@@ -229,6 +234,111 @@ describe("DocumentPassageViewer", () => {
       renderViewer("renewable");
 
       expect(await screen.findByText(/Something went wrong with your search/)).toBeInTheDocument();
+    });
+  });
+
+  describe("switching between search terms", () => {
+    // Lets a search be left in flight so the intermediate render can be inspected.
+    const deferredPage = () => {
+      let resolvePage: (value: unknown) => void;
+      const promise = new Promise((resolve) => {
+        resolvePage = resolve;
+      });
+      return { promise, resolve: (value: unknown) => resolvePage(value) };
+    };
+
+    it("does not show the previous term's results while the next one loads", async () => {
+      const second = deferredPage();
+      mockFetchSearchPassages
+        .mockResolvedValueOnce({ total_size: 1, results: [buildPassage({ id: "a", text: "First term result" })] })
+        .mockReturnValueOnce(second.promise);
+      renderViewer("renewable");
+      await screen.findByText("First term result");
+
+      await userEvent.clear(searchBox());
+      await userEvent.type(searchBox(), "biomass{Enter}");
+
+      // The second search is still in flight here.
+      expect(screen.queryByText("First term result")).not.toBeInTheDocument();
+      expect(screen.queryByText("No matching passages")).not.toBeInTheDocument();
+
+      second.resolve({ total_size: 1, results: [buildPassage({ id: "b", text: "Second term result" })] });
+      expect(await screen.findByText("Second term result")).toBeInTheDocument();
+    });
+
+    it("does not flash the no-results state while a search is in flight", async () => {
+      const search = deferredPage();
+      mockFetchSearchPassages.mockReturnValueOnce(search.promise);
+      renderViewer();
+
+      await userEvent.type(searchBox(), "renewable{Enter}");
+
+      expect(screen.queryByText("No matching passages")).not.toBeInTheDocument();
+      expect(screen.queryByText("Search passages")).not.toBeInTheDocument();
+
+      search.resolve({ total_size: 0, results: [] });
+      expect(await screen.findByText("No matching passages")).toBeInTheDocument();
+    });
+  });
+
+  describe("moving the preview to the first result", () => {
+    it("jumps to the page of the first result when a search returns", async () => {
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 1, results: [buildPassage({ pages: [23] })] });
+      renderViewer();
+
+      expect(screen.getByText("page:none")).toBeInTheDocument();
+
+      await userEvent.type(searchBox(), "renewable{Enter}");
+
+      expect(await screen.findByText("page:24")).toBeInTheDocument();
+    });
+
+    it("stays put when another page of results is loaded", async () => {
+      mockFetchSearchPassages
+        .mockResolvedValueOnce({ total_size: 4, results: [buildPassage({ id: "a", pages: [10] })] })
+        .mockResolvedValueOnce({ total_size: 4, results: [buildPassage({ id: "b", text: "Second page", pages: [80] })] });
+      renderViewer("renewable");
+      await screen.findByText("page:11");
+
+      await userEvent.click(await screen.findByRole("button", { name: /load more/i }));
+      await screen.findByText("Second page");
+
+      expect(screen.getByText("page:11")).toBeInTheDocument();
+    });
+
+    it("stays put after the reader has clicked through to another passage", async () => {
+      mockFetchSearchPassages.mockResolvedValue({
+        total_size: 2,
+        results: [buildPassage({ id: "a", pages: [10] }), buildPassage({ id: "b", text: "A later passage", pages: [80] })],
+      });
+      renderViewer("renewable");
+      await screen.findByText("page:11");
+
+      await userEvent.click(screen.getByRole("button", { name: /A later passage/ }));
+
+      expect(await screen.findByText("page:81")).toBeInTheDocument();
+    });
+
+    it("jumps again when a new search returns", async () => {
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 1, results: [buildPassage({ pages: [10] })] });
+      renderViewer("renewable");
+      await screen.findByText("page:11");
+
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 1, results: [buildPassage({ id: "b", pages: [55] })] });
+      await userEvent.clear(searchBox());
+      await userEvent.type(searchBox(), "biomass{Enter}");
+
+      expect(await screen.findByText("page:56")).toBeInTheDocument();
+    });
+
+    it("does not jump when a search returns nothing", async () => {
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 0, results: [] });
+      renderViewer();
+
+      await userEvent.type(searchBox(), "renewable{Enter}");
+
+      await screen.findByText("No matching passages");
+      expect(screen.getByText("page:none")).toBeInTheDocument();
     });
   });
 

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -185,7 +185,7 @@ describe("DocumentPassageViewer", () => {
 
       await waitFor(() => expect(searchBox()).toHaveValue(""));
       expect(screen.getByText("Search passages")).toBeInTheDocument();
-      expect(urlQuery.writes.at(-1)).toBeNull();
+      expect(urlQuery.writes.at(-1)).toBe("");
     });
   });
 

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -101,7 +101,7 @@ const renderViewer = (initialQuery = "") => {
   );
 };
 
-const searchBox = () => screen.getByRole("searchbox", { name: /search passages/i });
+const searchBox = () => screen.getByRole("textbox", { name: /search passages/i });
 
 // The Input atom's clear control is an unlabelled icon button, so it is reached through
 // the search landmark rather than by name.
@@ -131,7 +131,7 @@ describe("DocumentPassageViewer", () => {
       await userEvent.type(searchBox(), "renewable{Enter}");
 
       await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledTimes(1));
-      expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable", documentId: "CCLW.document.1.1" }));
+      expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable", documents: ["CCLW.document.1.1"] }));
     });
 
     it("puts the submitted term in the url so the search can be shared", async () => {

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -1,0 +1,253 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { SearchPassage } from "@/api/passages";
+import { TopicsContext } from "@/context/TopicsContext";
+import { TFamilyDocumentPublic, TSearchResponse, TTopics } from "@/types";
+
+import { DocumentPassageViewer } from "./DocumentPassageViewer";
+
+// The Adobe viewer needs a real browser, so the preview pane is stubbed out.
+vi.mock("@/components/EmbeddedPDF", () => ({
+  default: ({ pageNumber }: { pageNumber: number | null }) => <div data-cy="embedded-pdf">page:{pageNumber ?? "none"}</div>,
+}));
+
+const mockFetchSearchPassages = vi.hoisted(() => vi.fn());
+vi.mock("@/api/passages", () => ({ fetchSearchPassages: mockFetchSearchPassages }));
+
+// A stateful stand-in for the `q` URL param. nuqs' own testing adapter is fully
+// controlled and reverts the value after every write, which the component reads as a
+// browser navigation. The real adapter (wired in _app.tsx) keeps the value, so this fake
+// reproduces production semantics: read the initial term, then hold what is written.
+const urlQuery = vi.hoisted(() => ({ initial: "", writes: [] as (string | null)[] }));
+vi.mock("nuqs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("nuqs")>();
+  const { useState } = await import("react");
+  return {
+    ...actual,
+    useQueryState: () => {
+      const [value, setValue] = useState(urlQuery.initial);
+      return [
+        value,
+        (next: string | null) => {
+          urlQuery.writes.push(next);
+          setValue(next ?? "");
+          return Promise.resolve(new URLSearchParams());
+        },
+      ];
+    },
+  };
+});
+
+const buildPassage = (overrides: Partial<SearchPassage> = {}): SearchPassage => ({
+  id: "passage-1",
+  text_block_id: "block-1",
+  idx: 12,
+  text: "Certain ecological and other requirements for the areas used by cultivation.",
+  language: "en",
+  type: "",
+  type_confidence: 0,
+  page_number: 0,
+  pages: [16],
+  pages_with_bounding_boxes: [],
+  concepts: [],
+  heading_id: "heading-1",
+  heading_text: "Section 4: National Target 16",
+  document_id: "CCLW.document.1.1",
+  principal_id: "CCLW.family.1.0",
+  tokens: [],
+  ...overrides,
+});
+
+const document = {
+  cdn_object: "https://cdn.example.org/document.pdf",
+  import_id: "CCLW.document.1.1",
+  slug: "a-document",
+  title: "Law for the expansion of renewable energies",
+} as TFamilyDocumentPublic;
+
+const topics: TTopics = {
+  rootTopics: [],
+  topics: [
+    { wikibase_id: "Q1", preferred_label: "Extreme weather" },
+    { wikibase_id: "Q2", preferred_label: "Air pollution risk" },
+  ] as TTopics["topics"],
+};
+
+const vespaDocumentData = {
+  families: [
+    {
+      id: "family-1",
+      hits: [
+        { concept_counts: { "Q1:extreme weather": 3, "Q2:air pollution risk": 9 } },
+        // The same concept spread over a second hit, to prove counts are summed.
+        { concept_counts: { "Q1:extreme weather": 8 } },
+      ],
+    },
+  ],
+} as unknown as TSearchResponse;
+
+const renderViewer = (initialQuery = "") => {
+  urlQuery.initial = initialQuery;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TopicsContext.Provider value={topics}>
+        <DocumentPassageViewer document={document} vespaDocumentData={vespaDocumentData} />
+      </TopicsContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+const searchBox = () => screen.getByRole("searchbox", { name: /search passages/i });
+
+// The Input atom's clear control is an unlabelled icon button, so it is reached through
+// the search landmark rather than by name.
+const clearButton = () => within(screen.getByRole("search")).getByRole("button");
+
+describe("DocumentPassageViewer", () => {
+  beforeEach(() => {
+    urlQuery.initial = "";
+    urlQuery.writes = [];
+    mockFetchSearchPassages.mockReset();
+    mockFetchSearchPassages.mockResolvedValue({ total_size: 1, results: [buildPassage()] });
+  });
+
+  describe("handling the search term", () => {
+    it("does not search until the user submits a term", async () => {
+      renderViewer();
+      await screen.findByText("Search passages");
+
+      await userEvent.type(searchBox(), "renewable");
+
+      expect(mockFetchSearchPassages).not.toHaveBeenCalled();
+    });
+
+    it("searches the document for the term when the user presses enter", async () => {
+      renderViewer();
+
+      await userEvent.type(searchBox(), "renewable{Enter}");
+
+      await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledTimes(1));
+      expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable", documentId: "CCLW.document.1.1" }));
+    });
+
+    it("puts the submitted term in the url so the search can be shared", async () => {
+      renderViewer();
+
+      await userEvent.type(searchBox(), "renewable{Enter}");
+
+      await waitFor(() => expect(urlQuery.writes).toContain("renewable"));
+    });
+
+    it("trims surrounding whitespace from the term", async () => {
+      renderViewer();
+
+      await userEvent.type(searchBox(), "  renewable  {Enter}");
+
+      await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable" })));
+    });
+
+    it("does not search when the term is only whitespace", async () => {
+      renderViewer();
+
+      await userEvent.type(searchBox(), "   {Enter}");
+
+      expect(mockFetchSearchPassages).not.toHaveBeenCalled();
+    });
+
+    it("runs the search from the url on first render", async () => {
+      renderViewer("renewable");
+
+      await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable" })));
+      expect(searchBox()).toHaveValue("renewable");
+    });
+
+    it("keeps the term the user is typing, and only searches the submitted one", async () => {
+      renderViewer("renewable");
+      await screen.findByText(/Certain ecological/);
+
+      await userEvent.clear(searchBox());
+      await userEvent.type(searchBox(), "biomass");
+
+      expect(searchBox()).toHaveValue("biomass");
+      expect(mockFetchSearchPassages).toHaveBeenCalledTimes(1);
+      expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "renewable" }));
+    });
+
+    it("clears the term and returns to the empty state", async () => {
+      renderViewer("renewable");
+      await screen.findByText(/Certain ecological/);
+
+      await userEvent.click(clearButton());
+
+      await waitFor(() => expect(searchBox()).toHaveValue(""));
+      expect(screen.getByText("Search passages")).toBeInTheDocument();
+      expect(urlQuery.writes.at(-1)).toBeNull();
+    });
+  });
+
+  describe("results", () => {
+    it("renders a PassageBlock per result, without the document title", async () => {
+      renderViewer("renewable");
+
+      expect(await screen.findByText(/Certain ecological/)).toBeInTheDocument();
+      expect(screen.getByText("Pg. 16")).toBeInTheDocument();
+      expect(screen.getByText("Section 4: National Target 16")).toBeInTheDocument();
+      // The reader is already on this document, so its title is not repeated per passage.
+      expect(screen.queryByText(document.title)).not.toBeInTheDocument();
+    });
+
+    it("reports the number of matches", async () => {
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 12, results: [buildPassage()] });
+      renderViewer("renewable");
+
+      expect(await screen.findByText("12 matching passages")).toBeInTheDocument();
+    });
+
+    it("moves the preview to the passage page when a passage is clicked", async () => {
+      renderViewer("renewable");
+      const passage = await screen.findByRole("button", { name: /Certain ecological/ });
+
+      await userEvent.click(passage);
+
+      expect(await screen.findByText("page:16")).toBeInTheDocument();
+    });
+
+    it("shows the no results state when nothing matches", async () => {
+      mockFetchSearchPassages.mockResolvedValue({ total_size: 0, results: [] });
+      renderViewer("renewable");
+
+      expect(await screen.findByText("No matching passages")).toBeInTheDocument();
+      expect(screen.getByText("0 matching passages")).toBeInTheDocument();
+    });
+
+    it("shows an error message when the search fails", async () => {
+      mockFetchSearchPassages.mockRejectedValue(new Error("Passage search API error: 500"));
+      renderViewer("renewable");
+
+      expect(await screen.findByText(/Something went wrong with your search/)).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state concepts", () => {
+    it("lists the document's most common concepts, highest count first", async () => {
+      renderViewer();
+
+      const concepts = await screen.findAllByRole("button", { name: /Extreme weather|Air pollution risk/ });
+      // Extreme weather totals 11 across two hits, ahead of air pollution risk on 9.
+      expect(concepts.map((concept) => concept.textContent)).toEqual(["Extreme weather", "Air pollution risk"]);
+    });
+
+    it("searches for a concept when its pill is clicked", async () => {
+      renderViewer();
+
+      await userEvent.click(await screen.findByRole("button", { name: "Extreme weather" }));
+
+      await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ query: "Extreme weather" })));
+      expect(searchBox()).toHaveValue("Extreme weather");
+    });
+  });
+});

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -232,6 +232,67 @@ describe("DocumentPassageViewer", () => {
     });
   });
 
+  describe("loading more results", () => {
+    const pageOf = (ids: string[], total: number) => ({
+      total_size: total,
+      results: ids.map((id) => buildPassage({ id, text: `Passage ${id}` })),
+    });
+
+    it("starts at the first page", async () => {
+      renderViewer("renewable");
+
+      await waitFor(() => expect(mockFetchSearchPassages).toHaveBeenCalledWith(expect.objectContaining({ pageToken: 1 })));
+    });
+
+    it("does not offer more when every result is already loaded", async () => {
+      mockFetchSearchPassages.mockResolvedValue(pageOf(["a", "b"], 2));
+      renderViewer("renewable");
+
+      await screen.findByText("Passage a");
+      expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+    });
+
+    it("offers more when the total exceeds what is loaded", async () => {
+      mockFetchSearchPassages.mockResolvedValue(pageOf(["a", "b"], 5));
+      renderViewer("renewable");
+
+      expect(await screen.findByRole("button", { name: /load more/i })).toBeInTheDocument();
+      expect(screen.getByText("Showing 2 of 5")).toBeInTheDocument();
+    });
+
+    it("requests the next page and appends it below the first", async () => {
+      mockFetchSearchPassages.mockResolvedValueOnce(pageOf(["a", "b"], 4)).mockResolvedValueOnce(pageOf(["c", "d"], 4));
+      renderViewer("renewable");
+
+      await userEvent.click(await screen.findByRole("button", { name: /load more/i }));
+
+      expect(await screen.findByText("Passage c")).toBeInTheDocument();
+      expect(screen.getByText("Passage a")).toBeInTheDocument();
+      expect(mockFetchSearchPassages).toHaveBeenLastCalledWith(expect.objectContaining({ pageToken: 2 }));
+    });
+
+    it("stops offering more once the last page has arrived", async () => {
+      mockFetchSearchPassages.mockResolvedValueOnce(pageOf(["a", "b"], 4)).mockResolvedValueOnce(pageOf(["c", "d"], 4));
+      renderViewer("renewable");
+
+      await userEvent.click(await screen.findByRole("button", { name: /load more/i }));
+
+      await screen.findByText("Passage d");
+      expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+    });
+
+    it("stops offering more when a page comes back empty despite an over-reported total", async () => {
+      mockFetchSearchPassages.mockResolvedValueOnce(pageOf(["a"], 99)).mockResolvedValueOnce(pageOf([], 99));
+      renderViewer("renewable");
+
+      await userEvent.click(await screen.findByRole("button", { name: /load more/i }));
+
+      await waitFor(() => expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument());
+      // The results already on screen survive the empty page.
+      expect(screen.getByText("Passage a")).toBeInTheDocument();
+    });
+  });
+
   describe("empty state concepts", () => {
     it("lists the document's most common concepts, highest count first", async () => {
       renderViewer();

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { SearchPassage } from "@/api/passages";
+import type { ISearchPassage } from "@/api/passages";
 import { TopicsContext } from "@/context/TopicsContext";
 import { TFamilyDocumentPublic, TSearchResponse, TTopics } from "@/types";
 
@@ -40,7 +40,7 @@ vi.mock("nuqs", async (importOriginal) => {
   };
 });
 
-const buildPassage = (overrides: Partial<SearchPassage> = {}): SearchPassage => ({
+const buildPassage = (overrides: Partial<ISearchPassage> = {}): ISearchPassage => ({
   id: "passage-1",
   text_block_id: "block-1",
   idx: 12,

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -2,9 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { ISearchPassage } from "@/api/passages";
 import { TopicsContext } from "@/context/TopicsContext";
-import { TFamilyDocumentPublic, TSearchResponse, TTopics } from "@/types";
+import { ISearchPassage, TFamilyDocumentPublic, TSearchResponse, TTopics } from "@/types";
 
 import { DocumentPassageViewer } from "./DocumentPassageViewer";
 

--- a/src/components/documents/DocumentPassageViewer.test.tsx
+++ b/src/components/documents/DocumentPassageViewer.test.tsx
@@ -194,7 +194,7 @@ describe("DocumentPassageViewer", () => {
       renderViewer("renewable");
 
       expect(await screen.findByText(/Certain ecological/)).toBeInTheDocument();
-      expect(screen.getByText("Pg. 16")).toBeInTheDocument();
+      expect(screen.getByText("Pg. 17")).toBeInTheDocument();
       expect(screen.getByText("Section 4: National Target 16")).toBeInTheDocument();
       // The reader is already on this document, so its title is not repeated per passage.
       expect(screen.queryByText(document.title)).not.toBeInTheDocument();
@@ -213,7 +213,7 @@ describe("DocumentPassageViewer", () => {
 
       await userEvent.click(passage);
 
-      expect(await screen.findByText("page:16")).toBeInTheDocument();
+      expect(await screen.findByText("page:17")).toBeInTheDocument();
     });
 
     it("shows the no results state when nothing matches", async () => {

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -15,7 +15,8 @@ import { FullWidth } from "@/components/panels/FullWidth";
 import { RESULTS_PER_PAGE } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TopicsContext } from "@/context/TopicsContext";
-import { TFamilyDocumentPublic, TSearchResponse, TTopic } from "@/types";
+import { TFamilyDocumentPublic, TSearchResponse } from "@/types";
+import { getTopDocumentConcepts } from "@/utils/topics/getTopDocumentTopics";
 
 const TOP_CONCEPTS_LIMIT = 10;
 
@@ -34,29 +35,6 @@ const toPassageBlock = (passage: ISearchPassage, documentTitle: string): TPassag
   headingText: passage.heading_text ?? undefined,
   documentTitle,
 });
-
-// concept_counts keys are `<wikibase id>:<label>` and the same concept can appear across
-// several hits, so counts are summed before ranking. Concepts we have no topic record for
-// are dropped, as we would have no label to show.
-const getTopDocumentConcepts = (vespaDocumentData: TSearchResponse, topics: TTopic[], limit: number): TTopic[] => {
-  const totals = new Map<string, number>();
-  const topicsById = new Map(topics.map((topic) => [topic.wikibase_id, topic]));
-
-  (vespaDocumentData?.families ?? []).forEach((family) =>
-    family.hits.forEach((hit) =>
-      Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
-        const [conceptId] = conceptKey.split(":");
-        if (!topicsById.has(conceptId)) return;
-        totals.set(conceptId, (totals.get(conceptId) ?? 0) + count);
-      })
-    )
-  );
-
-  return Array.from(totals.entries())
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, limit)
-    .map(([conceptId, count]) => ({ ...topicsById.get(conceptId), count }));
-};
 
 type TPassageResultsProps = {
   onPassageClick: (passage: TPassageBlock) => void;

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -3,7 +3,7 @@ import { Search } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { memo, useCallback, useContext, useMemo, useState } from "react";
 
-import { fetchSearchPassages, type SearchPassage } from "@/api/passages";
+import { fetchSearchPassages, type ISearchPassage } from "@/api/passages";
 import EmbeddedPDF from "@/components/EmbeddedPDF";
 import Loader from "@/components/Loader";
 import { Button } from "@/components/atoms/button/Button";
@@ -25,7 +25,7 @@ type TProps = {
 };
 
 // The passages endpoint and the PassageBlock molecule name their fields differently.
-const toPassageBlock = (passage: SearchPassage, documentTitle: string): TPassageBlock => ({
+const toPassageBlock = (passage: ISearchPassage, documentTitle: string): TPassageBlock => ({
   id: passage.id,
   document_id: passage.document_id,
   idx: passage.idx,
@@ -78,7 +78,7 @@ PassageResults.displayName = "PassageResults";
 type TDocumentPreviewProps = {
   document: TFamilyDocumentPublic;
   pageNumber: number | null;
-  passages: SearchPassage[];
+  passages: ISearchPassage[];
 };
 
 // Memoised so the Adobe viewer is not torn down and rebuilt on every search interaction.
@@ -112,7 +112,7 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
   const { data, isError, isFetching, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ["document-passages", document.import_id, query],
     queryFn: ({ pageParam, signal }) =>
-      fetchSearchPassages({ query, documentId: document.import_id, pageSize: RESULTS_PER_PAGE, pageToken: pageParam, signal }),
+      fetchSearchPassages({ query, documents: [document.import_id], pageSize: RESULTS_PER_PAGE, pageToken: pageParam, signal }),
     initialPageParam: 1,
     // The API leaves `next_page` and `total_pages` unpopulated, so there is no cursor to
     // follow. Paging is driven by the running result count against the reported total.

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -197,7 +197,8 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     (passage: TPassageBlock) => {
       const page = passage.pages?.[0]?.page_number;
       if (!canPreview || page === undefined) return;
-      setPageNumber(page);
+      // `page_number` is 0-indexed in the passage model; the PDF viewer is 1-indexed.
+      setPageNumber(page + 1);
     },
     [canPreview]
   );

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -14,14 +14,9 @@ import { FullWidth } from "@/components/panels/FullWidth";
 import { RESULTS_PER_PAGE } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TopicsContext } from "@/context/TopicsContext";
-import { TFamilyDocumentPublic, TPassage, TSearchResponse, TTopic } from "@/types";
+import { TFamilyDocumentPublic, TSearchResponse, TTopic } from "@/types";
 
 const TOP_CONCEPTS_LIMIT = 8;
-
-// Passage highlighting in the PDF is deferred until the passage model settles
-// (FUS-67 / FUS-48), so the viewer is handed a stable empty list and only ever
-// re-renders to change page.
-const NO_PASSAGE_HIGHLIGHTS: TPassage[] = [];
 
 type TProps = {
   document: TFamilyDocumentPublic;
@@ -128,11 +123,15 @@ PassageResults.displayName = "PassageResults";
 type TDocumentPreviewProps = {
   document: TFamilyDocumentPublic;
   pageNumber: number | null;
+  passages: SearchPassage[];
 };
 
 // Memoised so the Adobe viewer is not torn down and rebuilt on every search interaction.
-const DocumentPreview = memo(({ document, pageNumber }: TDocumentPreviewProps) => (
-  <EmbeddedPDF document={document} documentPassageMatches={NO_PASSAGE_HIGHLIGHTS} pageNumber={pageNumber} />
+// `startingPageNumber` is deliberately not passed: it sits in EmbeddedPDF's effect
+// dependencies, so feeding the current page back in would re-register the passages on
+// every passage click. The hook already leaves the reader where it is on a refresh.
+const DocumentPreview = memo(({ document, pageNumber, passages }: TDocumentPreviewProps) => (
+  <EmbeddedPDF document={document} documentPassageMatches={passages} pageNumber={pageNumber} />
 ));
 DocumentPreview.displayName = "DocumentPreview";
 
@@ -180,10 +179,11 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
 
   // `keepPreviousData` holds the last results against the new query key, so they have to
   // be dropped explicitly once the search is cleared.
-  const passages = useMemo(
-    () => (hasQuery ? (data?.pages ?? []).flatMap((page) => page.results).map((passage) => toPassageBlock(passage, document.title)) : []),
-    [data, document.title, hasQuery]
-  );
+  // Kept in the API's own shape as well, since the PDF viewer highlights from the
+  // bounding boxes that `toPassageBlock` drops.
+  const searchPassages = useMemo(() => (hasQuery ? (data?.pages ?? []).flatMap((page) => page.results) : []), [data, hasQuery]);
+
+  const passages = useMemo(() => searchPassages.map((passage) => toPassageBlock(passage, document.title)), [searchPassages, document.title]);
 
   const topConcepts = useMemo(() => getTopDocumentConcepts(vespaDocumentData, topics, TOP_CONCEPTS_LIMIT), [vespaDocumentData, topics]);
 
@@ -277,7 +277,7 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
         </div>
 
         <div id="document-preview" className="w-full h-[600px] border-t border-border-light lg:w-1/2 lg:h-full lg:border-t-0 lg:border-l">
-          {canPreview ? <DocumentPreview document={document} pageNumber={pageNumber} /> : <EmptyDocument />}
+          {canPreview ? <DocumentPreview document={document} pageNumber={pageNumber} passages={searchPassages} /> : <EmptyDocument />}
         </div>
       </div>
     </section>

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { FileSearch2, ScanSearch, Search } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { memo, useCallback, useContext, useMemo, useState } from "react";
@@ -6,11 +6,12 @@ import { memo, useCallback, useContext, useMemo, useState } from "react";
 import { fetchSearchPassages, type SearchPassage } from "@/api/passages";
 import EmbeddedPDF from "@/components/EmbeddedPDF";
 import Loader from "@/components/Loader";
+import { Button } from "@/components/atoms/button/Button";
 import { Input } from "@/components/atoms/input/Input";
 import { EmptyDocument } from "@/components/documents/EmptyDocument";
 import { PassageBlock, TPassage as TPassageBlock } from "@/components/molecules/passageBlock/PassageBlock";
 import { FullWidth } from "@/components/panels/FullWidth";
-import { PASSAGES_PER_DOC } from "@/constants/paging";
+import { RESULTS_PER_PAGE } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TopicsContext } from "@/context/TopicsContext";
 import { TFamilyDocumentPublic, TPassage, TSearchResponse, TTopic } from "@/types";
@@ -152,9 +153,21 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
 
   const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
 
-  const { data, isError, isFetching } = useQuery({
+  const { data, isError, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ["document-passages", document.import_id, query],
-    queryFn: ({ signal }) => fetchSearchPassages({ query, documentId: document.import_id, pageSize: PASSAGES_PER_DOC, signal }),
+    queryFn: ({ pageParam, signal }) =>
+      fetchSearchPassages({ query, documentId: document.import_id, pageSize: RESULTS_PER_PAGE, pageToken: pageParam, signal }),
+    initialPageParam: 1,
+    // The API leaves `next_page` and `total_pages` unpopulated, so there is no cursor to
+    // follow. Paging is driven by the running result count against the reported total.
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((count, page) => count + page.results.length, 0);
+      const total = lastPage.total_size ?? 0;
+      // A page that comes back empty also ends paging, otherwise an over-reported total
+      // would leave the button fetching nothing forever.
+      if (loaded >= total || lastPage.results.length === 0) return undefined;
+      return allPages.length + 1;
+    },
     enabled: query.length > 0,
     // A term's results do not change within a session, so don't refetch one the user returns to.
     refetchOnWindowFocus: false,
@@ -168,7 +181,7 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
   // `keepPreviousData` holds the last results against the new query key, so they have to
   // be dropped explicitly once the search is cleared.
   const passages = useMemo(
-    () => (hasQuery ? (data?.results ?? []).map((passage) => toPassageBlock(passage, document.title)) : []),
+    () => (hasQuery ? (data?.pages ?? []).flatMap((page) => page.results).map((passage) => toPassageBlock(passage, document.title)) : []),
     [data, document.title, hasQuery]
   );
 
@@ -203,8 +216,9 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     [canPreview]
   );
 
-  const totalMatches = hasQuery ? (data?.total_size ?? 0) : 0;
-  const isLoading = isFetching && passages.length === 0;
+  const totalMatches = hasQuery ? (data?.pages[0]?.total_size ?? 0) : 0;
+  // `isFetching` also covers loading the next page, which must not blank the list.
+  const isLoading = isFetching && !isFetchingNextPage && passages.length === 0;
 
   return (
     <section className="flex-1 flex flex-col" id="document-passage-viewer">
@@ -215,7 +229,7 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
             clearable
             containerClasses="px-4 py-2"
             icon={<Search size={16} />}
-            inputClasses="text-base"
+            inputClasses="!text-sm"
             name="passage-search"
             onChange={(event) => setSearchTerm(event.target.value)}
             onClear={handleClear}
@@ -229,10 +243,10 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
         </p>
       </FullWidth>
 
-      <div className="flex-1 flex flex-col border-t border-border-light lg:flex-row lg:h-[80vh]">
+      <div className="flex flex-col border-t border-border-light lg:flex-row lg:h-[80vh]">
         <div
           id="document-passages"
-          className="w-full px-5 py-4 lg:w-1/2 lg:h-full lg:overflow-y-auto scrollbar-thin scrollbar-thumb-gray-200 scrollbar-track-white scrollbar-thumb-rounded-full"
+          className="w-full max-h-[80vh] overflow-y-auto px-5 py-4 lg:w-1/2 lg:h-full scrollbar-thin scrollbar-thumb-gray-200 scrollbar-track-white scrollbar-thumb-rounded-full"
         >
           {isLoading && (
             <div className="flex justify-center">
@@ -242,7 +256,21 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
           {!isLoading && isError && (
             <p className="py-10 text-center text-sm text-text-secondary">Something went wrong with your search. Please try again.</p>
           )}
-          {!isLoading && !isError && passages.length > 0 && <PassageResults passages={passages} onPassageClick={handlePassageClick} />}
+          {!isLoading && !isError && passages.length > 0 && (
+            <>
+              <PassageResults passages={passages} onPassageClick={handlePassageClick} />
+              {hasNextPage && (
+                <div className="flex flex-col items-center gap-2 pt-4">
+                  <Button variant="outlined" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+                    {isFetchingNextPage ? "Loading…" : "Load more"}
+                  </Button>
+                  <p className="text-sm text-text-secondary" aria-live="polite">
+                    Showing {passages.length} of {totalMatches}
+                  </p>
+                </div>
+              )}
+            </>
+          )}
           {!isLoading && !isError && passages.length === 0 && (
             <PassagesEmptyState concepts={topConcepts} hasQuery={hasQuery} onClearClick={handleClear} onConceptClick={handleConceptClick} />
           )}

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -3,7 +3,7 @@ import { Search } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { memo, useCallback, useContext, useMemo, useState } from "react";
 
-import { fetchSearchPassages, type ISearchPassage } from "@/api/passages";
+import { fetchSearchPassages } from "@/api/passages";
 import EmbeddedPDF from "@/components/EmbeddedPDF";
 import Loader from "@/components/Loader";
 import { Button } from "@/components/atoms/button/Button";
@@ -15,7 +15,7 @@ import { FullWidth } from "@/components/panels/FullWidth";
 import { RESULTS_PER_PAGE } from "@/constants/paging";
 import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TopicsContext } from "@/context/TopicsContext";
-import { TFamilyDocumentPublic, TSearchResponse } from "@/types";
+import { ISearchPassage, TFamilyDocumentPublic, TSearchResponse } from "@/types";
 import { getTopDocumentConcepts } from "@/utils/topics/getTopDocumentTopics";
 
 const TOP_CONCEPTS_LIMIT = 10;

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -1,0 +1,256 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { FileSearch2, ScanSearch, Search } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+import { memo, useCallback, useContext, useMemo, useState } from "react";
+
+import { fetchSearchPassages, type SearchPassage } from "@/api/passages";
+import EmbeddedPDF from "@/components/EmbeddedPDF";
+import Loader from "@/components/Loader";
+import { Input } from "@/components/atoms/input/Input";
+import { EmptyDocument } from "@/components/documents/EmptyDocument";
+import { PassageBlock, TPassage as TPassageBlock } from "@/components/molecules/passageBlock/PassageBlock";
+import { FullWidth } from "@/components/panels/FullWidth";
+import { PASSAGES_PER_DOC } from "@/constants/paging";
+import { QUERY_PARAMS } from "@/constants/queryParams";
+import { TopicsContext } from "@/context/TopicsContext";
+import { TFamilyDocumentPublic, TPassage, TSearchResponse, TTopic } from "@/types";
+
+const TOP_CONCEPTS_LIMIT = 8;
+
+// Passage highlighting in the PDF is deferred until the passage model settles
+// (FUS-67 / FUS-48), so the viewer is handed a stable empty list and only ever
+// re-renders to change page.
+const NO_PASSAGE_HIGHLIGHTS: TPassage[] = [];
+
+type TProps = {
+  document: TFamilyDocumentPublic;
+  vespaDocumentData: TSearchResponse;
+};
+
+// The passages endpoint and the PassageBlock molecule name their fields differently.
+const toPassageBlock = (passage: SearchPassage, documentTitle: string): TPassageBlock => ({
+  id: passage.id,
+  document_id: passage.document_id,
+  idx: passage.idx,
+  content: passage.text,
+  pages: passage.pages?.map((pageNumber) => ({ page_number: pageNumber })),
+  headingText: passage.heading_text ?? undefined,
+  documentTitle,
+});
+
+// concept_counts keys are `<wikibase id>:<label>` and the same concept can appear across
+// several hits, so counts are summed before ranking. Concepts we have no topic record for
+// are dropped, as we would have no label to show.
+const getTopDocumentConcepts = (vespaDocumentData: TSearchResponse, topics: TTopic[], limit: number): TTopic[] => {
+  const totals = new Map<string, number>();
+  const topicsById = new Map(topics.map((topic) => [topic.wikibase_id, topic]));
+
+  (vespaDocumentData?.families ?? []).forEach((family) =>
+    family.hits.forEach((hit) =>
+      Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
+        const [conceptId] = conceptKey.split(":");
+        if (!topicsById.has(conceptId)) return;
+        totals.set(conceptId, (totals.get(conceptId) ?? 0) + count);
+      })
+    )
+  );
+
+  return Array.from(totals.entries())
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, limit)
+    .map(([conceptId, count]) => ({ ...topicsById.get(conceptId), count }));
+};
+
+type TEmptyStateProps = {
+  concepts: TTopic[];
+  hasQuery: boolean;
+  onClearClick: () => void;
+  onConceptClick: (label: string) => void;
+};
+
+const PassagesEmptyState = ({ concepts, hasQuery, onClearClick, onConceptClick }: TEmptyStateProps) => (
+  <div className="flex flex-col gap-8 py-10">
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="rounded-full bg-bg-flat p-4 text-elem-icon">{hasQuery ? <ScanSearch size={24} /> : <FileSearch2 size={24} />}</div>
+      <p className="font-medium text-text-primary">{hasQuery ? "No matching passages" : "Search passages"}</p>
+      <p className="max-w-xs text-sm text-text-secondary">
+        {hasQuery ? (
+          <>
+            <button type="button" onClick={onClearClick} className="underline hocus:text-text-primary">
+              Clear your search
+            </button>{" "}
+            to continue, or try a commonly mentioned topic below.
+          </>
+        ) : (
+          "Type a search or select from topics that appear in this document."
+        )}
+      </p>
+    </div>
+    {concepts.length > 0 && (
+      <div className="flex flex-col gap-3 border-t border-border-light pt-6">
+        <p className="text-sm text-text-secondary">Commonly mentioned in this document</p>
+        <ul className="flex flex-wrap gap-2">
+          {concepts.map((concept) => (
+            <li key={concept.wikibase_id}>
+              <button
+                type="button"
+                onClick={() => onConceptClick(concept.preferred_label)}
+                className="rounded-full border border-border-normal px-3 py-1 text-sm text-text-brand hocus:border-inky-blue hocus:bg-bg-flat"
+              >
+                {concept.preferred_label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+  </div>
+);
+
+type TPassageResultsProps = {
+  onPassageClick: (passage: TPassageBlock) => void;
+  passages: TPassageBlock[];
+};
+
+// Memoised so that typing in the search input does not re-render every result card.
+const PassageResults = memo(({ onPassageClick, passages }: TPassageResultsProps) => (
+  <ul className="flex flex-col gap-4" id="document-passage-matches" aria-label="Passage matches">
+    {passages.map((passage) => (
+      <li key={passage.id}>
+        <PassageBlock passage={passage} showDocument={false} onPassageClick={onPassageClick} />
+      </li>
+    ))}
+  </ul>
+));
+PassageResults.displayName = "PassageResults";
+
+type TDocumentPreviewProps = {
+  document: TFamilyDocumentPublic;
+  pageNumber: number | null;
+};
+
+// Memoised so the Adobe viewer is not torn down and rebuilt on every search interaction.
+const DocumentPreview = memo(({ document, pageNumber }: TDocumentPreviewProps) => (
+  <EmbeddedPDF document={document} documentPassageMatches={NO_PASSAGE_HIGHLIGHTS} pageNumber={pageNumber} />
+));
+DocumentPreview.displayName = "DocumentPreview";
+
+export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) => {
+  const { topics } = useContext(TopicsContext);
+  const [query, setQuery] = useQueryState(QUERY_PARAMS.query_string, parseAsString.withDefault(""));
+  const [searchTerm, setSearchTerm] = useState(query);
+  const [pageNumber, setPageNumber] = useState<number | null>(null);
+
+  // Keep the input in step with the URL when the query changes elsewhere, e.g. the
+  // browser back button or a concept being picked from the empty state. Adjusting during
+  // render rather than in an effect avoids a second render pass with a stale input.
+  const [previousQuery, setPreviousQuery] = useState(query);
+  if (query !== previousQuery) {
+    setPreviousQuery(query);
+    setSearchTerm(query);
+  }
+
+  const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
+
+  const { data, isError, isFetching } = useQuery({
+    queryKey: ["document-passages", document.import_id, query],
+    queryFn: ({ signal }) => fetchSearchPassages({ query, documentId: document.import_id, pageSize: PASSAGES_PER_DOC, signal }),
+    enabled: query.length > 0,
+    // A term's results do not change within a session, so don't refetch one the user returns to.
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    // Hold the previous results in place while the next term loads, to avoid the list collapsing.
+    placeholderData: keepPreviousData,
+  });
+
+  const hasQuery = query.length > 0;
+
+  // `keepPreviousData` holds the last results against the new query key, so they have to
+  // be dropped explicitly once the search is cleared.
+  const passages = useMemo(
+    () => (hasQuery ? (data?.results ?? []).map((passage) => toPassageBlock(passage, document.title)) : []),
+    [data, document.title, hasQuery]
+  );
+
+  const topConcepts = useMemo(() => getTopDocumentConcepts(vespaDocumentData, topics, TOP_CONCEPTS_LIMIT), [vespaDocumentData, topics]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // nuqs removes the param when given null, keeping an empty search out of the URL.
+    setQuery(searchTerm.trim() || null);
+  };
+
+  const handleClear = () => {
+    setSearchTerm("");
+    setQuery(null);
+  };
+
+  const handleConceptClick = useCallback(
+    (label: string) => {
+      setSearchTerm(label);
+      setQuery(label);
+    },
+    [setQuery]
+  );
+
+  const handlePassageClick = useCallback(
+    (passage: TPassageBlock) => {
+      const page = passage.pages?.[0]?.page_number;
+      if (!canPreview || page === undefined) return;
+      setPageNumber(page);
+    },
+    [canPreview]
+  );
+
+  const totalMatches = hasQuery ? (data?.total_size ?? 0) : 0;
+  const isLoading = isFetching && passages.length === 0;
+
+  return (
+    <section className="flex-1 flex flex-col" id="document-passage-viewer">
+      <FullWidth extraClasses="flex flex-col gap-4 py-4">
+        <form onSubmit={handleSubmit} role="search">
+          <Input
+            aria-label="Search passages in this document"
+            clearable
+            containerClasses="px-4 py-2"
+            icon={<Search size={16} />}
+            inputClasses="text-base"
+            name="passage-search"
+            onChange={(event) => setSearchTerm(event.target.value)}
+            onClear={handleClear}
+            placeholder="Enter search term"
+            type="search"
+            value={searchTerm}
+          />
+        </form>
+        <p className="text-sm text-text-secondary text-right" aria-live="polite">
+          {isLoading ? "Searching…" : `${totalMatches} matching ${totalMatches === 1 ? "passage" : "passages"}`}
+        </p>
+      </FullWidth>
+
+      <div className="flex-1 flex flex-col border-t border-border-light lg:flex-row lg:h-[80vh]">
+        <div
+          id="document-passages"
+          className="w-full px-5 py-4 lg:w-1/2 lg:h-full lg:overflow-y-auto scrollbar-thin scrollbar-thumb-gray-200 scrollbar-track-white scrollbar-thumb-rounded-full"
+        >
+          {isLoading && (
+            <div className="flex justify-center">
+              <Loader />
+            </div>
+          )}
+          {!isLoading && isError && (
+            <p className="py-10 text-center text-sm text-text-secondary">Something went wrong with your search. Please try again.</p>
+          )}
+          {!isLoading && !isError && passages.length > 0 && <PassageResults passages={passages} onPassageClick={handlePassageClick} />}
+          {!isLoading && !isError && passages.length === 0 && (
+            <PassagesEmptyState concepts={topConcepts} hasQuery={hasQuery} onClearClick={handleClear} onConceptClick={handleConceptClick} />
+          )}
+        </div>
+
+        <div id="document-preview" className="w-full h-[600px] border-t border-border-light lg:w-1/2 lg:h-full lg:border-t-0 lg:border-l">
+          {canPreview ? <DocumentPreview document={document} pageNumber={pageNumber} /> : <EmptyDocument />}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -1,5 +1,5 @@
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
-import { FileSearch2, ScanSearch, Search } from "lucide-react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Search } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { memo, useCallback, useContext, useMemo, useState } from "react";
 
@@ -9,6 +9,7 @@ import Loader from "@/components/Loader";
 import { Button } from "@/components/atoms/button/Button";
 import { Input } from "@/components/atoms/input/Input";
 import { EmptyDocument } from "@/components/documents/EmptyDocument";
+import { EmptyPassages } from "@/components/molecules/emptyPassages/EmptyPassages";
 import { PassageBlock, TPassage as TPassageBlock } from "@/components/molecules/passageBlock/PassageBlock";
 import { FullWidth } from "@/components/panels/FullWidth";
 import { RESULTS_PER_PAGE } from "@/constants/paging";
@@ -16,7 +17,7 @@ import { QUERY_PARAMS } from "@/constants/queryParams";
 import { TopicsContext } from "@/context/TopicsContext";
 import { TFamilyDocumentPublic, TSearchResponse, TTopic } from "@/types";
 
-const TOP_CONCEPTS_LIMIT = 8;
+const TOP_CONCEPTS_LIMIT = 10;
 
 type TProps = {
   document: TFamilyDocumentPublic;
@@ -56,52 +57,6 @@ const getTopDocumentConcepts = (vespaDocumentData: TSearchResponse, topics: TTop
     .slice(0, limit)
     .map(([conceptId, count]) => ({ ...topicsById.get(conceptId), count }));
 };
-
-type TEmptyStateProps = {
-  concepts: TTopic[];
-  hasQuery: boolean;
-  onClearClick: () => void;
-  onConceptClick: (label: string) => void;
-};
-
-const PassagesEmptyState = ({ concepts, hasQuery, onClearClick, onConceptClick }: TEmptyStateProps) => (
-  <div className="flex flex-col gap-8 py-10">
-    <div className="flex flex-col items-center gap-3 text-center">
-      <div className="rounded-full bg-bg-flat p-4 text-elem-icon">{hasQuery ? <ScanSearch size={24} /> : <FileSearch2 size={24} />}</div>
-      <p className="font-medium text-text-primary">{hasQuery ? "No matching passages" : "Search passages"}</p>
-      <p className="max-w-xs text-sm text-text-secondary">
-        {hasQuery ? (
-          <>
-            <button type="button" onClick={onClearClick} className="underline hocus:text-text-primary">
-              Clear your search
-            </button>{" "}
-            to continue, or try a commonly mentioned topic below.
-          </>
-        ) : (
-          "Type a search or select from topics that appear in this document."
-        )}
-      </p>
-    </div>
-    {concepts.length > 0 && (
-      <div className="flex flex-col gap-3 border-t border-border-light pt-6">
-        <p className="text-sm text-text-secondary">Commonly mentioned in this document</p>
-        <ul className="flex flex-wrap gap-2">
-          {concepts.map((concept) => (
-            <li key={concept.wikibase_id}>
-              <button
-                type="button"
-                onClick={() => onConceptClick(concept.preferred_label)}
-                className="rounded-full border border-border-normal px-3 py-1 text-sm text-text-brand hocus:border-inky-blue hocus:bg-bg-flat"
-              >
-                {concept.preferred_label}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-    )}
-  </div>
-);
 
 type TPassageResultsProps = {
   onPassageClick: (passage: TPassageBlock) => void;
@@ -145,14 +100,16 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
   // browser back button or a concept being picked from the empty state. Adjusting during
   // render rather than in an effect avoids a second render pass with a stale input.
   const [previousQuery, setPreviousQuery] = useState(query);
+  const [hasNavigatedForQuery, setHasNavigatedForQuery] = useState(false);
   if (query !== previousQuery) {
     setPreviousQuery(query);
     setSearchTerm(query);
+    setHasNavigatedForQuery(false);
   }
 
   const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
 
-  const { data, isError, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+  const { data, isError, isFetching, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ["document-passages", document.import_id, query],
     queryFn: ({ pageParam, signal }) =>
       fetchSearchPassages({ query, documentId: document.import_id, pageSize: RESULTS_PER_PAGE, pageToken: pageParam, signal }),
@@ -171,23 +128,27 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     // A term's results do not change within a session, so don't refetch one the user returns to.
     refetchOnWindowFocus: false,
     refetchOnMount: false,
-    // Hold the previous results in place while the next term loads, to avoid the list collapsing.
-    placeholderData: keepPreviousData,
   });
 
   const hasQuery = query.length > 0;
 
-  // `keepPreviousData` holds the last results against the new query key, so they have to
-  // be dropped explicitly once the search is cleared.
-  // Kept in the API's own shape as well, since the PDF viewer highlights from the
-  // bounding boxes that `toPassageBlock` drops.
   const searchPassages = useMemo(() => (hasQuery ? (data?.pages ?? []).flatMap((page) => page.results) : []), [data, hasQuery]);
 
   const passages = useMemo(() => searchPassages.map((passage) => toPassageBlock(passage, document.title)), [searchPassages, document.title]);
 
+  // Take the reader to the first match once a search returns. Guarded so it happens once
+  // per search: paging in more results and clicking a passage both change the state above,
+  // and neither should pull the view back to the top of the results.
+  const firstResultPage = passages[0]?.pages?.[0]?.page_number;
+  if (hasQuery && !hasNavigatedForQuery && firstResultPage !== undefined) {
+    setHasNavigatedForQuery(true);
+    // `page_number` is 0-indexed in the passage model; the PDF viewer is 1-indexed.
+    setPageNumber(firstResultPage + 1);
+  }
+
   const topConcepts = useMemo(() => getTopDocumentConcepts(vespaDocumentData, topics, TOP_CONCEPTS_LIMIT), [vespaDocumentData, topics]);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     // nuqs removes the param when given null, keeping an empty search out of the URL.
     setQuery(searchTerm.trim() || null);
@@ -217,8 +178,9 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
   );
 
   const totalMatches = hasQuery ? (data?.pages[0]?.total_size ?? 0) : 0;
-  // `isFetching` also covers loading the next page, which must not blank the list.
-  const isLoading = isFetching && !isFetchingNextPage && passages.length === 0;
+
+  // Avoid cases where the result state flashes before the request has resolved
+  const isLoading = hasQuery && !isFetchingNextPage && passages.length === 0 && (isPending || isFetching);
 
   return (
     <section className="flex-1 flex flex-col" id="document-passage-viewer">
@@ -272,7 +234,7 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
             </>
           )}
           {!isLoading && !isError && passages.length === 0 && (
-            <PassagesEmptyState concepts={topConcepts} hasQuery={hasQuery} onClearClick={handleClear} onConceptClick={handleConceptClick} />
+            <EmptyPassages concepts={topConcepts} hasQuery={hasQuery} onClearClick={handleClear} onConceptClick={handleConceptClick} />
           )}
         </div>
 

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -192,11 +192,11 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
             containerClasses="px-4 py-2"
             icon={<Search size={16} />}
             inputClasses="!text-sm"
-            name="passage-search"
+            name="Search"
             onChange={(event) => setSearchTerm(event.target.value)}
             onClear={handleClear}
             placeholder="Enter search term"
-            type="search"
+            type="text"
             value={searchTerm}
           />
         </form>

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -150,13 +150,12 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
 
   const handleSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // nuqs removes the param when given null, keeping an empty search out of the URL.
-    setQuery(searchTerm.trim() || null);
+    setQuery(searchTerm.trim());
   };
 
   const handleClear = () => {
     setSearchTerm("");
-    setQuery(null);
+    setQuery("");
   };
 
   const handleConceptClick = useCallback(

--- a/src/components/documents/DocumentPassageViewer.tsx
+++ b/src/components/documents/DocumentPassageViewer.tsx
@@ -85,8 +85,6 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     setHasNavigatedForQuery(false);
   }
 
-  const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
-
   const { data, isError, isFetching, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ["document-passages", document.import_id, query],
     queryFn: ({ pageParam, signal }) =>
@@ -108,11 +106,18 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     refetchOnMount: false,
   });
 
+  const canPreview = !!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf");
+
   const hasQuery = query.length > 0;
+
+  const totalMatches = hasQuery ? (data?.pages[0]?.total_size ?? 0) : 0;
 
   const searchPassages = useMemo(() => (hasQuery ? (data?.pages ?? []).flatMap((page) => page.results) : []), [data, hasQuery]);
 
   const passages = useMemo(() => searchPassages.map((passage) => toPassageBlock(passage, document.title)), [searchPassages, document.title]);
+
+  // Avoid cases where the result state flashes before the request has resolved
+  const isLoading = hasQuery && !isFetchingNextPage && passages.length === 0 && (isPending || isFetching);
 
   // Take the reader to the first match once a search returns. Guarded so it happens once
   // per search: paging in more results and clicking a passage both change the state above,
@@ -153,11 +158,6 @@ export const DocumentPassageViewer = ({ document, vespaDocumentData }: TProps) =
     },
     [canPreview]
   );
-
-  const totalMatches = hasQuery ? (data?.pages[0]?.total_size ?? 0) : 0;
-
-  // Avoid cases where the result state flashes before the request has resolved
-  const isLoading = hasQuery && !isFetchingNextPage && passages.length === 0 && (isPending || isFetching);
 
   return (
     <section className="flex-1 flex flex-col" id="document-passage-viewer">

--- a/src/components/molecules/emptyPassages/EmptyPassages.stories.tsx
+++ b/src/components/molecules/emptyPassages/EmptyPassages.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { TTopic } from "@/types";
+
+import { EmptyPassages } from "./EmptyPassages";
+
+const meta = {
+  title: "Molecules/EmptyPassages",
+  component: EmptyPassages,
+  parameters: { layout: "centered" },
+  args: { onClearClick: () => {}, onConceptClick: () => {} },
+  argTypes: {
+    onClearClick: { control: false },
+    onConceptClick: { control: false },
+  },
+} satisfies Meta<typeof EmptyPassages>;
+type TStory = StoryObj<typeof EmptyPassages>;
+
+export default meta;
+
+const concepts: Partial<TTopic>[] = [
+  { preferred_label: "extreme weather", wikibase_id: "Q374" },
+  { preferred_label: "air pollution", wikibase_id: "Q412" },
+  { preferred_label: "marine risk", wikibase_id: "Q368" },
+  { preferred_label: "terrestrial risk", wikibase_id: "Q404" },
+];
+
+export const NoQuery: TStory = {
+  args: {
+    concepts: concepts as TTopic[],
+    hasQuery: false,
+  },
+};
+
+export const NoResults: TStory = {
+  args: {
+    concepts: concepts as TTopic[],
+    hasQuery: true,
+  },
+};
+
+export const NoConcepts: TStory = {
+  args: {
+    concepts: [],
+    hasQuery: false,
+  },
+};
+
+export const NoResultsWithoutConcepts: TStory = {
+  args: {
+    concepts: [],
+    hasQuery: true,
+  },
+};

--- a/src/components/molecules/emptyPassages/EmptyPassages.test.tsx
+++ b/src/components/molecules/emptyPassages/EmptyPassages.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { TTopic } from "@/types";
+
+import { EmptyPassages } from "./EmptyPassages";
+
+const concepts = [
+  { wikibase_id: "Q374", preferred_label: "extreme weather" },
+  { wikibase_id: "Q412", preferred_label: "air pollution" },
+] as TTopic[];
+
+describe("EmptyPassages", () => {
+  it("prompts the user to search when there is no query", () => {
+    render(<EmptyPassages concepts={[]} hasQuery={false} onClearClick={vi.fn()} onConceptClick={vi.fn()} />);
+    expect(screen.getByText("Search passages")).toBeInTheDocument();
+    expect(screen.getByText("Type a search or select from topics that appear in this document.")).toBeInTheDocument();
+  });
+
+  it("does not offer to clear the search when there is no query", () => {
+    render(<EmptyPassages concepts={[]} hasQuery={false} onClearClick={vi.fn()} onConceptClick={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "clear your search" })).not.toBeInTheDocument();
+  });
+
+  it("reports no matches when there is a query", () => {
+    render(<EmptyPassages concepts={[]} hasQuery onClearClick={vi.fn()} onConceptClick={vi.fn()} />);
+    expect(screen.getByText("No matching passages")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "clear your search" })).toBeInTheDocument();
+  });
+
+  it("calls onClearClick when clearing the search", async () => {
+    const onClearClick = vi.fn();
+    render(<EmptyPassages concepts={[]} hasQuery onClearClick={onClearClick} onConceptClick={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "clear your search" }));
+    expect(onClearClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders a button for every concept", () => {
+    render(<EmptyPassages concepts={concepts} hasQuery={false} onClearClick={vi.fn()} onConceptClick={vi.fn()} />);
+    expect(screen.getByText("Commonly mentioned in this document")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "extreme weather" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "air pollution" })).toBeInTheDocument();
+  });
+
+  it("calls onConceptClick with the concept label", async () => {
+    const onConceptClick = vi.fn();
+    render(<EmptyPassages concepts={concepts} hasQuery={false} onClearClick={vi.fn()} onConceptClick={onConceptClick} />);
+    await userEvent.click(screen.getByRole("button", { name: "air pollution" }));
+    expect(onConceptClick).toHaveBeenCalledWith("air pollution");
+  });
+
+  it("does not render the concepts section when there are no concepts", () => {
+    render(<EmptyPassages concepts={[]} hasQuery={false} onClearClick={vi.fn()} onConceptClick={vi.fn()} />);
+    expect(screen.queryByText("Commonly mentioned in this document")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/emptyPassages/EmptyPassages.tsx
+++ b/src/components/molecules/emptyPassages/EmptyPassages.tsx
@@ -1,0 +1,50 @@
+import { FileSearch2, ScanSearch } from "lucide-react";
+
+import { TTopic } from "@/types";
+
+type TEmptyStateProps = {
+  concepts: TTopic[];
+  hasQuery: boolean;
+  onClearClick: () => void;
+  onConceptClick: (label: string) => void;
+};
+
+export const EmptyPassages = ({ concepts, hasQuery, onClearClick, onConceptClick }: TEmptyStateProps) => (
+  <div className="flex flex-col gap-8 py-10">
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="rounded-full bg-bg-flat p-4 text-elem-icon">{hasQuery ? <ScanSearch size={24} /> : <FileSearch2 size={24} />}</div>
+      <p className="font-medium text-text-primary">{hasQuery ? "No matching passages" : "Search passages"}</p>
+      <p className="max-w-xs text-sm text-text-secondary">
+        {hasQuery ? (
+          <>
+            Remove filters,{" "}
+            <button type="button" onClick={onClearClick} className="underline text-text-brand hocus:text-text-primary">
+              clear your search
+            </button>{" "}
+            or try a commonly mentioned topic below.
+          </>
+        ) : (
+          "Type a search or select from topics that appear in this document."
+        )}
+      </p>
+    </div>
+    {concepts.length > 0 && (
+      <div className="flex flex-col gap-3 border-t border-border-light pt-6">
+        <p className="text-sm text-text-secondary">Commonly mentioned in this document</p>
+        <ul className="flex flex-wrap gap-2">
+          {concepts.map((concept) => (
+            <li key={concept.wikibase_id}>
+              <button
+                type="button"
+                onClick={() => onConceptClick(concept.preferred_label)}
+                className="rounded-full border border-border-normal px-3 py-1 text-sm text-text-brand hocus:border-inky-blue hocus:bg-bg-flat"
+              >
+                {concept.preferred_label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+  </div>
+);

--- a/src/components/molecules/passageBlock/PassageBlock.stories.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.stories.tsx
@@ -58,6 +58,15 @@ export const NoHeading: TStory = {
   },
 };
 
+export const MultiplePages: TStory = {
+  args: {
+    passage: {
+      ...basePassage,
+      pages: [{ page_number: 15 }, { page_number: 16 }, { page_number: 17 }],
+    },
+  },
+};
+
 export const NoPage: TStory = {
   args: {
     passage: {

--- a/src/components/molecules/passageBlock/PassageBlock.test.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.test.tsx
@@ -28,15 +28,27 @@ describe("PassageBlock", () => {
     expect(screen.getByText("Renewable Energy Sources Act")).toBeInTheDocument();
   });
 
-  it("renders the page number when present", () => {
+  it("renders the page number when present, shifted from the 0-indexed model", () => {
     render(<PassageBlock passage={basePassage} />);
-    expect(screen.getByText("Pg. 16")).toBeInTheDocument();
+    expect(screen.getByText("Pg. 17")).toBeInTheDocument();
+  });
+
+  it("lists every page when a passage spans more than one", () => {
+    const passage: TPassage = { ...basePassage, pages: [{ page_number: 0 }, { page_number: 1 }, { page_number: 2 }] };
+    render(<PassageBlock passage={passage} />);
+    expect(screen.getByText("Pgs. 1,2,3")).toBeInTheDocument();
+  });
+
+  it("does not render a page number for an empty pages array", () => {
+    const passage: TPassage = { ...basePassage, pages: [] };
+    render(<PassageBlock passage={passage} />);
+    expect(screen.queryByText(/^Pgs?\./)).not.toBeInTheDocument();
   });
 
   it("does not render a page number when absent", () => {
     const passage: TPassage = { ...basePassage, pages: undefined };
     render(<PassageBlock passage={passage} />);
-    expect(screen.queryByText(/^Pg\./)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Pgs?\./)).not.toBeInTheDocument();
   });
 
   it("renders the heading text when present", () => {

--- a/src/components/molecules/passageBlock/PassageBlock.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.tsx
@@ -60,17 +60,19 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
 
   return (
     <div
-      className={`bg-bg-primary border border-border-normal rounded-xl overflow-clip transition ${
-        isClickable ? "hocus:shadow-sm hocus:bg-paper" : "shadow-xs"
-      }`}
+      className={`bg-bg-primary border border-border-normal rounded-xl overflow-clip transition ${isClickable ? "hocus:shadow-sm " : "shadow-xs"}`}
     >
-      <div className="px-8 py-7">
+      <div className="text-sm text-text-primary">
         {isClickable ? (
-          <button type="button" onClick={() => onPassageClick(passage)} className="text-left w-full text-base text-text-primary hocus:underline">
+          <button
+            type="button"
+            onClick={() => onPassageClick(passage)}
+            className="text-left w-full text-sm text-text-primary px-8 py-7 hocus:bg-paper"
+          >
             {passage.content}
           </button>
         ) : (
-          <p className="text-base text-text-primary">{passage.content}</p>
+          <p className="px-8 py-7">{passage.content}</p>
         )}
       </div>
       {hasFooter && (

--- a/src/components/molecules/passageBlock/PassageBlock.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.tsx
@@ -31,9 +31,12 @@ type TProps = {
   onCopyClick?: () => void;
   onDocumentLinkClick?: () => void;
   onPassageClick?: (passage: TPassage) => void;
+  // Hide the document title and its link when the passage is already shown in the
+  // context of that document, e.g. on the document page.
+  showDocument?: boolean;
 };
 
-export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPassageClick }: TProps) => {
+export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPassageClick, showDocument = true }: TProps) => {
   const [hasCopied, setHasCopied] = useState(false);
 
   useEffect(() => {
@@ -44,6 +47,8 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
 
   const isClickable = !!onPassageClick;
   const pageNumber = passage.pages?.[0]?.page_number;
+  const hasContext = pageNumber !== undefined || !!passage.headingText;
+  const hasFooter = showDocument || hasContext;
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(passage.content);
@@ -66,38 +71,44 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
           <p className="text-base text-text-primary">{passage.content}</p>
         )}
       </div>
-      <div className="bg-paper px-8 py-3 flex gap-16 items-start">
-        <div className="flex-1 min-w-0 flex flex-col gap-2.5">
-          <div className="flex gap-2 items-center">
-            <File size={16} className="text-elem-icon shrink-0" />
-            <p className="text-sm text-text-primary truncate">{passage.documentTitle}</p>
+      {hasFooter && (
+        <div className="bg-paper px-8 py-3 flex gap-16 items-start">
+          <div className="flex-1 min-w-0 flex flex-col gap-2.5">
+            {showDocument && (
+              <div className="flex gap-2 items-center">
+                <File size={16} className="text-elem-icon shrink-0" />
+                <p className="text-sm text-text-primary truncate">{passage.documentTitle}</p>
+              </div>
+            )}
+            {hasContext && (
+              <div className="flex gap-4 items-center">
+                {pageNumber !== undefined && (
+                  <div className="flex gap-2 items-center shrink-0">
+                    <LocateFixed size={16} className="text-elem-icon" />
+                    <p className="text-sm text-text-primary whitespace-nowrap">Pg. {pageNumber}</p>
+                  </div>
+                )}
+                {passage.headingText && (
+                  <>
+                    {pageNumber !== undefined && <span className="w-px h-3 bg-border-normal shrink-0" />}
+                    <p className="text-sm text-text-primary truncate">{passage.headingText}</p>
+                  </>
+                )}
+              </div>
+            )}
           </div>
-          {(pageNumber !== undefined || passage.headingText) && (
-            <div className="flex gap-4 items-center">
-              {pageNumber !== undefined && (
-                <div className="flex gap-2 items-center shrink-0">
-                  <LocateFixed size={16} className="text-elem-icon" />
-                  <p className="text-sm text-text-primary whitespace-nowrap">Pg. {pageNumber}</p>
-                </div>
-              )}
-              {passage.headingText && (
-                <>
-                  {pageNumber !== undefined && <span className="w-px h-3 bg-border-normal shrink-0" />}
-                  <p className="text-sm text-text-primary truncate">{passage.headingText}</p>
-                </>
-              )}
-            </div>
-          )}
+          <div className="flex gap-3 items-center shrink-0">
+            {showDocument && (
+              <button type="button" onClick={onDocumentLinkClick} aria-label="View document" className="text-elem-icon hocus:text-inky-blue">
+                <ExternalLink size={16} />
+              </button>
+            )}
+            <button type="button" onClick={handleCopyClick} aria-label="Copy passage text" className="text-elem-icon hocus:text-inky-blue">
+              {hasCopied ? <Check size={16} className="text-inky-blue" /> : <Copy size={16} />}
+            </button>
+          </div>
         </div>
-        <div className="flex gap-3 items-center shrink-0">
-          <button type="button" onClick={onDocumentLinkClick} aria-label="View document" className="text-elem-icon hocus:text-inky-blue">
-            <ExternalLink size={16} />
-          </button>
-          <button type="button" onClick={handleCopyClick} aria-label="Copy passage text" className="text-elem-icon hocus:text-inky-blue">
-            {hasCopied ? <Check size={16} className="text-inky-blue" /> : <Copy size={16} />}
-          </button>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/molecules/passageBlock/PassageBlock.tsx
+++ b/src/components/molecules/passageBlock/PassageBlock.tsx
@@ -46,8 +46,10 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
   }, [hasCopied]);
 
   const isClickable = !!onPassageClick;
-  const pageNumber = passage.pages?.[0]?.page_number;
-  const hasContext = pageNumber !== undefined || !!passage.headingText;
+  // `page_number` is 0-indexed in the passage model, so is shifted for display.
+  const pageNumbers = passage.pages?.map(({ page_number }) => page_number + 1) ?? [];
+  const hasPages = pageNumbers.length > 0;
+  const hasContext = hasPages || !!passage.headingText;
   const hasFooter = showDocument || hasContext;
 
   const handleCopyClick = () => {
@@ -82,15 +84,17 @@ export const PassageBlock = ({ passage, onCopyClick, onDocumentLinkClick, onPass
             )}
             {hasContext && (
               <div className="flex gap-4 items-center">
-                {pageNumber !== undefined && (
+                {hasPages && (
                   <div className="flex gap-2 items-center shrink-0">
                     <LocateFixed size={16} className="text-elem-icon" />
-                    <p className="text-sm text-text-primary whitespace-nowrap">Pg. {pageNumber}</p>
+                    <p className="text-sm text-text-primary whitespace-nowrap">
+                      {pageNumbers.length === 1 ? "Pg." : "Pgs."} {pageNumbers.join(",")}
+                    </p>
                   </div>
                 )}
                 {passage.headingText && (
                   <>
-                    {pageNumber !== undefined && <span className="w-px h-3 bg-border-normal shrink-0" />}
+                    {hasPages && <span className="w-px h-3 bg-border-normal shrink-0" />}
                     <p className="text-sm text-text-primary truncate">{passage.headingText}</p>
                   </>
                 )}

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -1,7 +1,7 @@
 import type { SearchPassage } from "@/api/passages";
 import { TFamilyDocumentPublic, TPassage } from "@/types";
 
-import usePDFPreview, { getHighlights } from "./usePDFPreview";
+import usePDFPreview, { getHighlights, TAnnotation } from "./usePDFPreview";
 
 // Stands in for the Adobe SDK, which needs a real browser. Records the calls the hook
 // makes so the annotation behaviour can be asserted on.
@@ -222,7 +222,7 @@ describe("registerPassages", () => {
 
   // Pages sent to addAnnotations, read back off the generated Adobe payload.
   const annotatedPages = () =>
-    adobe.addAnnotations.mock.calls.flatMap((call) => call[0].map((annotation: any) => annotation.target.selector.node.index + 1));
+    adobe.addAnnotations.mock.calls.flatMap((call) => call[0].map((annotation: TAnnotation) => annotation.target.selector.node.index + 1));
 
   const firePageChange = async (pageNumber: number) => {
     const [, handler] = adobe.registerCallback.mock.calls[0];
@@ -231,6 +231,8 @@ describe("registerPassages", () => {
 
   beforeEach(() => {
     Object.values(adobe).forEach((mock) => mock.mockReset());
+    // Adobe SDK is not typed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     window.AdobeDC = { View: { Enum: { CallbackType: { EVENT_LISTENER: "EVENT_LISTENER" } } } } as any;
   });
 

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -1,5 +1,4 @@
-import type { ISearchPassage } from "@/api/passages";
-import { TAnnotation, TFamilyDocumentPublic, TPassage } from "@/types";
+import { ISearchPassage, TAnnotation, TFamilyDocumentPublic, TPassage } from "@/types";
 
 import usePDFPreview, { getHighlights } from "./usePDFPreview";
 

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -1,0 +1,343 @@
+import type { SearchPassage } from "@/api/passages";
+import { TFamilyDocumentPublic, TPassage } from "@/types";
+
+import usePDFPreview, { getHighlights } from "./usePDFPreview";
+
+// Stands in for the Adobe SDK, which needs a real browser. Records the calls the hook
+// makes so the annotation behaviour can be asserted on.
+const adobe = vi.hoisted(() => ({
+  addAnnotations: vi.fn(),
+  removeAnnotationsFromPDF: vi.fn(),
+  registerCallback: vi.fn(),
+  gotoLocation: vi.fn(),
+}));
+
+vi.mock("@/api/pdf", () => ({
+  default: class {
+    ready = () => Promise.resolve();
+    getAdobeView = () =>
+      Promise.resolve({
+        registerCallback: adobe.registerCallback,
+        previewFile: () =>
+          Promise.resolve({
+            getAPIs: () => Promise.resolve({ gotoLocation: adobe.gotoLocation }),
+            getAnnotationManager: () =>
+              Promise.resolve({
+                setConfig: vi.fn(),
+                addAnnotations: adobe.addAnnotations,
+                removeAnnotationsFromPDF: adobe.removeAnnotationsFromPDF,
+              }),
+          }),
+      });
+  },
+}));
+
+const legacyPassage = (overrides: Partial<TPassage> = {}): TPassage => ({
+  text_block_id: "block-1",
+  // The legacy model is 1-indexed.
+  text_block_page: 16,
+  text: "A passage",
+  // [xMin,yMin], [xMax,yMin], [xMax,yMax], [xMin,yMax]
+  text_block_coords: [
+    [40, 415],
+    [568, 415],
+    [568, 566],
+    [40, 566],
+  ],
+  ...overrides,
+});
+
+const newPassage = (overrides: Partial<SearchPassage> = {}): SearchPassage =>
+  ({
+    id: "passage-1",
+    text_block_id: "block-1",
+    text: "A passage",
+    // The v2 model is 0-indexed.
+    pages: [40],
+    pages_with_bounding_boxes: [
+      {
+        number: 40,
+        bounding_boxes: [
+          {
+            coordinates: [
+              { x: 41.9, y: 415.5 },
+              { x: 568.6, y: 415.5 },
+              { x: 568.6, y: 566.8 },
+              { x: 41.9, y: 566.8 },
+            ],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  }) as SearchPassage;
+
+describe("getHighlights", () => {
+  describe("the legacy Vespa model", () => {
+    it("keeps the already 1-indexed page number", () => {
+      expect(getHighlights([legacyPassage()])[0].pageNumber).toBe(16);
+    });
+
+    it("maps the four corners to [xMin, yMin, xMax, yMax]", () => {
+      expect(getHighlights([legacyPassage()])[0].boundingBox).toEqual([40, 415, 568, 566]);
+    });
+
+    it("produces one highlight per passage, keyed by the block id", () => {
+      const highlights = getHighlights([legacyPassage()]);
+      expect(highlights).toHaveLength(1);
+      expect(highlights[0].id).toBe("block-1");
+    });
+
+    it("skips a passage with no coordinates rather than emitting a broken box", () => {
+      expect(getHighlights([legacyPassage({ text_block_coords: [] })])).toEqual([]);
+    });
+  });
+
+  describe("the v2 passages model", () => {
+    it("shifts the 0-indexed page number to match the viewer", () => {
+      expect(getHighlights([newPassage()])[0].pageNumber).toBe(41);
+    });
+
+    it("maps the four corners to [xMin, yMin, xMax, yMax]", () => {
+      expect(getHighlights([newPassage()])[0].boundingBox).toEqual([41.9, 415.5, 568.6, 566.8]);
+    });
+
+    it("emits a highlight for every box on a page", () => {
+      const passage = newPassage({
+        pages_with_bounding_boxes: [
+          {
+            number: 0,
+            bounding_boxes: [
+              {
+                coordinates: [
+                  { x: 1, y: 2 },
+                  { x: 3, y: 2 },
+                  { x: 3, y: 4 },
+                  { x: 1, y: 4 },
+                ],
+              },
+              {
+                coordinates: [
+                  { x: 5, y: 6 },
+                  { x: 7, y: 6 },
+                  { x: 7, y: 8 },
+                  { x: 5, y: 8 },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const highlights = getHighlights([passage]);
+
+      expect(highlights).toHaveLength(2);
+      expect(highlights.map((highlight) => highlight.boundingBox)).toEqual([
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ]);
+    });
+
+    it("emits highlights across every page the passage spans", () => {
+      const box = {
+        coordinates: [
+          { x: 1, y: 2 },
+          { x: 3, y: 2 },
+          { x: 3, y: 4 },
+          { x: 1, y: 4 },
+        ],
+      };
+      const passage = newPassage({
+        pages_with_bounding_boxes: [
+          { number: 0, bounding_boxes: [box] },
+          { number: 7, bounding_boxes: [box, box] },
+        ],
+      });
+
+      expect(getHighlights([passage]).map((highlight) => highlight.pageNumber)).toEqual([1, 8, 8]);
+    });
+
+    it("gives every box a distinct id, since one passage can produce many", () => {
+      const box = {
+        coordinates: [
+          { x: 1, y: 2 },
+          { x: 3, y: 2 },
+          { x: 3, y: 4 },
+          { x: 1, y: 4 },
+        ],
+      };
+      const passage = newPassage({
+        pages_with_bounding_boxes: [
+          { number: 0, bounding_boxes: [box, box] },
+          { number: 7, bounding_boxes: [box] },
+        ],
+      });
+
+      const ids = getHighlights([passage]).map((highlight) => highlight.id);
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("skips pages with no boxes", () => {
+      expect(getHighlights([newPassage({ pages_with_bounding_boxes: [{ number: 3, bounding_boxes: [] }] })])).toEqual([]);
+    });
+
+    it("skips a passage with no page geometry at all", () => {
+      expect(getHighlights([newPassage({ pages_with_bounding_boxes: [] })])).toEqual([]);
+    });
+  });
+
+  it("normalises a mixed list from both models together", () => {
+    const highlights = getHighlights([legacyPassage(), newPassage()]);
+
+    expect(highlights.map((highlight) => highlight.pageNumber)).toEqual([16, 41]);
+  });
+});
+
+describe("registerPassages", () => {
+  const document = { cdn_object: "doc.pdf", import_id: "D1", title: "Doc" } as TFamilyDocumentPublic;
+
+  // A passage whose single box sits on `page`, expressed 0-indexed as the API does.
+  const passageOnPage = (page: number, id: string): SearchPassage =>
+    newPassage({
+      id,
+      text_block_id: id,
+      pages: [page],
+      pages_with_bounding_boxes: [
+        {
+          number: page,
+          bounding_boxes: [
+            {
+              coordinates: [
+                { x: 1, y: 2 },
+                { x: 3, y: 2 },
+                { x: 3, y: 4 },
+                { x: 1, y: 4 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+  // Pages sent to addAnnotations, read back off the generated Adobe payload.
+  const annotatedPages = () =>
+    adobe.addAnnotations.mock.calls.flatMap((call) => call[0].map((annotation: any) => annotation.target.selector.node.index + 1));
+
+  const firePageChange = async (pageNumber: number) => {
+    const [, handler] = adobe.registerCallback.mock.calls[0];
+    await handler({ type: "CURRENT_ACTIVE_PAGE", data: { pageNumber } });
+  };
+
+  beforeEach(() => {
+    Object.values(adobe).forEach((mock) => mock.mockReset());
+    window.AdobeDC = { View: { Enum: { CallbackType: { EVENT_LISTENER: "EVENT_LISTENER" } } } } as any;
+  });
+
+  it("registers the page-change listener only once across repeated calls", async () => {
+    const preview = usePDFPreview(document, "key");
+
+    await preview.registerPassages([passageOnPage(0, "a")]);
+    await preview.registerPassages([passageOnPage(0, "a"), passageOnPage(5, "b")]);
+    await preview.registerPassages([passageOnPage(0, "a"), passageOnPage(5, "b"), passageOnPage(9, "c")]);
+
+    expect(adobe.registerCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("annotates from the latest passages, not the set the listener was created with", async () => {
+    const preview = usePDFPreview(document, "key");
+
+    await preview.registerPassages([passageOnPage(0, "a")]);
+    // Page 6 (0-indexed 5) only exists in this second set.
+    await preview.registerPassages([passageOnPage(0, "a"), passageOnPage(5, "b")]);
+    adobe.addAnnotations.mockClear();
+
+    await firePageChange(6);
+
+    expect(annotatedPages()).toEqual([6]);
+  });
+
+  it("does not repeat the remove/add pair when the same page fires again", async () => {
+    const preview = usePDFPreview(document, "key");
+    await preview.registerPassages([passageOnPage(5, "b")]);
+
+    await firePageChange(6);
+    adobe.removeAnnotationsFromPDF.mockClear();
+    adobe.addAnnotations.mockClear();
+
+    await firePageChange(6);
+    await firePageChange(6);
+
+    expect(adobe.removeAnnotationsFromPDF).not.toHaveBeenCalled();
+    expect(adobe.addAnnotations).not.toHaveBeenCalled();
+  });
+
+  it("re-annotates the same page once the passages behind it change", async () => {
+    const preview = usePDFPreview(document, "key");
+    await preview.registerPassages([passageOnPage(5, "b")]);
+    await firePageChange(6);
+    adobe.addAnnotations.mockClear();
+
+    // A second box lands on the page the reader is already looking at.
+    await preview.registerPassages([passageOnPage(5, "b"), passageOnPage(5, "c")], 6);
+
+    expect(annotatedPages()).toEqual([6, 6]);
+  });
+
+  it("never leaves two sets of annotations on the page when updates overlap", async () => {
+    // Make remove/add resolve on later ticks so concurrent updates would interleave.
+    const defer = () => new Promise((resolve) => setTimeout(resolve, 0));
+    adobe.removeAnnotationsFromPDF.mockImplementation(defer);
+    adobe.addAnnotations.mockImplementation(defer);
+
+    const preview = usePDFPreview(document, "key");
+    // Registration renders the starting page (6), so the two pages exercised below are
+    // ones it has not already drawn.
+    await preview.registerPassages([passageOnPage(5, "b"), passageOnPage(8, "c"), passageOnPage(11, "d")]);
+    adobe.removeAnnotationsFromPDF.mockClear();
+    adobe.addAnnotations.mockClear();
+
+    // Two page changes fired back to back, without awaiting the first.
+    await Promise.all([firePageChange(9), firePageChange(12)]);
+
+    // Each add must be preceded by its own remove, never remove/remove/add/add.
+    expect(adobe.removeAnnotationsFromPDF).toHaveBeenCalledTimes(2);
+    expect(adobe.addAnnotations).toHaveBeenCalledTimes(2);
+    expect(adobe.addAnnotations.mock.invocationCallOrder[0]).toBeLessThan(adobe.removeAnnotationsFromPDF.mock.invocationCallOrder[1]);
+  });
+
+  it("does not move the reader when passages are refreshed", async () => {
+    const preview = usePDFPreview(document, "key");
+    await preview.registerPassages([passageOnPage(5, "b")]);
+    adobe.gotoLocation.mockClear();
+
+    // A second page of results arrives while the reader is part way through the document.
+    await preview.registerPassages([passageOnPage(5, "b"), passageOnPage(20, "d")]);
+
+    expect(adobe.gotoLocation).not.toHaveBeenCalled();
+  });
+
+  it("redraws the page the reader is on when passages are refreshed", async () => {
+    const preview = usePDFPreview(document, "key");
+    await preview.registerPassages([passageOnPage(5, "b")]);
+    await firePageChange(9);
+    adobe.addAnnotations.mockClear();
+
+    // A box lands on page 9 (0-indexed 8), where the reader already is.
+    await preview.registerPassages([passageOnPage(5, "b"), passageOnPage(8, "c")]);
+
+    expect(annotatedPages()).toEqual([9]);
+  });
+
+  it("clears highlights when moving to a page that has none", async () => {
+    const preview = usePDFPreview(document, "key");
+    await preview.registerPassages([passageOnPage(5, "b")]);
+    adobe.removeAnnotationsFromPDF.mockClear();
+    adobe.addAnnotations.mockClear();
+
+    await firePageChange(2);
+
+    expect(adobe.removeAnnotationsFromPDF).toHaveBeenCalledTimes(1);
+    expect(adobe.addAnnotations).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -1,4 +1,4 @@
-import type { SearchPassage } from "@/api/passages";
+import type { ISearchPassage } from "@/api/passages";
 import { TFamilyDocumentPublic, TPassage } from "@/types";
 
 import usePDFPreview, { getHighlights, TAnnotation } from "./usePDFPreview";
@@ -47,7 +47,7 @@ const legacyPassage = (overrides: Partial<TPassage> = {}): TPassage => ({
   ...overrides,
 });
 
-const newPassage = (overrides: Partial<SearchPassage> = {}): SearchPassage =>
+const newPassage = (overrides: Partial<ISearchPassage> = {}): ISearchPassage =>
   ({
     id: "passage-1",
     text_block_id: "block-1",
@@ -70,7 +70,7 @@ const newPassage = (overrides: Partial<SearchPassage> = {}): SearchPassage =>
       },
     ],
     ...overrides,
-  }) as SearchPassage;
+  }) as ISearchPassage;
 
 describe("getHighlights", () => {
   describe("the legacy Vespa model", () => {
@@ -198,7 +198,7 @@ describe("registerPassages", () => {
   const document = { cdn_object: "doc.pdf", import_id: "D1", title: "Doc" } as TFamilyDocumentPublic;
 
   // A passage whose single box sits on `page`, expressed 0-indexed as the API does.
-  const passageOnPage = (page: number, id: string): SearchPassage =>
+  const passageOnPage = (page: number, id: string): ISearchPassage =>
     newPassage({
       id,
       text_block_id: id,

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -1,7 +1,7 @@
 import type { ISearchPassage } from "@/api/passages";
-import { TFamilyDocumentPublic, TPassage } from "@/types";
+import { TAnnotation, TFamilyDocumentPublic, TPassage } from "@/types";
 
-import usePDFPreview, { getHighlights, TAnnotation } from "./usePDFPreview";
+import usePDFPreview, { getHighlights } from "./usePDFPreview";
 
 // Stands in for the Adobe SDK, which needs a real browser. Records the calls the hook
 // makes so the annotation behaviour can be asserted on.

--- a/src/hooks/usePDFPreview.test.ts
+++ b/src/hooks/usePDFPreview.test.ts
@@ -286,28 +286,6 @@ describe("registerPassages", () => {
     expect(annotatedPages()).toEqual([6, 6]);
   });
 
-  it("never leaves two sets of annotations on the page when updates overlap", async () => {
-    // Make remove/add resolve on later ticks so concurrent updates would interleave.
-    const defer = () => new Promise((resolve) => setTimeout(resolve, 0));
-    adobe.removeAnnotationsFromPDF.mockImplementation(defer);
-    adobe.addAnnotations.mockImplementation(defer);
-
-    const preview = usePDFPreview(document, "key");
-    // Registration renders the starting page (6), so the two pages exercised below are
-    // ones it has not already drawn.
-    await preview.registerPassages([passageOnPage(5, "b"), passageOnPage(8, "c"), passageOnPage(11, "d")]);
-    adobe.removeAnnotationsFromPDF.mockClear();
-    adobe.addAnnotations.mockClear();
-
-    // Two page changes fired back to back, without awaiting the first.
-    await Promise.all([firePageChange(9), firePageChange(12)]);
-
-    // Each add must be preceded by its own remove, never remove/remove/add/add.
-    expect(adobe.removeAnnotationsFromPDF).toHaveBeenCalledTimes(2);
-    expect(adobe.addAnnotations).toHaveBeenCalledTimes(2);
-    expect(adobe.addAnnotations.mock.invocationCallOrder[0]).toBeLessThan(adobe.removeAnnotationsFromPDF.mock.invocationCallOrder[1]);
-  });
-
   it("does not move the reader when passages are refreshed", async () => {
     const preview = usePDFPreview(document, "key");
     await preview.registerPassages([passageOnPage(5, "b")]);

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -62,7 +62,37 @@ const getPassageHighlights = (passage: TViewerPassage): THighlight[] => {
 
 export const getHighlights = (passages: TViewerPassage[]): THighlight[] => passages.flatMap(getPassageHighlights);
 
-function generateAnnotations(document: TFamilyDocumentPublic, highlights: THighlight[]) {
+export type TAnnotation = {
+  "@context": string[];
+  type: "Annotation";
+  id: string;
+  bodyValue: string;
+  motivation: "commenting";
+  target: {
+    source: string;
+    selector: {
+      node: {
+        index: number;
+      };
+      subtype: "highlight";
+      boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
+      quadPoints: [xMin: number, yMin: number, xMax: number, yMin: number, xMin: number, yMax: number, xMax: number, yMax: number];
+      styleClass: "body-value-css";
+      type: "AdobeAnnoSelector";
+      strokeColor: "#FFFF00";
+      strokeWidth: 1;
+      opacity: 0.25;
+    };
+  };
+  creator: {
+    type: "Person";
+    name: "Climate Policy Radar";
+  };
+  created: string;
+  modified: string;
+};
+
+function generateAnnotations(document: TFamilyDocumentPublic, highlights: THighlight[]): TAnnotation[] {
   const date = new Date();
   return highlights.map(({ id, pageNumber, boundingBox: [xMin, yMin, xMax, yMax] }) => {
     return {

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -1,12 +1,12 @@
 import { faro } from "@grafana/faro-web-sdk";
 
-import type { ISearchPassage } from "@/api/passages";
 import ViewSDKClient from "@/api/pdf";
 import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
 import {
   IAdobeAnnotationManagerApi,
   IAdobeViewer,
   IAdobeViewerApi,
+  ISearchPassage,
   TAdobeApis,
   TAdobeEvent,
   THighlight,

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -100,9 +100,13 @@ function generateAnnotations(document: TFamilyDocumentPublic, highlights: THighl
   });
 }
 
+// Adobe SDK does not provide a type
 type TAdobeApis = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   adobeViewer: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   viewerApi: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   annotationManagerApi: any;
 };
 
@@ -125,8 +129,12 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   };
 
   // Memoize the Adobe Viewer API - this is used to control the viewer, e.g. change page
+  // Adobe SDK does not provide a type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let adobeViewerMemo: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let viewerApiMemo: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let annotationManagerApiMemo: any;
 
   // The page-change listener is registered once and reads the highlights from here, so
@@ -289,6 +297,8 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     // This will catch passage clicks, as well as navigation within the native pdf reader
     await adobeViewer.registerCallback(
       window.AdobeDC.View.Enum.CallbackType.EVENT_LISTENER,
+      // Adobe SDK does not provide a type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       async (event: any) => {
         if (event.type === "CURRENT_ACTIVE_PAGE") {
           await addAnnotationsForPage(event.data.pageNumber);

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -1,7 +1,20 @@
+import { faro } from "@grafana/faro-web-sdk";
+
 import type { ISearchPassage } from "@/api/passages";
 import ViewSDKClient from "@/api/pdf";
 import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
-import { TPassage, TFamilyDocumentPublic } from "@/types";
+import {
+  IAdobeAnnotationManagerApi,
+  IAdobeViewer,
+  IAdobeViewerApi,
+  TAdobeApis,
+  TAdobeEvent,
+  THighlight,
+  TPassage,
+  TFamilyDocumentPublic,
+} from "@/types";
+import { generateAnnotations } from "@/utils/adobe/generateAnnotations";
+import { reportMissingAdobeMethods } from "@/utils/adobe/reportMissingAdobeMethods";
 
 /*
   The viewer is fed passages from two sources with different geometry models:
@@ -15,13 +28,6 @@ import { TPassage, TFamilyDocumentPublic } from "@/types";
   hook never has to know which model a passage came from.
 */
 export type TViewerPassage = TPassage | ISearchPassage;
-
-type THighlight = {
-  id: string;
-  // 1-indexed, matching Adobe's page events and `gotoLocation`.
-  pageNumber: number;
-  boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
-};
 
 const isNewModelPassage = (passage: TViewerPassage): passage is ISearchPassage => "pages_with_bounding_boxes" in passage;
 
@@ -62,84 +68,6 @@ const getPassageHighlights = (passage: TViewerPassage): THighlight[] => {
 
 export const getHighlights = (passages: TViewerPassage[]): THighlight[] => passages.flatMap(getPassageHighlights);
 
-export type TAnnotation = {
-  "@context": string[];
-  type: "Annotation";
-  id: string;
-  bodyValue: string;
-  motivation: "commenting";
-  target: {
-    source: string;
-    selector: {
-      node: {
-        index: number;
-      };
-      subtype: "highlight";
-      boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
-      quadPoints: [xMin: number, yMin: number, xMax: number, yMin: number, xMin: number, yMax: number, xMax: number, yMax: number];
-      styleClass: "body-value-css";
-      type: "AdobeAnnoSelector";
-      strokeColor: "#FFFF00";
-      strokeWidth: 1;
-      opacity: 0.25;
-    };
-  };
-  creator: {
-    type: "Person";
-    name: "Climate Policy Radar";
-  };
-  created: string;
-  modified: string;
-};
-
-function generateAnnotations(document: TFamilyDocumentPublic, highlights: THighlight[]): TAnnotation[] {
-  const date = new Date();
-  return highlights.map(({ id, pageNumber, boundingBox: [xMin, yMin, xMax, yMax] }) => {
-    return {
-      "@context": ["https://www.w3.org/ns/anno.jsonld", "https://comments.acrobat.com/ns/anno.jsonld"],
-      type: "Annotation",
-      id,
-      bodyValue: "",
-      motivation: "commenting",
-      target: {
-        source: document.import_id,
-        selector: {
-          node: {
-            // Adobe indexes pages from 0.
-            index: pageNumber - 1,
-          },
-          subtype: "highlight",
-          // format [Xmin, Ymin, Xmax, Ymax]
-          boundingBox: [xMin, yMin, xMax, yMax],
-          // format [upper-left, upper-right, lower-left, lower-right] as x,y pairs
-          quadPoints: [xMin, yMin, xMax, yMin, xMin, yMax, xMax, yMax],
-          styleClass: "body-value-css",
-          type: "AdobeAnnoSelector",
-          strokeColor: "#FFFF00",
-          strokeWidth: 1,
-          opacity: 0.25,
-        },
-      },
-      creator: {
-        type: "Person",
-        name: "Climate Policy Radar",
-      },
-      created: date.toISOString(),
-      modified: date.toISOString(),
-    };
-  });
-}
-
-// Adobe SDK does not provide a type
-type TAdobeApis = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  adobeViewer: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  viewerApi: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  annotationManagerApi: any;
-};
-
 export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, adobeKey: string) {
   const viewerConfig = {
     showDownloadPDF: false,
@@ -159,13 +87,9 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   };
 
   // Memoize the Adobe Viewer API - this is used to control the viewer, e.g. change page
-  // Adobe SDK does not provide a type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let adobeViewerMemo: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let viewerApiMemo: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let annotationManagerApiMemo: any;
+  let adobeViewerMemo: IAdobeViewer;
+  let viewerApiMemo: IAdobeViewerApi;
+  let annotationManagerApiMemo: IAdobeAnnotationManagerApi;
 
   // The page-change listener is registered once and reads the highlights from here, so
   // that a new set of passages does not require a second listener. `highlightsVersion`
@@ -184,7 +108,9 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   const getAdobeApis = async (): Promise<TAdobeApis> => {
     const viewSDKClient = new ViewSDKClient();
     await viewSDKClient.ready();
-    const adobeViewer = await viewSDKClient.getAdobeView(physicalDocument, adobeKey, "pdf-div");
+    // The one place the untyped SDK crosses into typed code. `getAdobeView` comes from
+    // plain JS, so this annotation is an unchecked assertion — hence the runtime check below.
+    const adobeViewer: IAdobeViewer = await viewSDKClient.getAdobeView(physicalDocument, adobeKey, "pdf-div");
     adobeViewerMemo = adobeViewer;
     // Preview the file (this returns the Adobe Viewer APIs)
     const adobeViewerAPI = await adobeViewer.previewFile(
@@ -213,11 +139,14 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     annotationManagerApi.setConfig(annotationConfig);
     annotationManagerApiMemo = annotationManagerApi;
 
-    return {
+    const apis = {
       adobeViewer,
       viewerApi,
       annotationManagerApi,
     };
+    reportMissingAdobeMethods(apis);
+
+    return apis;
   };
 
   // Changes the page of the pdf reader to the page number provided
@@ -234,7 +163,6 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   // Only ever holding one page's worth of annotations is deliberate — the Adobe SDK
   // degrades badly when a document carries a large number of them.
   const applyAnnotationsForPage = async (pageNumber: number) => {
-    // console.log("applyAnnotationsForPage");
     let annotationManagerApi = annotationManagerApiMemo;
     if (!annotationManagerApiMemo) {
       const { annotationManagerApi: newAnnotationManagerApi } = await getAdobeApis();
@@ -257,15 +185,11 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     const pageHighlights = currentHighlights.filter((highlight) => highlight.pageNumber === pageNumber);
     try {
       // Clear annotations before adding provided ones
-      // console.time("Removing annotations");
       await annotationManagerApi.removeAnnotationsFromPDF();
-      // console.timeEnd("Removing annotations");
       if (pageHighlights.length > 0) {
         // Generate highlights for the provided passages
         const annotations = generateAnnotations(physicalDocument, pageHighlights);
-        // console.time("Adding annotations");
         await annotationManagerApi.addAnnotations(annotations);
-        // console.timeEnd("Adding annotations");
       }
     } catch (error) {
       // Whatever is on the page is now unknown, so let the next attempt redo this page
@@ -278,7 +202,12 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   // Queues an annotation update behind any still in flight. Without this the remove/add
   // pairs of two overlapping updates interleave and both sets stay on the page.
   const addAnnotationsForPage = (pageNumber: number): Promise<void> => {
-    annotationQueue = annotationQueue.then(() => applyAnnotationsForPage(pageNumber)).catch(() => {});
+    annotationQueue = annotationQueue
+      .then(() => applyAnnotationsForPage(pageNumber))
+      // Swallowed so one failure does not stall every later update, but reported
+      .catch((error: unknown) => {
+        faro.api?.pushError(error instanceof Error ? error : new Error(String(error)));
+      });
     return annotationQueue;
   };
 
@@ -327,9 +256,7 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     // This will catch passage clicks, as well as navigation within the native pdf reader
     await adobeViewer.registerCallback(
       window.AdobeDC.View.Enum.CallbackType.EVENT_LISTENER,
-      // Adobe SDK does not provide a type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async (event: any) => {
+      async (event: TAdobeEvent) => {
         if (event.type === "CURRENT_ACTIVE_PAGE") {
           await addAnnotationsForPage(event.data.pageNumber);
         }

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -1,42 +1,88 @@
+import type { SearchPassage } from "@/api/passages";
 import ViewSDKClient from "@/api/pdf";
 import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
 import { TPassage, TFamilyDocumentPublic } from "@/types";
 
-function generateHighlights(document: TFamilyDocumentPublic, documentPassageMatches: TPassage[]) {
+/*
+  The viewer is fed passages from two sources with different geometry models:
+
+  - Legacy Vespa search: `text_block_coords`, a single box per passage, on a 1-indexed
+    `text_block_page`.
+  - v2 `/search/passages`: `pages_with_bounding_boxes`, potentially many boxes spread
+    over many pages, with a 0-indexed page `number`.
+
+  Both are normalised to `THighlight` before anything else happens, so the rest of the
+  hook never has to know which model a passage came from.
+*/
+export type TViewerPassage = TPassage | SearchPassage;
+
+type THighlight = {
+  id: string;
+  // 1-indexed, matching Adobe's page events and `gotoLocation`.
+  pageNumber: number;
+  boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
+};
+
+const isNewModelPassage = (passage: TViewerPassage): passage is SearchPassage => "pages_with_bounding_boxes" in passage;
+
+// Both models list their four corners in the same order — top-left, top-right,
+// bottom-right, bottom-left — so only the container shape and the page indexing differ.
+const getPassageHighlights = (passage: TViewerPassage): THighlight[] => {
+  if (isNewModelPassage(passage)) {
+    return (passage.pages_with_bounding_boxes ?? []).flatMap((page) =>
+      (page.bounding_boxes ?? []).flatMap((box, boxIndex) => {
+        const [topLeft, topRight, bottomRight] = box.coordinates ?? [];
+        if (!topLeft || !topRight || !bottomRight) return [];
+
+        return [
+          {
+            // A passage can contribute several boxes, so the passage id alone would not
+            // be unique across annotations.
+            id: `${passage.text_block_id}-${page.number}-${boxIndex}`,
+            // `number` is 0-indexed in this model.
+            pageNumber: page.number + 1,
+            boundingBox: [topLeft.x, topLeft.y, topRight.x, bottomRight.y] as THighlight["boundingBox"],
+          },
+        ];
+      })
+    );
+  }
+
+  const [topLeft, topRight, bottomRight] = passage.text_block_coords ?? [];
+  if (!topLeft || !topRight || !bottomRight) return [];
+
+  return [
+    {
+      id: passage.text_block_id,
+      pageNumber: passage.text_block_page,
+      boundingBox: [topLeft[0], topLeft[1], topRight[0], bottomRight[1]],
+    },
+  ];
+};
+
+export const getHighlights = (passages: TViewerPassage[]): THighlight[] => passages.flatMap(getPassageHighlights);
+
+function generateAnnotations(document: TFamilyDocumentPublic, highlights: THighlight[]) {
   const date = new Date();
-  return documentPassageMatches.map((passage) => {
+  return highlights.map(({ id, pageNumber, boundingBox: [xMin, yMin, xMax, yMax] }) => {
     return {
       "@context": ["https://www.w3.org/ns/anno.jsonld", "https://comments.acrobat.com/ns/anno.jsonld"],
       type: "Annotation",
-      id: passage.text_block_id,
+      id,
       bodyValue: "",
       motivation: "commenting",
       target: {
         source: document.import_id,
         selector: {
           node: {
-            index: passage.text_block_page - 1,
+            // Adobe indexes pages from 0.
+            index: pageNumber - 1,
           },
           subtype: "highlight",
-          // WE CAN ASSUME BLOCK_COORDS IS ALWAYS LENGTH 4
-          // format [xmin, ymin, xmax, ymax]
-          boundingBox: [
-            passage.text_block_coords[0][0],
-            passage.text_block_coords[0][1],
-            passage.text_block_coords[1][0],
-            passage.text_block_coords[2][1],
-          ],
-          // format [Xmin, Ymin, Xmax, Ymin, Xmax, Ymax, Xmin, Ymax]
-          quadPoints: [
-            passage.text_block_coords[0][0],
-            passage.text_block_coords[0][1],
-            passage.text_block_coords[1][0],
-            passage.text_block_coords[0][1],
-            passage.text_block_coords[0][0],
-            passage.text_block_coords[2][1],
-            passage.text_block_coords[1][0],
-            passage.text_block_coords[2][1],
-          ],
+          // format [Xmin, Ymin, Xmax, Ymax]
+          boundingBox: [xMin, yMin, xMax, yMax],
+          // format [upper-left, upper-right, lower-left, lower-right] as x,y pairs
+          quadPoints: [xMin, yMin, xMax, yMin, xMin, yMax, xMax, yMax],
           styleClass: "body-value-css",
           type: "AdobeAnnoSelector",
           strokeColor: "#FFFF00",
@@ -82,6 +128,20 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
   let adobeViewerMemo: any;
   let viewerApiMemo: any;
   let annotationManagerApiMemo: any;
+
+  // The page-change listener is registered once and reads the highlights from here, so
+  // that a new set of passages does not require a second listener. `highlightsVersion`
+  // changes whenever they do, and is what makes the de-duplication below page-accurate.
+  let currentHighlights: THighlight[] = [];
+  let highlightsVersion = 0;
+  let hasRegisteredCallback = false;
+  // The (highlights, page) pair last pushed to the SDK, and the page it referred to.
+  let renderedKey: string | null = null;
+  let renderedPage: number | null = null;
+  // Annotation updates are serialised through this. Each is a remove-then-add pair, and
+  // two running concurrently interleave as remove/remove/add/add, which leaves both sets
+  // drawn on top of each other.
+  let annotationQueue: Promise<void> = Promise.resolve();
 
   const getAdobeApis = async (): Promise<TAdobeApis> => {
     const viewSDKClient = new ViewSDKClient();
@@ -132,9 +192,11 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     await viewerApi.gotoLocation(pageNumber);
   };
 
-  // Removes existing highlights before add the provided passage highlights to the document
-  const addAnnotationsForPage = async (documentPassageMatches: TPassage[]) => {
-    // console.log("addAnnotationsForPage");
+  // Removes existing highlights before adding the ones that fall on the given page.
+  // Only ever holding one page's worth of annotations is deliberate — the Adobe SDK
+  // degrades badly when a document carries a large number of them.
+  const applyAnnotationsForPage = async (pageNumber: number) => {
+    // console.log("applyAnnotationsForPage");
     let annotationManagerApi = annotationManagerApiMemo;
     if (!annotationManagerApiMemo) {
       const { annotationManagerApi: newAnnotationManagerApi } = await getAdobeApis();
@@ -143,25 +205,54 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     if (!annotationManagerApi) {
       return;
     }
-    // Clear annotations before adding provided ones
-    // console.time("Removing annotations");
-    await annotationManagerApi.removeAnnotationsFromPDF();
-    // console.timeEnd("Removing annotations");
-    if (documentPassageMatches.length > 0) {
-      // Generate highlights for the provided passages
-      const highlights = generateHighlights(physicalDocument, documentPassageMatches);
-      // console.time("Adding annotations");
-      await annotationManagerApi.addAnnotations(highlights);
-      // console.timeEnd("Adding annotations");
+
+    // CURRENT_ACTIVE_PAGE fires repeatedly for the same page, and the remove/add pair is
+    // the expensive part, so identical work is skipped. Checked here rather than when the
+    // update is queued, so it sees what actually reached the SDK.
+    const key = `${highlightsVersion}:${pageNumber}`;
+    if (key === renderedKey) {
+      return;
+    }
+    renderedKey = key;
+    renderedPage = pageNumber;
+
+    const pageHighlights = currentHighlights.filter((highlight) => highlight.pageNumber === pageNumber);
+    try {
+      // Clear annotations before adding provided ones
+      // console.time("Removing annotations");
+      await annotationManagerApi.removeAnnotationsFromPDF();
+      // console.timeEnd("Removing annotations");
+      if (pageHighlights.length > 0) {
+        // Generate highlights for the provided passages
+        const annotations = generateAnnotations(physicalDocument, pageHighlights);
+        // console.time("Adding annotations");
+        await annotationManagerApi.addAnnotations(annotations);
+        // console.timeEnd("Adding annotations");
+      }
+    } catch (error) {
+      // Whatever is on the page is now unknown, so let the next attempt redo this page
+      // rather than trusting the cache.
+      renderedKey = null;
+      throw error;
     }
   };
 
-  // Set up a new callback to listen for page changes once we have a new set of passages
-  // When the page changes, we will add the annotations for that page
-  const registerPassages = async (documentPassageMatches: TPassage[], startingPageNumber?: number) => {
-    let hasRegisteredCallback = false;
-    // Ensure we either start on the page passed in, or the page of the first passage, or default to first page
-    const startingPage = startingPageNumber || documentPassageMatches[0]?.text_block_page || 1;
+  // Queues an annotation update behind any still in flight. Without this the remove/add
+  // pairs of two overlapping updates interleave and both sets stay on the page.
+  const addAnnotationsForPage = (pageNumber: number): Promise<void> => {
+    annotationQueue = annotationQueue.then(() => applyAnnotationsForPage(pageNumber)).catch(() => {});
+    return annotationQueue;
+  };
+
+  // Takes a new set of passages, shows the ones on the starting page, and makes sure a
+  // page-change listener is in place to swap the highlights as the reader navigates.
+  const registerPassages = async (documentPassageMatches: TViewerPassage[], startingPageNumber?: number) => {
+    // A passage can carry boxes on more than one page, so highlights are flattened first
+    // and the page filtering works off those rather than off the passages.
+    currentHighlights = getHighlights(documentPassageMatches);
+    highlightsVersion += 1;
+    // Ensure we either start on the page passed in, or the page of the first highlight, or default to first page
+    const startingPage = startingPageNumber || currentHighlights[0]?.pageNumber || 1;
 
     let adobeViewer = adobeViewerMemo;
     if (!adobeViewer || !annotationManagerApiMemo) {
@@ -171,29 +262,40 @@ export default function usePDFPreview(physicalDocument: TFamilyDocumentPublic, a
     if (!adobeViewer) {
       return;
     }
-    // Open the viewer on the page of the first passage highlight
-    changePage(startingPage);
-    // We only want to add the annotations intentionally when we are confident this is a first load and initialisation
-    // Otherwise the callback below can handle highlights management on the page change event
-    // Add the annotations for the initial page
-    if (!hasRegisteredCallback) {
-      await addAnnotationsForPage(documentPassageMatches.filter((passage) => passage.text_block_page === startingPage));
+
+    // Only the first call moves the reader. Later calls are highlight refreshes — another
+    // page of results arriving — and navigating on those would drag the view away from
+    // wherever the reader had got to, as well as racing the page-change event.
+    // Read and claimed together, with no await between, so concurrent calls cannot both
+    // believe they are the first.
+    const isFirstRegistration = !hasRegisteredCallback;
+    hasRegisteredCallback = true;
+
+    if (isFirstRegistration) {
+      // Open the viewer on the page of the first passage highlight
+      changePage(startingPage);
+    }
+    // Redraw whichever page is on screen using the new highlights
+    await addAnnotationsForPage(isFirstRegistration ? startingPage : (renderedPage ?? startingPage));
+
+    // Register the page-change listener exactly once per viewer. Doing it on every call
+    // would stack listeners, and because each closes over the highlights it was created
+    // with, whichever finished last would decide what ended up on screen.
+    if (!isFirstRegistration) {
+      return;
     }
 
-    // Finally - register a callback on page change
     // Everytime we change page - add the highlights for that page
     // This will catch passage clicks, as well as navigation within the native pdf reader
     await adobeViewer.registerCallback(
       window.AdobeDC.View.Enum.CallbackType.EVENT_LISTENER,
       async (event: any) => {
         if (event.type === "CURRENT_ACTIVE_PAGE") {
-          await addAnnotationsForPage(documentPassageMatches.filter((passage) => passage.text_block_page === event.data.pageNumber));
+          await addAnnotationsForPage(event.data.pageNumber);
         }
       },
       { enableFilePreviewEvents: true }
     );
-
-    hasRegisteredCallback = true;
   };
 
   return { getAdobeApis, changePage, registerPassages };

--- a/src/hooks/usePDFPreview.ts
+++ b/src/hooks/usePDFPreview.ts
@@ -1,4 +1,4 @@
-import type { SearchPassage } from "@/api/passages";
+import type { ISearchPassage } from "@/api/passages";
 import ViewSDKClient from "@/api/pdf";
 import { DEFAULT_DOCUMENT_TITLE } from "@/constants/document";
 import { TPassage, TFamilyDocumentPublic } from "@/types";
@@ -14,7 +14,7 @@ import { TPassage, TFamilyDocumentPublic } from "@/types";
   Both are normalised to `THighlight` before anything else happens, so the rest of the
   hook never has to know which model a passage came from.
 */
-export type TViewerPassage = TPassage | SearchPassage;
+export type TViewerPassage = TPassage | ISearchPassage;
 
 type THighlight = {
   id: string;
@@ -23,7 +23,7 @@ type THighlight = {
   boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
 };
 
-const isNewModelPassage = (passage: TViewerPassage): passage is SearchPassage => "pages_with_bounding_boxes" in passage;
+const isNewModelPassage = (passage: TViewerPassage): passage is ISearchPassage => "pages_with_bounding_boxes" in passage;
 
 // Both models list their four corners in the same order — top-left, top-right,
 // bottom-right, bottom-left — so only the container shape and the page indexing differ.

--- a/src/pages/documents/[id].tsx
+++ b/src/pages/documents/[id].tsx
@@ -10,6 +10,7 @@ import { FiveColumns } from "@/components/atoms/columns/FiveColumns";
 import { Debug } from "@/components/atoms/debug/Debug";
 import { ConceptsDocumentViewer } from "@/components/documents/ConceptsDocumentViewer";
 import { DocumentHead } from "@/components/documents/DocumentHead";
+import { DocumentPassageViewer } from "@/components/documents/DocumentPassageViewer";
 import Layout from "@/components/layouts/Main";
 import { Section } from "@/components/molecules/section/Section";
 import { getDocumentDescription } from "@/constants/metaDescriptions";
@@ -134,18 +135,22 @@ const DocumentPage = ({
               usesDataIn={Boolean(debug?.usesDataIn)}
             />
 
-            <ConceptsDocumentViewer
-              initialQueryTerm={qsSearchString}
-              initialExactMatch={exactMatchQuery}
-              initialPageNumber={startingPageNumber}
-              initialConceptFilters={conceptFilters}
-              vespaDocumentData={vespaDocumentData}
-              document={document}
-              searchStatus={status}
-              searchResultFamilies={isEmptySearch(router.query) ? [] : families}
-              handleSemanticSearchChange={handleSemanticSearchChange}
-              handlePassagesOrderChange={handlePassagesOrderChange}
-            />
+            {features["new-search"] ? (
+              <DocumentPassageViewer document={document} vespaDocumentData={vespaDocumentData} />
+            ) : (
+              <ConceptsDocumentViewer
+                initialQueryTerm={qsSearchString}
+                initialExactMatch={exactMatchQuery}
+                initialPageNumber={startingPageNumber}
+                initialConceptFilters={conceptFilters}
+                vespaDocumentData={vespaDocumentData}
+                document={document}
+                searchStatus={status}
+                searchResultFamilies={isEmptySearch(router.query) ? [] : families}
+                handleSemanticSearchChange={handleSemanticSearchChange}
+                handlePassagesOrderChange={handlePassagesOrderChange}
+              />
+            )}
           </section>
           {family.attribution.category === "Litigation" && (
             <Head>

--- a/src/types/adobe.ts
+++ b/src/types/adobe.ts
@@ -1,0 +1,91 @@
+/*
+  Adobe's PDF Embed API ships no type definitions and there is no @types package for it, so
+  these declare only the surface the PDF viewer actually uses.
+
+  These are a hand-written promise about a runtime object, not something TypeScript can
+  verify. Adobe serves an unversioned viewer.js and offers no way to pin a version, so the
+  SDK can change without a deploy on our side — `findMissingAdobeMethods` in usePDFPreview
+  checks the methods below at runtime for exactly that reason.
+
+  https://developer.adobe.com/document-services/docs/overview/pdf-embed-api/
+*/
+
+// The W3C annotation payload Adobe expects from `addAnnotations`.
+export type TAnnotation = {
+  "@context": string[];
+  type: "Annotation";
+  id: string;
+  bodyValue: string;
+  motivation: "commenting";
+  target: {
+    source: string;
+    selector: {
+      node: {
+        index: number;
+      };
+      subtype: "highlight";
+      boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
+      quadPoints: [xMin: number, yMin: number, xMax: number, yMin: number, xMin: number, yMax: number, xMax: number, yMax: number];
+      styleClass: "body-value-css";
+      type: "AdobeAnnoSelector";
+      strokeColor: "#FFFF00";
+      strokeWidth: 1;
+      opacity: 0.25;
+    };
+  };
+  creator: {
+    type: "Person";
+    name: "Climate Policy Radar";
+  };
+  created: string;
+  modified: string;
+};
+
+// Only CURRENT_ACTIVE_PAGE is handled, but the SDK sends every file preview event through
+// the same callback, so `type` stays open.
+export type TAdobeEvent = {
+  type: string;
+  data: { pageNumber: number };
+};
+
+// https://developer.adobe.com/document-services/docs/overview/pdf-embed-api/howtos_ui/#viewer-api
+export interface IAdobeViewerApi {
+  gotoLocation(pageNumber: number): Promise<void>;
+}
+
+// https://developer.adobe.com/document-services/docs/overview/pdf-embed-api/howtos_comments/#basic-apis-for-commenting
+export interface IAdobeAnnotationManagerApi {
+  setConfig(config: Record<string, boolean>): Promise<void>;
+  addAnnotations(annotations: TAnnotation[]): Promise<void>;
+  removeAnnotationsFromPDF(): Promise<void>;
+}
+
+export interface IAdobePreviewedFile {
+  getAPIs(): Promise<IAdobeViewerApi>;
+  getAnnotationManager(): Promise<IAdobeAnnotationManagerApi>;
+}
+
+export interface IAdobeViewer {
+  previewFile(
+    file: {
+      content: { location: { url: string } };
+      metaData: { fileName: string; id: string };
+    },
+    config: Record<string, boolean | string>
+  ): Promise<IAdobePreviewedFile>;
+  registerCallback(type: string, callback: (event: TAdobeEvent) => void, options: { enableFilePreviewEvents: boolean }): Promise<void>;
+}
+
+export type TAdobeApis = {
+  adobeViewer: IAdobeViewer;
+  viewerApi: IAdobeViewerApi;
+  annotationManagerApi: IAdobeAnnotationManagerApi;
+};
+
+// Custom CPR types to support Adobe SDK
+export type THighlight = {
+  id: string;
+  // 1-indexed, matching Adobe's page events and `gotoLocation`.
+  pageNumber: number;
+  boundingBox: [xMin: number, yMin: number, xMax: number, yMax: number];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from "./bff/document";
 export * from "./bff/family";
 export * from "./display";
 export * from "./features";
+export * from "./passages";
 export * from "./search";
 export * from "./search/filters";
 export * from "./search/labels";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./adobe";
 export * from "./api";
 export * from "./bff/collection";
 export * from "./bff/document";

--- a/src/types/passages.ts
+++ b/src/types/passages.ts
@@ -1,0 +1,49 @@
+export interface IPassageBoundingBox {
+  coordinates: { x: number; y: number }[];
+}
+
+export interface IPassagePageWithBoundingBoxes {
+  number: number;
+  bounding_boxes: IPassageBoundingBox[];
+}
+
+export interface ISearchPassage {
+  id: string;
+  text_block_id: string;
+  idx: number;
+  text: string;
+  language: string | null;
+  type: string;
+  type_confidence: number;
+  page_number: number;
+  pages: number[];
+  pages_with_bounding_boxes: IPassagePageWithBoundingBoxes[];
+  concepts: unknown[];
+  heading_id: string | null;
+  heading_text: string | null;
+  document_id: string;
+  principal_id: string;
+  tokens: string[];
+}
+
+export interface ISearchPassagesResponse {
+  took_ms: number | null;
+  total_size: number | null;
+  page: number;
+  page_size: number;
+  total_pages: number | null;
+  next_page: string | null;
+  previous_page: string | null;
+  results: ISearchPassage[];
+}
+
+export interface ISearchPassagesParams {
+  query: string;
+  documents: string[];
+  pageSize?: number;
+  // 1-indexed page number. The API's `page` parameter is currently ignored, and its
+  // `next_page` / `total_pages` fields come back null, so callers page by incrementing
+  // this and comparing the running result count against `total_size`.
+  pageToken?: number;
+  signal?: AbortSignal;
+}

--- a/src/types/search/query.ts
+++ b/src/types/search/query.ts
@@ -10,6 +10,11 @@ export type TSearchQueryRule =
       key?: "published_date";
       op: "eq" | "not_eq" | "lt" | "lte" | "gt" | "gte";
       value: string;
+    }
+  | {
+      field: "document_id";
+      op: "contains";
+      value: string;
     };
 
 export type TSearchQueryGroup = {

--- a/src/utils/adobe/generateAnnotations.test.ts
+++ b/src/utils/adobe/generateAnnotations.test.ts
@@ -1,0 +1,56 @@
+import { TFamilyDocumentPublic, THighlight } from "@/types";
+
+import { generateAnnotations } from "./generateAnnotations";
+
+const familyDocument = { cdn_object: "doc.pdf", import_id: "D1", title: "Doc" } as TFamilyDocumentPublic;
+
+const highlight = (overrides: Partial<THighlight> = {}): THighlight => ({
+  id: "block-1",
+  // 1-indexed, as the viewer counts pages.
+  pageNumber: 16,
+  boundingBox: [40, 415, 568, 566],
+  ...overrides,
+});
+
+describe("generateAnnotations", () => {
+  it("produces one annotation per highlight", () => {
+    const annotations = generateAnnotations(familyDocument, [highlight({ id: "a" }), highlight({ id: "b" })]);
+
+    expect(annotations).toHaveLength(2);
+    expect(annotations.map((annotation) => annotation.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns nothing when there are no highlights", () => {
+    expect(generateAnnotations(familyDocument, [])).toEqual([]);
+  });
+
+  it("shifts the page number down, since Adobe indexes pages from 0", () => {
+    const [annotation] = generateAnnotations(familyDocument, [highlight({ pageNumber: 16 })]);
+
+    expect(annotation.target.selector.node.index).toBe(15);
+  });
+
+  it("keeps the first page on index 0", () => {
+    const [annotation] = generateAnnotations(familyDocument, [highlight({ pageNumber: 1 })]);
+
+    expect(annotation.target.selector.node.index).toBe(0);
+  });
+
+  it("passes the bounding box through unchanged", () => {
+    const [annotation] = generateAnnotations(familyDocument, [highlight({ boundingBox: [40, 415, 568, 566] })]);
+
+    expect(annotation.target.selector.boundingBox).toEqual([40, 415, 568, 566]);
+  });
+
+  it("derives the quad points as upper-left, upper-right, lower-left, lower-right", () => {
+    const [annotation] = generateAnnotations(familyDocument, [highlight({ boundingBox: [1, 2, 3, 4] })]);
+
+    expect(annotation.target.selector.quadPoints).toEqual([1, 2, 3, 2, 1, 4, 3, 4]);
+  });
+
+  it("targets the document the highlight belongs to", () => {
+    const [annotation] = generateAnnotations({ ...familyDocument, import_id: "CCLW.executive.1.2" }, [highlight()]);
+
+    expect(annotation.target.source).toBe("CCLW.executive.1.2");
+  });
+});

--- a/src/utils/adobe/generateAnnotations.ts
+++ b/src/utils/adobe/generateAnnotations.ts
@@ -1,0 +1,39 @@
+import { TAnnotation, TFamilyDocumentPublic, THighlight } from "@/types";
+
+export const generateAnnotations = (document: TFamilyDocumentPublic, highlights: THighlight[]): TAnnotation[] => {
+  const date = new Date();
+  return highlights.map(({ id, pageNumber, boundingBox: [xMin, yMin, xMax, yMax] }) => {
+    return {
+      "@context": ["https://www.w3.org/ns/anno.jsonld", "https://comments.acrobat.com/ns/anno.jsonld"],
+      type: "Annotation",
+      id,
+      bodyValue: "",
+      motivation: "commenting",
+      target: {
+        source: document.import_id,
+        selector: {
+          node: {
+            // Adobe indexes pages from 0.
+            index: pageNumber - 1,
+          },
+          subtype: "highlight",
+          // format [Xmin, Ymin, Xmax, Ymax]
+          boundingBox: [xMin, yMin, xMax, yMax],
+          // format [upper-left, upper-right, lower-left, lower-right] as x,y pairs
+          quadPoints: [xMin, yMin, xMax, yMin, xMin, yMax, xMax, yMax],
+          styleClass: "body-value-css",
+          type: "AdobeAnnoSelector",
+          strokeColor: "#FFFF00",
+          strokeWidth: 1,
+          opacity: 0.25,
+        },
+      },
+      creator: {
+        type: "Person",
+        name: "Climate Policy Radar",
+      },
+      created: date.toISOString(),
+      modified: date.toISOString(),
+    };
+  });
+};

--- a/src/utils/adobe/reportMissingAdobeMethods.ts
+++ b/src/utils/adobe/reportMissingAdobeMethods.ts
@@ -1,0 +1,31 @@
+import { faro } from "@grafana/faro-web-sdk";
+
+import { TAdobeApis } from "@/types";
+
+/*
+  Adobe serves an unversioned viewer.js and offers no way to pin a version, so the SDK can
+  change under us with no deploy on our side. The methods below are the ones called at a
+  distance from where the APIs are obtained, so they are checked once, at that seam.
+
+  Deliberately not guarded with `?.` at each call site: optional chaining would turn a
+  renamed method into silently missing highlights, which is the one failure nobody would
+  ever report.
+*/
+const findMissingAdobeMethods = ({ adobeViewer, viewerApi, annotationManagerApi }: TAdobeApis): string[] =>
+  (
+    [
+      ["adobeViewer.registerCallback", adobeViewer?.registerCallback],
+      ["viewerApi.gotoLocation", viewerApi?.gotoLocation],
+      ["annotationManagerApi.addAnnotations", annotationManagerApi?.addAnnotations],
+      ["annotationManagerApi.removeAnnotationsFromPDF", annotationManagerApi?.removeAnnotationsFromPDF],
+    ] as const
+  )
+    .filter(([, method]) => typeof method !== "function")
+    .map(([name]) => name);
+
+export const reportMissingAdobeMethods = (apis: TAdobeApis): void => {
+  const missing = findMissingAdobeMethods(apis);
+  if (missing.length === 0) return;
+
+  faro.api?.pushError(new Error(`Adobe PDF Embed API is missing expected methods: ${missing.join(", ")}`));
+};

--- a/src/utils/topics/getTopDocumentTopics.ts
+++ b/src/utils/topics/getTopDocumentTopics.ts
@@ -1,0 +1,24 @@
+import { TSearchResponse, TTopic } from "@/types";
+
+// concept_counts keys are `<wikibase id>:<label>` and the same concept can appear across
+// several hits, so counts are summed before ranking. Concepts we have no topic record for
+// are dropped, as we would have no label to show.
+export const getTopDocumentConcepts = (vespaDocumentData: TSearchResponse, topics: TTopic[], limit: number): TTopic[] => {
+  const totals = new Map<string, number>();
+  const topicsById = new Map(topics.map((topic) => [topic.wikibase_id, topic]));
+
+  (vespaDocumentData?.families ?? []).forEach((family) =>
+    family.hits.forEach((hit) =>
+      Object.entries(hit.concept_counts ?? {}).forEach(([conceptKey, count]) => {
+        const [conceptId] = conceptKey.split(":");
+        if (!topicsById.has(conceptId)) return;
+        totals.set(conceptId, (totals.get(conceptId) ?? 0) + count);
+      })
+    )
+  );
+
+  return Array.from(totals.entries())
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, limit)
+    .map(([conceptId, count]) => ({ ...topicsById.get(conceptId), count }));
+};

--- a/tests/generic/genericDocumentTests.ts
+++ b/tests/generic/genericDocumentTests.ts
@@ -11,11 +11,7 @@ export const runGenericDocumentTests = (theme: TTheme): void => {
 
   documentsToTest.forEach(({ titleForTests, slug, withSearch, withTopic, withParentTopic }) => {
     test(`adding a search query generates passage matches - ${titleForTests}`, async ({ page }) => {
-      // NavBar hides the header search input with no replacement when new-search is on (NavBar.tsx) - no inline search UI exists yet to test
-      test.skip(process.env.E2E_TEST_FEATURE_FLAGS === "true", "No inline document search UI exists yet under the new-search feature flag");
-
       // Load the document page
-
       await documentPage.goToDocument(page, slug);
       await documentPage.waitUntilLoaded(page);
       await genericPage.dismissPopups(page);
@@ -38,8 +34,10 @@ export const runGenericDocumentTests = (theme: TTheme): void => {
     });
 
     test(`selecting a topic generates passage matches - ${titleForTests}`, async ({ page }) => {
-      // Load the document page
+      // TODO: remove when we have topics enabled for new passage search
+      test.skip(process.env.E2E_TEST_FEATURE_FLAGS === "true", "We don't have topics enabled for new passage search");
 
+      // Load the document page
       await documentPage.goToDocument(page, slug);
       await documentPage.waitUntilLoaded(page);
       await genericPage.dismissPopups(page);


### PR DESCRIPTION
# What's changed
- Adding the new passage search to the document page

## Why
- Part of the new search initiative

## AI attribution
- Creating v1 new passages endpoint
- Logic and recommendations on performance optimisation for the new v1 `DocumentPassageViewer` component
- Used heavily for generating unit tests and storybook shells

## Screenshots
<img width="1478" height="1016" alt="Screenshot 2026-07-30 at 16 44 56" src="https://github.com/user-attachments/assets/6eae18b6-ba95-40c7-a8d6-3277edf4cb6e" />
