### PR TITLE
fix: use a non-reserved bot label and qualify it for logging

### DIFF
--- a/infra/resources/waf.py
+++ b/infra/resources/waf.py
@@ -3,6 +3,9 @@ import pulumi_aws as aws
 
 from resources.util import tag_name
 
+# Label applied to bot traffic so the logging filter can select it.
+BOT_LABEL = "frontend:bot"
+
 
 class FrontendWebAcl(pulumi.ComponentResource):
     """
@@ -140,7 +143,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
                 ),
                 # Label bot requests so logging can filter to them (see logging_filter).
                 rule_labels=[
-                    aws.wafv2.WebAclRuleRuleLabelArgs(name="frontend:waf:bot"),
+                    aws.wafv2.WebAclRuleRuleLabelArgs(name=BOT_LABEL),
                 ],
                 visibility_config=aws.wafv2.WebAclRuleVisibilityConfigArgs(
                     cloudwatch_metrics_enabled=True,
@@ -171,8 +174,12 @@ class FrontendWebAcl(pulumi.ComponentResource):
 
         # Log bot-tagged requests to CloudWatch: captures every bot at the edge,
         # including non-JS crawlers that never reach PostHog. Needs bot control,
-        # since the `frontend:waf:bot` label only exists when FlagBotTraffic runs.
+        # since the BOT_LABEL label only exists when FlagBotTraffic runs.
         if enable_logging:
+            account_id = aws.get_caller_identity(
+                opts=pulumi.InvokeOptions(provider=self._useast1)
+            ).account_id
+
             # Log group must be named aws-waf-logs-*, and in us-east-1 for a
             # CLOUDFRONT-scoped WebACL.
             self.log_group = aws.cloudwatch.LogGroup(
@@ -189,7 +196,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
                 # WAFv2 wants the log-group ARN without the trailing ":*".
                 log_destination_configs=[
                     self.log_group.arn.apply(
-                        lambda arn: arn[:-2] if arn.endswith(":*") else arn
+                        lambda arn: arn.removesuffix(":*")
                     )
                 ],
                 # Keep only bot-tagged requests, drop the rest (cost control).
@@ -202,7 +209,7 @@ class FrontendWebAcl(pulumi.ComponentResource):
                             conditions=[
                                 aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionArgs(
                                     label_name_condition=aws.wafv2.WebAclLoggingConfigurationLoggingFilterFilterConditionLabelNameConditionArgs(
-                                        label_name="frontend:waf:bot",
+                                        label_name=f"awswaf:{account_id}:webacl:{name}:{BOT_LABEL}",
                                     ),
                                 ),
                             ],


### PR DESCRIPTION
# What's changed

Renames the WAF bot label from `frontend:waf:bot` to `frontend:bot`, and uses the fully qualified label in the logging filter.

## Why

Two separate bugs, both introduced in #1440, both only reachable in production.

**1. `waf` is a reserved WAF label namespace.** AWS reserves `awswaf`, `aws`, `waf`, `rulegroup`, `webacl`, `regexpatternset`, `ipset` and `managed` in label namespaces and names. It doesn't just ignore the label, it rejects the entire `UpdateWebACL` call, which fails the whole stack update:
```
WAFInvalidParameterException: Error reason: The parameter value isn't supported., field: null, parameter: frontend:waf:bot
```
This blocked every production frontend `pulumi up` since #1440 merged, most recently mcf-production update #157 on an unrelated PR (#1436).

**2. The logging filter needs a fully qualified label.** `LabelNameCondition` requires the full `awswaf:<account>:webacl:<name>:...` form. A bare label name doesn't error, it just matches nothing, and with `default_behavior="DROP"` that
means zero logs. So even with bug 1 fixed, WAF bot logging would have appeared to deploy successfully while capturing nothing.

**Why CI didn't catch either.** `enable_bot_control` and `enable_logging` are both gated on `env == "production"`, so the `FlagBotTraffic` rule carrying the label doesn't exist in staging. Staging went green because it never ran the code path.

Docs: https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-label-requirements.html

## AI attribution

Root-caused and fixed with Claude.

## Screenshots

n/a, infra only.

## NB

Merging this won't deploy it. This only touches `infra/resources/**`, and `merge_to_main.yml`'s paths filter only watches `infra/__main__.py`, so the `pulumi-up` job will be skipped, exactly as happened with #1435.  Will need to run pulumi up after merged (which I don't have permissions to do)
