### PR TITLE
fix: own the rollback alarm so 4XX stops failing deployments

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -24,6 +24,7 @@ from resources.ecs_express_service import (
     ExpressGatewayServiceComponent,
 )
 from resources.github_actions_role import GitHubActionsRole
+from resources.rollback_alarm import RollbackAlarm, RollbackAlarmConfig
 from resources.util import (
     BehaviourOptions,
     CookieConfig,
@@ -262,6 +263,19 @@ if not is_review_template:
             ),
         ),
     )
+
+    # Replaces the alarm ECS Express creates, which fails deployments on 4XX.
+    # Production only: lower environments lack the traffic to make it meaningful.
+    if env == "production" and not is_review_stack:
+        RollbackAlarm(
+            name_prefix,
+            config=RollbackAlarmConfig(
+                theme=theme,
+                cluster=f"frontend-{env}",
+                service_name=f"{theme}-frontend-{env}",
+            ),
+            opts=pulumi.ResourceOptions(depends_on=[ecs_frontend_service]),
+        )
 
     # Export outputs
     pulumi.export("ecs_service_url", ecs_frontend_service.url)

--- a/infra/resources/rollback_alarm.py
+++ b/infra/resources/rollback_alarm.py
@@ -1,0 +1,164 @@
+"""Owns the deployment rollback alarm that ECS Express otherwise creates itself.
+
+The default alarm counts 4XX as a deployment failure and divides by
+`RequestCountPerTarget` (a per-target average), which inflates the rate by the
+task count. Neither is configurable via the express API, so we take over the
+alarm under the same name and correct it to 5XX over `RequestCount`.
+"""
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_aws as aws
+
+# ECS Express tags both of a service's blue/green target groups with this.
+_TARGET_GROUP_NAME_TAG = "{theme}-frontend"
+
+
+@dataclass
+class RollbackAlarmConfig:
+    """Configuration for the deployment rollback alarm."""
+
+    theme: str
+    cluster: str
+    service_name: str
+    # Percentage of requests returning 5XX that fails a deployment.
+    threshold: float = 1.0
+    evaluation_periods: int = 3
+    datapoints_to_alarm: int = 2
+    period: int = 60
+
+
+def _dimension_from_arn(arn: str) -> str:
+    """CloudWatch wants the ARN suffix, e.g. `targetgroup/name/id`."""
+    return arn.split(":")[-1]
+
+
+def _load_balancer_dimension(arn: str) -> str:
+    """CloudWatch wants `app/name/id`, i.e. everything after `loadbalancer/`."""
+    return arn.split("loadbalancer/")[-1]
+
+
+class RollbackAlarm(pulumi.ComponentResource):
+    """A 5XX-only error rate alarm, replacing the ECS Express default."""
+
+    def __init__(
+        self,
+        name: str,
+        config: RollbackAlarmConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ):
+        super().__init__("pkg:index:RollbackAlarm", name, None, opts)
+
+        target_group_tag = _TARGET_GROUP_NAME_TAG.format(theme=config.theme)
+        target_groups = aws.resourcegroupstaggingapi.get_resources(
+            resource_type_filters=["elasticloadbalancing:targetgroup"],
+            tag_filters=[
+                aws.resourcegroupstaggingapi.GetResourcesTagFilterArgs(
+                    key="Name", values=[target_group_tag]
+                ),
+                aws.resourcegroupstaggingapi.GetResourcesTagFilterArgs(
+                    key="AmazonECSManaged", values=["true"]
+                ),
+            ],
+        )
+        target_group_arns = sorted(
+            mapping.resource_arn for mapping in target_groups.resource_tag_mapping_lists
+        )
+        if not target_group_arns:
+            raise Exception(
+                f"No ECS-managed target groups tagged Name={target_group_tag}."
+            )
+
+        # The idle half of the blue/green pair can be detached between deployments,
+        # so find one that is still attached.
+        load_balancer_arn = next(
+            (
+                arns[0]
+                for arns in (
+                    aws.lb.get_target_group(arn=arn).load_balancer_arns
+                    for arn in target_group_arns
+                )
+                if arns
+            ),
+            None,
+        )
+        if load_balancer_arn is None:
+            raise Exception(
+                f"No target group for {config.service_name} is attached to a load "
+                "balancer, so the alarm's dimensions cannot be resolved."
+            )
+        lb_dimension = _load_balancer_dimension(load_balancer_arn)
+
+        # Either half of the blue/green pair can fail a deployment, so score each
+        # and alarm on the worse.
+        queries: list[aws.cloudwatch.MetricAlarmMetricQueryArgs] = []
+        for index, target_group_arn in enumerate(target_group_arns):
+            dimensions = {
+                "TargetGroup": _dimension_from_arn(target_group_arn),
+                "LoadBalancer": lb_dimension,
+            }
+            queries.append(
+                aws.cloudwatch.MetricAlarmMetricQueryArgs(
+                    id=f"m{index}_5xx",
+                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
+                        namespace="AWS/ApplicationELB",
+                        metric_name="HTTPCode_Target_5XX_Count",
+                        dimensions=dimensions,
+                        period=config.period,
+                        stat="Sum",
+                    ),
+                    return_data=False,
+                )
+            )
+            queries.append(
+                aws.cloudwatch.MetricAlarmMetricQueryArgs(
+                    id=f"m{index}_total",
+                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
+                        namespace="AWS/ApplicationELB",
+                        metric_name="RequestCount",
+                        dimensions=dimensions,
+                        period=config.period,
+                        stat="Sum",
+                    ),
+                    return_data=False,
+                )
+            )
+            queries.append(
+                aws.cloudwatch.MetricAlarmMetricQueryArgs(
+                    id=f"em{index}",
+                    # FILL guards against a zero denominator in quiet minutes.
+                    expression=f"100 * m{index}_5xx / FILL(m{index}_total, 1)",
+                    label=f"5XX percentage for target group {index}",
+                    return_data=False,
+                )
+            )
+
+        worst = ",".join(f"em{index}" for index in range(len(target_group_arns)))
+        queries.append(
+            aws.cloudwatch.MetricAlarmMetricQueryArgs(
+                id="e",
+                expression=f"MAX([{worst}])",
+                label="5XX error percentage",
+                # Exactly one query may return data.
+                return_data=True,
+            )
+        )
+
+        self.alarm = aws.cloudwatch.MetricAlarm(
+            f"{name}-rollback-alarm",
+            # Must match the name ECS Express used, or the service's
+            # deploymentConfiguration still points at the broken alarm.
+            name=f"{config.cluster}/{config.service_name}/RollbackAlarm",
+            alarm_description="Rate of 5XX errors",
+            comparison_operator="GreaterThanThreshold",
+            evaluation_periods=config.evaluation_periods,
+            datapoints_to_alarm=config.datapoints_to_alarm,
+            threshold=config.threshold,
+            treat_missing_data="notBreaching",
+            actions_enabled=True,
+            metric_queries=queries,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.register_outputs({"alarm_arn": self.alarm.arn})


### PR DESCRIPTION
# What's changed

Defines the frontend deployment rollback alarm in Pulumi rather than leaving it to ECS Express, and corrects it to alarm on 5XX only.

- new `infra/resources/rollback_alarm.py`
- called from `infra/__main__.py`, production stacks only
- target groups found by their `Name: <theme>-frontend` tag, so no AWS-generated ids are hardcoded

## Why

Production deploys are being rolled back while the app is healthy. ECS says why:

```json
"statusReason": "Service deployment rolled back because of one or more active alarms.",
"triggeredAlarmNames": ["frontend-production/cpr-frontend-production/RollbackAlarm"], "deploymentCircuitBreaker": { "failureCount": 0 }
```

No task failed to start, and there were zero 5XX. The rollbacks were caused entirely by 404s.

The default alarm ECS Express creates has two faults:

1. It counts 4XX as a failed release. Its IF(4xx < 5, 0, 4xx) gate against a 1% threshold means 5 client errors in a minute computes to 10-75%, because per-minute request counts are small. That condition is met in 2-3% of all minutes on a site with crawler traffic.
2. The denominator is wrong. It divides whole-target-group error counts by RequestCountPerTarget, a per-target average, inflating the rate by the task count. The datapoint that killed the 07-30 deploy read 218%.

Deploys also generate their own 404s: each build changes the Next.js build id while assets are served from the container, so clients mid-session request paths the new task lacks. Background odds of a clean bake window are ~3%, yet 5 of 7
cpr deploys rolled back.

Raising the threshold wouldn't fix it. cpr's true 4XX rate is 1.07%, already over 1%. The alarm has to stop counting 4XX.

Neither the alarm nor the deployment configuration is exposed by create-express-gateway-service, so ExpressGatewayServiceArgs can't reach them. We take the alarm over under the same name instead: PutMetricAlarm is an upsert, so this adopts the AWS-created alarm, and any future rewrite by ECS Express gets reverted on the next pulumi up.

All four production themes run 3 tasks, so all four alarms are affected. cclw is the most exposed at 6.14% 4XX, roughly six times cpr's, and has been passing on timing alone.

## AI attribution
Claude helped a lot both with diagnosing and implementing

## Screenshots
n/a, infra only.

Follow-ups, not in scope:
serve _next/static from a CDN so deploys stop generating 404s at source
enable ALB access logs, currently off, the only way to confirm which URLs 404