### PR TITLE
adds waf bot logging and fixes ccc bot header forwarding

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -555,6 +555,8 @@ if not is_review_stack_or_template:
         name=f"{theme}-{env}-frontend-waf",
         # Bot Control is a paid add-on; only run it in production.
         enable_bot_control=env == "production",
+        # Log bot-tagged requests (edge-level record of all bots, including non-JS).
+        enable_logging=env == "production",
         tags={"CUSTOM_APP_THEME": theme, "Environment": env},
     )
 
@@ -712,6 +714,7 @@ if not is_review_stack_or_template:
                         "Accept",
                         "Access-Control-Request-Method",
                         "Access-Control-Request-Headers",
+                        "x-amzn-waf-is-bot",
                     ],
                 ),
                 cookies=CookieConfig(

--- a/infra/resources/waf.py
+++ b/infra/resources/waf.py
@@ -20,6 +20,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
         self,
         name: str,
         enable_bot_control: bool = False,
+        enable_logging: bool = False,
         tags: dict[str, str] | None = None,
         opts: pulumi.ResourceOptions | None = None,
     ):
@@ -137,6 +138,10 @@ class FrontendWebAcl(pulumi.ComponentResource):
                         key="awswaf:managed:aws:bot-control:",
                     ),
                 ),
+                # Label bot requests so logging can filter to them (see logging_filter).
+                rule_labels=[
+                    aws.wafv2.WebAclRuleRuleLabelArgs(name="frontend:waf:bot"),
+                ],
                 visibility_config=aws.wafv2.WebAclRuleVisibilityConfigArgs(
                     cloudwatch_metrics_enabled=True,
                     metric_name="FlagBotTraffic",
@@ -163,6 +168,49 @@ class FrontendWebAcl(pulumi.ComponentResource):
             tags=self.tags,
             opts=pulumi.ResourceOptions(provider=self._useast1, parent=self),
         )
+
+        # Log bot-tagged requests to CloudWatch: captures every bot at the edge,
+        # including non-JS crawlers that never reach PostHog. Needs bot control,
+        # since the `frontend:waf:bot` label only exists when FlagBotTraffic runs.
+        if enable_logging:
+            # Log group must be named aws-waf-logs-*, and in us-east-1 for a
+            # CLOUDFRONT-scoped WebACL.
+            self.log_group = aws.cloudwatch.LogGroup(
+                f"{name}-waf-logs",
+                name=f"aws-waf-logs-{name}",
+                retention_in_days=30,
+                tags=self.tags,
+                opts=pulumi.ResourceOptions(provider=self._useast1, parent=self),
+            )
+
+            self.logging_config = aws.wafv2.WebAclLoggingConfiguration(
+                f"{name}-waf-logging",
+                resource_arn=self.web_acl.arn,
+                # WAFv2 wants the log-group ARN without the trailing ":*".
+                log_destination_configs=[
+                    self.log_group.arn.apply(
+                        lambda arn: arn[:-2] if arn.endswith(":*") else arn
+                    )
+                ],
+                # Keep only bot-tagged requests, drop the rest (cost control).
+                logging_filter=aws.wafv2.WebAclLoggingConfigurationLoggingFilterArgs(
+                    default_behavior="DROP",
+                    filters=[
+                        aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterArgs(
+                            behavior="KEEP",
+                            requirement="MEETS_ANY",
+                            conditions=[
+                                aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionArgs(
+                                    label_name_condition=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionLabelNameConditionArgs(
+                                        label_name="frontend:waf:bot",
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                opts=pulumi.ResourceOptions(provider=self._useast1, parent=self),
+            )
 
         self.register_outputs(
             {


### PR DESCRIPTION
## What
- Enable AWS WAF logging on the production frontend WebACLs, sending bot-tagged requests to CloudWatch.
- Filter logs to bot traffic only, using a new `frontend:waf:bot` label on the `FlagBotTraffic` rule.
- Forward `x-amzn-waf-is-bot` on ccc's public distribution (climatecasechart.com), which its origin request policy was dropping.

## Why
WAF already tags bots on every request, but nothing recorded them, so most bots (crawlers, scrapers, HTTP libraries) were invisible: they never run JavaScript, so they never reach PostHog. Logging captures the full bot picture at the edge, which supports current bot analytics and future analysis of AI/crawler usage of our data.

The ccc change closes a gap where the public climatecasechart.com distribution used a separate origin request policy that did not forward the WAF bot header, so ccc's public traffic never received it.

## Changes
- `infra/resources/waf.py`: add `enable_logging` param; add the `frontend:waf:bot` label to `FlagBotTraffic`; create a CloudWatch log group (`aws-waf-logs-*`, us-east-1, 30 day retention) and a `WebAclLoggingConfiguration` that keeps only bot-tagged requests.
- `infra/__main__.py`: pass `enable_logging=env == "production"`; add `x-amzn-waf-is-bot` to the ccc `redirection_cors_policy` forwarded headers.

## Cost
Small. The bot-only filter and 30-day retention keep it to roughly single-digit to low-tens of pounds a month, scaling with bot volume. No change to the existing Bot Control cost. Can move the destination to S3 if volume grows.

## Validation and risks
- The logging filter matches the `frontend:waf:bot` label. If the fully-qualified label name is off, logging succeeds with zero records (silent failure), so confirm real bot records actually appear after deploy, not just a green apply.
- WAF to CloudWatch is normally auto-authorised by the `aws-waf-logs-` prefix. If the apply 403s, add a `LogResourcePolicy` for `delivery.logs.amazonaws.com`.
- Logging is gated to production and depends on bot control, since the label only exists when `FlagBotTraffic` runs.
