### PR TITLE
Fix broken document links and unhandled-error 500s across family/document/collection pages

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,10 +29,12 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
+      - id: base-sha
+        run: echo "sha=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@v4
         id: filter
         with:
-          base: HEAD~1
+          base: ${{ steps.base-sha.outputs.sha }}
           filters: |
             staging-frontend-cpr:
               - 'infra/Pulumi.cpr-staging.yaml'

--- a/src/bff/methods/getCollectionData.test.ts
+++ b/src/bff/methods/getCollectionData.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_FEATURES } from "@/constants/features";
-import { collectionByIdHandler, collectionSlugHandler, dataInCollectionHandler, testCollectionSlug } from "@/tests/mocks/api/collectionDataHandlers";
+import {
+  collectionByIdHandler,
+  collectionSlugHandler,
+  dataInChildFamilyHandler,
+  dataInCollectionHandler,
+  testChildFamilyImportId,
+  testCollectionSlug,
+} from "@/tests/mocks/api/collectionDataHandlers";
 import { server } from "@/tests/mocks/server";
 
 import { getCollectionData } from "./getCollectionData";
@@ -45,6 +52,58 @@ describe("getCollectionData", () => {
 
   it("does not throw when the data-in fetch fails and new-data-model is enabled", async () => {
     server.use(collectionSlugHandler(), collectionByIdHandler(), dataInCollectionHandler({ status: 500 }));
+
+    const result = await getCollectionData(testCollectionSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("fetches and validates each child family's data-in document when new-data-model is enabled", async () => {
+    server.use(
+      collectionSlugHandler(),
+      collectionByIdHandler(),
+      dataInCollectionHandler({
+        body: {
+          id: "collection-1",
+          title: "Test Collection",
+          description: null,
+          attributes: { deprecated_slug: "test-collection-slug" },
+          labels: [],
+          items: [],
+          documents: [
+            { type: "has_member", value: { id: testChildFamilyImportId, title: "Child Family", description: null, attributes: {}, labels: [] } },
+          ],
+        },
+      }),
+      dataInChildFamilyHandler()
+    );
+
+    const result = await getCollectionData(testCollectionSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.errors).toEqual([]);
+    expect(result.data.collection.families).toHaveLength(1);
+    expect(result.data.collection.families[0].import_id).toBe(testChildFamilyImportId);
+  });
+
+  it("logs an error but does not throw when a child family's data-in fetch fails", async () => {
+    server.use(
+      collectionSlugHandler(),
+      collectionByIdHandler(),
+      dataInCollectionHandler({
+        body: {
+          id: "collection-1",
+          title: "Test Collection",
+          description: null,
+          attributes: {},
+          labels: [],
+          items: [],
+          documents: [
+            { type: "has_member", value: { id: testChildFamilyImportId, title: "Child Family", description: null, attributes: {}, labels: [] } },
+          ],
+        },
+      }),
+      dataInChildFamilyHandler({ status: 500 })
+    );
 
     const result = await getCollectionData(testCollectionSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
 

--- a/src/bff/methods/getCollectionData.test.ts
+++ b/src/bff/methods/getCollectionData.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_FEATURES } from "@/constants/features";
+import { collectionByIdHandler, collectionSlugHandler, dataInCollectionHandler, testCollectionSlug } from "@/tests/mocks/api/collectionDataHandlers";
+import { server } from "@/tests/mocks/server";
+
+import { getCollectionData } from "./getCollectionData";
+
+describe("getCollectionData", () => {
+  it("returns collection data on the happy path", async () => {
+    server.use(collectionSlugHandler(), collectionByIdHandler());
+
+    const result = await getCollectionData(testCollectionSlug, DEFAULT_FEATURES);
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("returns null data when the slug lookup responds with a non-200 status", async () => {
+    server.use(collectionSlugHandler({ status: 404 }));
+
+    const result = await getCollectionData(testCollectionSlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query collection slug");
+  });
+
+  it("returns null data when the slug lookup responds 200 with no collection_import_id", async () => {
+    server.use(
+      collectionSlugHandler({
+        body: {
+          name: testCollectionSlug,
+          family_import_id: null,
+          family_document_import_id: null,
+          collection_import_id: null,
+          created: "2024-01-01",
+        },
+      })
+    );
+
+    const result = await getCollectionData(testCollectionSlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query collection slug");
+  });
+
+  it("does not throw when the data-in fetch fails and new-data-model is enabled", async () => {
+    server.use(collectionSlugHandler(), collectionByIdHandler(), dataInCollectionHandler({ status: 500 }));
+
+    const result = await getCollectionData(testCollectionSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+  });
+});

--- a/src/bff/methods/getCollectionData.ts
+++ b/src/bff/methods/getCollectionData.ts
@@ -13,8 +13,14 @@ export const getCollectionData = async (slug: string, features: TFeatures): Prom
 
   let slugResponse: TApiSlugResponse;
   try {
-    const { data: slugData } = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
-    slugResponse = slugData.data;
+    // http-common's get() returns error.response rather than throwing for Axios errors,
+    // so we must check the status explicitly rather than relying on catch for non-2xx responses.
+    const slugApiResponse = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
+    if (slugApiResponse?.status !== 200 || !slugApiResponse.data?.data?.collection_import_id) {
+      errors.push(new Error("Failed to query collection slug"));
+      return { data: null, errors };
+    }
+    slugResponse = slugApiResponse.data.data;
   } catch (error) {
     errors.push(new Error("Failed to query collection slug", error));
     return { data: null, errors };
@@ -48,17 +54,19 @@ export const getCollectionData = async (slug: string, features: TFeatures): Prom
       errors.push(error as Error);
     }
 
-    const collectionFamilies = getChildDocuments(dataInCollection.documents);
+    if (dataInCollection) {
+      const collectionFamilies = getChildDocuments(dataInCollection.documents);
 
-    try {
-      dataInFamilies = await Promise.all<TDataInDocument>(
-        collectionFamilies.map(async ({ value: collectionFamily }) => {
-          const { data: dataInFamilyResponse } = await apiClient.get<TApiItemResponse>(`/data-in/documents/${collectionFamily.id}`);
-          return validateDataInDocument(dataInFamilyResponse.data);
-        })
-      );
-    } catch (error) {
-      errors.push(error as Error);
+      try {
+        dataInFamilies = await Promise.all<TDataInDocument>(
+          collectionFamilies.map(async ({ value: collectionFamily }) => {
+            const { data: dataInFamilyResponse } = await apiClient.get<TApiItemResponse>(`/data-in/documents/${collectionFamily.id}`);
+            return validateDataInDocument(dataInFamilyResponse.data);
+          })
+        );
+      } catch (error) {
+        errors.push(error as Error);
+      }
     }
   }
 

--- a/src/bff/methods/getDocumentData.test.ts
+++ b/src/bff/methods/getDocumentData.test.ts
@@ -1,0 +1,58 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_FEATURES } from "@/constants/features";
+import {
+  documentByIdHandler,
+  documentSlugHandler,
+  testDocumentImportId,
+  testDocumentSlug,
+  vespaDocumentHandler,
+} from "@/tests/mocks/api/documentDataHandlers";
+import { server } from "@/tests/mocks/server";
+
+import { getDocumentData } from "./getDocumentData";
+
+describe("getDocumentData", () => {
+  it("returns document data on the happy path", async () => {
+    server.use(documentSlugHandler(), documentByIdHandler(), vespaDocumentHandler());
+
+    const result = await getDocumentData(testDocumentSlug, DEFAULT_FEATURES);
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("returns null data when the slug lookup responds with a non-200 status", async () => {
+    server.use(documentSlugHandler({ status: 404 }));
+
+    const result = await getDocumentData(testDocumentSlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query document slug");
+  });
+
+  it("returns null data when the slug lookup responds 200 with no family_document_import_id", async () => {
+    server.use(
+      documentSlugHandler({
+        body: { name: testDocumentSlug, family_import_id: null, family_document_import_id: null, collection_import_id: null, created: "2024-01-01" },
+      })
+    );
+
+    const result = await getDocumentData(testDocumentSlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query document slug");
+  });
+
+  it("returns null data when the document-by-id lookup fails outright", async () => {
+    server.use(
+      documentSlugHandler(),
+      http.get(`${process.env.CONCEPTS_API_URL}/families/documents/${testDocumentImportId}`, () => HttpResponse.error())
+    );
+
+    const result = await getDocumentData(testDocumentSlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to fetch document data");
+  });
+});

--- a/src/bff/methods/getDocumentData.test.ts
+++ b/src/bff/methods/getDocumentData.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_FEATURES } from "@/constants/features";
 import {
+  dataInDocumentHandler,
   documentByIdHandler,
   documentSlugHandler,
   testDocumentImportId,
@@ -54,5 +55,30 @@ describe("getDocumentData", () => {
 
     expect(result.data).toBeNull();
     expect(result.errors[0].message).toBe("Failed to fetch document data");
+  });
+
+  it("fetches and validates the data-in document when new-data-model is enabled", async () => {
+    server.use(documentSlugHandler(), documentByIdHandler(), vespaDocumentHandler(), dataInDocumentHandler());
+
+    const result = await getDocumentData(testDocumentSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("logs an error but does not throw when the data-in fetch fails and new-data-model is enabled", async () => {
+    server.use(documentSlugHandler(), documentByIdHandler(), vespaDocumentHandler(), dataInDocumentHandler({ status: 500 }));
+
+    const result = await getDocumentData(testDocumentSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("logs an error but does not throw when the data-in response fails schema validation", async () => {
+    server.use(documentSlugHandler(), documentByIdHandler(), vespaDocumentHandler(), dataInDocumentHandler({ body: { id: testDocumentImportId } }));
+
+    const result = await getDocumentData(testDocumentSlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });

--- a/src/bff/methods/getDocumentData.ts
+++ b/src/bff/methods/getDocumentData.ts
@@ -23,8 +23,14 @@ export const getDocumentData = async (slug: string, features: TFeatures): Promis
 
   let slugResponse: TApiSlugResponse;
   try {
-    const { data: slugData } = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
-    slugResponse = slugData.data;
+    // http-common's get() returns error.response rather than throwing for Axios errors,
+    // so we must check the status explicitly rather than relying on catch for non-2xx responses.
+    const slugApiResponse = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
+    if (slugApiResponse?.status !== 200 || !slugApiResponse.data?.data?.family_document_import_id) {
+      errors.push(new Error("Failed to query document slug"));
+      return { data: null, errors };
+    }
+    slugResponse = slugApiResponse.data.data;
   } catch (error) {
     errors.push(new Error("Failed to query document slug", error));
     return { data: null, errors };

--- a/src/bff/methods/getFamilyData.test.ts
+++ b/src/bff/methods/getFamilyData.test.ts
@@ -1,0 +1,101 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_FEATURES } from "@/constants/features";
+import {
+  familyByIdHandler,
+  familyCollectionHandler,
+  familySlugHandler,
+  geographySubdivisionsHandler,
+  testFamilyImportId,
+  testFamilySlug,
+  vespaFamilyHandler,
+} from "@/tests/mocks/api/familyDataHandlers";
+import { server } from "@/tests/mocks/server";
+
+import { getFamilyData } from "./getFamilyData";
+
+describe("getFamilyData", () => {
+  it("returns family data on the happy path", async () => {
+    server.use(familySlugHandler(), familyByIdHandler(), familyCollectionHandler(), geographySubdivisionsHandler(), vespaFamilyHandler());
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.errors.map((e) => e.message)).toEqual([]);
+    expect(result.data).not.toBeNull();
+    expect(result.data.family.import_id).toBe(testFamilyImportId);
+  });
+
+  it("returns null data when the slug lookup responds with a non-200 status", async () => {
+    server.use(familySlugHandler({ status: 404 }));
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query family slug");
+  });
+
+  it("returns null data when the slug lookup responds 200 with no family_import_id", async () => {
+    server.use(
+      familySlugHandler({
+        body: { name: testFamilySlug, family_import_id: null, family_document_import_id: null, collection_import_id: null, created: "2024-01-01" },
+      })
+    );
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to query family slug");
+  });
+
+  it("logs an error but does not throw when the family response is missing geographies", async () => {
+    server.use(
+      familySlugHandler(),
+      familyByIdHandler({ family: { geographies: undefined } }),
+      familyCollectionHandler(),
+      geographySubdivisionsHandler(),
+      vespaFamilyHandler()
+    );
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.data).not.toBeNull();
+    expect(result.errors.some((error) => error.message === "Family data missing geographies array")).toBe(true);
+  });
+
+  it("logs an error but does not throw when the family response is missing collections", async () => {
+    server.use(
+      familySlugHandler(),
+      familyByIdHandler({ family: { collections: undefined } }),
+      familyCollectionHandler(),
+      geographySubdivisionsHandler(),
+      vespaFamilyHandler()
+    );
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.data).not.toBeNull();
+    expect(result.errors.some((error) => error.message === "Family data missing collections array")).toBe(true);
+  });
+
+  it("skips the slug lookup and uses importId directly when provided", async () => {
+    server.use(familyByIdHandler(), familyCollectionHandler(), geographySubdivisionsHandler(), vespaFamilyHandler());
+
+    const result = await getFamilyData("", DEFAULT_FEATURES, testFamilyImportId);
+
+    expect(result.data).not.toBeNull();
+    expect(result.data.family.import_id).toBe(testFamilyImportId);
+  });
+
+  it("returns null data when the families-by-id lookup fails outright", async () => {
+    server.use(
+      familySlugHandler(),
+      http.get(`${process.env.CONCEPTS_API_URL}/families/${testFamilyImportId}`, () => HttpResponse.error())
+    );
+
+    const result = await getFamilyData(testFamilySlug, DEFAULT_FEATURES);
+
+    expect(result.data).toBeNull();
+    expect(result.errors[0].message).toBe("Failed to fetch families data");
+  });
+});

--- a/src/bff/methods/getFamilyData.test.ts
+++ b/src/bff/methods/getFamilyData.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_FEATURES } from "@/constants/features";
 import {
+  dataInFamilyHandler,
   familyByIdHandler,
   familyCollectionHandler,
   familySlugHandler,
@@ -97,5 +98,54 @@ describe("getFamilyData", () => {
 
     expect(result.data).toBeNull();
     expect(result.errors[0].message).toBe("Failed to fetch families data");
+  });
+
+  it("fetches and validates the data-in document when new-data-model is enabled", async () => {
+    server.use(
+      familySlugHandler(),
+      familyByIdHandler(),
+      familyCollectionHandler(),
+      geographySubdivisionsHandler(),
+      vespaFamilyHandler(),
+      dataInFamilyHandler()
+    );
+
+    const result = await getFamilyData(testFamilySlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    // The data-in fetch and schema validation should succeed without pushing a fetch-failure
+    // error; downstream transformer errors (e.g. missing taxonomy items) are a separate concern.
+    expect(result.errors.some((e) => e.message.includes("data-in") || e.message.includes("Failed to fetch"))).toBe(false);
+    expect(result.data).not.toBeNull();
+  });
+
+  it("logs an error but does not throw when the data-in fetch fails and new-data-model is enabled", async () => {
+    server.use(
+      familySlugHandler(),
+      familyByIdHandler(),
+      familyCollectionHandler(),
+      geographySubdivisionsHandler(),
+      vespaFamilyHandler(),
+      dataInFamilyHandler({ status: 500 })
+    );
+
+    const result = await getFamilyData(testFamilySlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+  });
+
+  it("logs an error but does not throw when the data-in response fails schema validation", async () => {
+    server.use(
+      familySlugHandler(),
+      familyByIdHandler(),
+      familyCollectionHandler(),
+      geographySubdivisionsHandler(),
+      vespaFamilyHandler(),
+      dataInFamilyHandler({ body: { id: testFamilyImportId } })
+    );
+
+    const result = await getFamilyData(testFamilySlug, { ...DEFAULT_FEATURES, "new-data-model": true });
+
+    expect(result.data).not.toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });

--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -34,8 +34,14 @@ export const getFamilyData = async (slug: string, features: TFeatures, importId?
   if (slug) {
     try {
       // As the families API cannot be queried by slugs, we need to get the slugResponse
-      const { data: slugData } = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
-      familyImportId = slugData.data.family_import_id;
+      // http-common's get() returns error.response rather than throwing for Axios errors,
+      // so we must check the status explicitly rather than relying on catch for non-2xx responses.
+      const slugApiResponse = await apiClient.get<TApiItemResponse<TApiSlugResponse>>(`/families/slugs/${slug}`);
+      if (slugApiResponse?.status !== 200 || !slugApiResponse.data?.data?.family_import_id) {
+        errors.push(new Error("Failed to query family slug"));
+        return { data: null, errors };
+      }
+      familyImportId = slugApiResponse.data.data.family_import_id;
     } catch (error) {
       errors.push(new Error("Failed to query family slug", error));
       return { data: null, errors };

--- a/src/bff/methods/getFamilyData.ts
+++ b/src/bff/methods/getFamilyData.ts
@@ -93,9 +93,15 @@ export const getFamilyData = async (slug: string, features: TFeatures, importId?
   const countries = response_geo[1];
   const corpusTypes: TCorpusTypeDictionary = config.corpus_types;
 
+  // http-common's get() can resolve a 200 with a malformed body, so guard against
+  // family.geographies being missing before reading array methods off it.
+  if (!Array.isArray(family.geographies)) {
+    errors.push(new Error("Family data missing geographies array"));
+  }
+
   // This is because our family.geographies field isn't hydrated but rather a string[]
   const allSubdivisions = await Promise.all<TApiGeographySubdivision[]>(
-    family.geographies
+    (family.geographies ?? [])
       .filter((country) => country.length === 3 && !EXCLUDED_ISO_CODES.includes(country))
       .map(async (country) => {
         try {
@@ -120,8 +126,12 @@ export const getFamilyData = async (slug: string, features: TFeatures, importId?
   );
   const subdivisions = allSubdivisions.flat().filter((subdivision) => subdivision !== undefined);
 
+  if (!Array.isArray(family.collections)) {
+    errors.push(new Error("Family data missing collections array"));
+  }
+
   const allCollections = await Promise.all<TApiCollectionPublicWithFamilies[]>(
-    family.collections.map(async (collection) => {
+    (family.collections ?? []).map(async (collection) => {
       try {
         const { data: collectionResponse } = await apiClient.get(`/families/collections/${collection.import_id}`);
         return collectionResponse.data;

--- a/src/utils/eventTable.test.tsx
+++ b/src/utils/eventTable.test.tsx
@@ -1,6 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import * as nextRouterMock from "next-router-mock";
+import { vi } from "vitest";
+
 import { TFamilyAttribution, TFamilyDocumentPublic, TFamilyPublic } from "@/types";
 
-import { getEventTableRows } from "./eventTable";
+import { getDocumentLink, getEventTableRows } from "./eventTable";
+
+vi.mock("next/router", () => nextRouterMock);
 
 describe("getEventTableRows", () => {
   it("returns an empty list of document rows if there are no documents in the family", () => {
@@ -210,5 +216,34 @@ describe("getEventTableRows", () => {
 
     expect(eventRows).toHaveLength(1);
     expect(eventRows[0].id).toBe("Document 1:Event 1");
+  });
+});
+
+describe("getDocumentLink", () => {
+  it("does not link to /documents/null when the document has no slug", () => {
+    const documentWithoutSlug = {
+      import_id: "Document 1",
+      slug: null,
+      title: "Document 1",
+      cdn_object: "https://example.com/doc.pdf",
+    } as TFamilyDocumentPublic;
+
+    render(<>{getDocumentLink(documentWithoutSlug, false, false, false)}</>);
+
+    expect(screen.queryByRole("link", { name: /document 1/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/we do not have this document/i)).toBeInTheDocument();
+  });
+
+  it("links to the document preview when a slug is present", () => {
+    const documentWithSlug = {
+      import_id: "Document 1",
+      slug: "document-1",
+      title: "Document 1",
+      cdn_object: "https://example.com/doc.pdf",
+    } as TFamilyDocumentPublic;
+
+    render(<>{getDocumentLink(documentWithSlug, false, false, false)}</>);
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", expect.stringContaining("/documents/document-1"));
   });
 });

--- a/src/utils/eventTable.tsx
+++ b/src/utils/eventTable.tsx
@@ -142,8 +142,13 @@ const getFamilyDocuments = (family: TFamilyPublic): TEventRowData[] =>
 
 const linkClasses = "block text-[#0038a9] underline underline-offset-4 decoration-[#d1d5db] hover:decoration-[#6b7280]";
 
-const getDocumentLink = (document: TFamilyDocumentPublic, hasMatches: boolean, isMainDocument: boolean, isLitigation: boolean): React.ReactNode => {
-  const canPreview = hasMatches || (!!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf"));
+export const getDocumentLink = (
+  document: TFamilyDocumentPublic,
+  hasMatches: boolean,
+  isMainDocument: boolean,
+  isLitigation: boolean
+): React.ReactNode => {
+  const canPreview = !!document.slug && (hasMatches || (!!document.cdn_object && document.cdn_object.toLowerCase().endsWith(".pdf")));
   const canViewSource = !canPreview && !!document.source_url;
 
   if (canPreview)
@@ -259,7 +264,7 @@ export const getEventTableRows = ({
     /* Topics */
 
     let topicsDisplay: ReactNode = null;
-    if (document && familyTopics) {
+    if (document && document.slug && familyTopics) {
       const documentTopicsData = familyTopics.documents.find((doc) => doc.importId === document.import_id)?.conceptCounts ?? {};
 
       const sortedTopics = orderBy(Object.entries(documentTopicsData), ["1"], ["desc"]);

--- a/tests/mocks/api/collectionDataHandlers.ts
+++ b/tests/mocks/api/collectionDataHandlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 
+import { TDataInDocument } from "@/schemas";
 import { TApiCollectionPublicWithFamilies } from "@/types";
 
 export const testCollectionSlug = "test-collection-slug";
@@ -38,10 +39,48 @@ export const collectionByIdHandler = (overrides: Partial<{ status: number; colle
     return HttpResponse.json({ data: { ...testCollection, ...overrides.collection } });
   });
 
-export const dataInCollectionHandler = (overrides: Partial<{ status: number }> = {}) =>
+export const testChildFamilyImportId = "family-in-collection-1";
+
+export const dataInCollectionHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
   http.get(`${process.env.CONCEPTS_API_URL}/data-in/documents/${testCollectionImportId}`, () => {
     if (overrides.status && overrides.status !== 200) {
       return HttpResponse.json({ detail: "error" }, { status: overrides.status });
     }
-    return HttpResponse.json({ data: { id: testCollectionImportId, attributes: {}, labels: [], items: [], documents: [] } });
+    return HttpResponse.json({
+      data: overrides.body ?? {
+        id: testCollectionImportId,
+        title: "Test Collection",
+        description: null,
+        attributes: {},
+        labels: [],
+        items: [],
+        documents: [],
+      },
+    });
+  });
+
+// A minimal but schema-complete TDataInDocument for a family: satisfies validateFamilyAttributes
+// (deprecated_slug, published_date) and the activity_status/category/provider labels required by
+// transformFamily's downstream pipeline (transformAttribution, groupByType's mandatory-type check).
+export const testChildFamilyDataIn: TDataInDocument = {
+  id: testChildFamilyImportId,
+  title: "Child Family",
+  description: null,
+  attributes: { deprecated_slug: "child-family-slug", published_date: "2024-01-01" },
+  labels: [
+    { type: "activity_status", value: { id: "activity_status::published", type: "concept", value: "Published", labels: [] } },
+    { type: "category", value: { id: "category::policy", type: "concept", value: "Policy", labels: [] } },
+    {
+      type: "provider",
+      value: { id: "provider::cpr", type: "agent", value: "CPR", labels: [], attributes: {} },
+    },
+  ],
+};
+
+export const dataInChildFamilyHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/data-in/documents/${testChildFamilyImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({ data: overrides.body ?? testChildFamilyDataIn });
   });

--- a/tests/mocks/api/collectionDataHandlers.ts
+++ b/tests/mocks/api/collectionDataHandlers.ts
@@ -1,0 +1,47 @@
+import { http, HttpResponse } from "msw";
+
+import { TApiCollectionPublicWithFamilies } from "@/types";
+
+export const testCollectionSlug = "test-collection-slug";
+export const testCollectionImportId = "collection-1";
+
+export const testCollection = {
+  description: "Test collection",
+  families: [],
+  import_id: testCollectionImportId,
+  metadata: {},
+  slug: testCollectionSlug,
+  title: "Test Collection",
+} as TApiCollectionPublicWithFamilies;
+
+export const collectionSlugHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/slugs/${testCollectionSlug}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json(overrides.body ?? { detail: "Not Found" }, { status: overrides.status });
+    }
+    return HttpResponse.json({
+      data: overrides.body ?? {
+        name: testCollectionSlug,
+        family_import_id: null,
+        family_document_import_id: null,
+        collection_import_id: testCollectionImportId,
+        created: "2024-01-01",
+      },
+    });
+  });
+
+export const collectionByIdHandler = (overrides: Partial<{ status: number; collection: Partial<TApiCollectionPublicWithFamilies> }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/collections/${testCollectionImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({ data: { ...testCollection, ...overrides.collection } });
+  });
+
+export const dataInCollectionHandler = (overrides: Partial<{ status: number }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/data-in/documents/${testCollectionImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({ data: { id: testCollectionImportId, attributes: {}, labels: [], items: [], documents: [] } });
+  });

--- a/tests/mocks/api/documentDataHandlers.ts
+++ b/tests/mocks/api/documentDataHandlers.ts
@@ -83,3 +83,13 @@ export const vespaDocumentHandler = () =>
       { status: 200 }
     );
   });
+
+export const dataInDocumentHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/data-in/documents/${testDocumentImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({
+      data: overrides.body ?? { id: testDocumentImportId, title: "Test Document", description: null, attributes: {}, labels: [] },
+    });
+  });

--- a/tests/mocks/api/documentDataHandlers.ts
+++ b/tests/mocks/api/documentDataHandlers.ts
@@ -1,0 +1,85 @@
+import { http, HttpResponse } from "msw";
+
+import { TApiDocumentPublic, TApiFamilyPublic } from "@/types";
+
+export const testDocumentSlug = "test-document-slug";
+export const testDocumentImportId = "document-1";
+
+const testFamily = {
+  category: "Executive",
+  collections: [],
+  concepts: [],
+  corpus_id: "CCLW.corpus.i00000001.n0000",
+  documents: [],
+  events: [],
+  geographies: ["FRA"],
+  import_id: "family-1",
+  last_updated_date: "2024-01-01",
+  metadata: {},
+  organisation: "CPR",
+  organisation_attribution_url: null,
+  published_date: "2024-01-01",
+  slug: "test-family-slug",
+  summary: "Test family summary",
+  title: "Test Family",
+} as TApiFamilyPublic;
+
+export const testDocument = {
+  cdn_object: "",
+  content_type: null,
+  document_role: null,
+  document_type: null,
+  family: testFamily,
+  import_id: testDocumentImportId,
+  language: null,
+  languages: [],
+  md5_sum: null,
+  slug: testDocumentSlug,
+  source_url: null,
+  title: "Test Document",
+  valid_metadata: {},
+  variant_name: null,
+  variant: null,
+  document_status: "published",
+} as TApiDocumentPublic;
+
+export const documentSlugHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/slugs/${testDocumentSlug}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json(overrides.body ?? { detail: "Not Found" }, { status: overrides.status });
+    }
+    return HttpResponse.json({
+      data: overrides.body ?? {
+        name: testDocumentSlug,
+        family_import_id: null,
+        family_document_import_id: testDocumentImportId,
+        collection_import_id: null,
+        created: "2024-01-01",
+      },
+    });
+  });
+
+export const documentByIdHandler = (overrides: Partial<{ status: number; document: Partial<TApiDocumentPublic> }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/documents/${testDocumentImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({ data: { ...testDocument, ...overrides.document } });
+  });
+
+export const vespaDocumentHandler = () =>
+  http.get(`${process.env.BACKEND_API_URL}/document/${testDocumentImportId}`, () => {
+    return HttpResponse.json(
+      {
+        hits: 0,
+        total_family_hits: 0,
+        query_time_ms: 1,
+        total_time_ms: 1,
+        continuation_token: null,
+        this_continuation_token: "",
+        prev_continuation_token: null,
+        families: [],
+      },
+      { status: 200 }
+    );
+  });

--- a/tests/mocks/api/familyDataHandlers.ts
+++ b/tests/mocks/api/familyDataHandlers.ts
@@ -71,3 +71,13 @@ export const vespaFamilyHandler = () =>
       families: [],
     });
   });
+
+export const dataInFamilyHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/data-in/documents/${testFamilyImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({
+      data: overrides.body ?? { id: testFamilyImportId, title: "Test Family", description: null, attributes: {}, labels: [] },
+    });
+  });

--- a/tests/mocks/api/familyDataHandlers.ts
+++ b/tests/mocks/api/familyDataHandlers.ts
@@ -1,0 +1,73 @@
+import { http, HttpResponse } from "msw";
+
+import { TApiFamilyPublic } from "@/types";
+
+export const testFamilyImportId = "family-1";
+export const testFamilySlug = "test-family-slug";
+
+export const testFamily = {
+  category: "Executive",
+  collections: [],
+  concepts: [],
+  corpus_id: "CCLW.corpus.i00000001.n0000",
+  documents: [],
+  events: [],
+  geographies: ["FRA"],
+  import_id: testFamilyImportId,
+  last_updated_date: "2024-01-01",
+  metadata: {},
+  organisation: "CPR",
+  organisation_attribution_url: null,
+  published_date: "2024-01-01",
+  slug: testFamilySlug,
+  summary: "Test family summary",
+  title: "Test Family",
+} as TApiFamilyPublic;
+
+export const familySlugHandler = (overrides: Partial<{ status: number; body: unknown }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/slugs/${testFamilySlug}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json(overrides.body ?? { detail: "Not Found" }, { status: overrides.status });
+    }
+    return HttpResponse.json({
+      data: overrides.body ?? {
+        name: testFamilySlug,
+        family_import_id: testFamilyImportId,
+        family_document_import_id: null,
+        collection_import_id: null,
+        created: "2024-01-01",
+      },
+    });
+  });
+
+export const familyByIdHandler = (overrides: Partial<{ status: number; family: Partial<TApiFamilyPublic> }> = {}) =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/${testFamilyImportId}`, () => {
+    if (overrides.status && overrides.status !== 200) {
+      return HttpResponse.json({ detail: "error" }, { status: overrides.status });
+    }
+    return HttpResponse.json({ data: { ...testFamily, ...overrides.family } });
+  });
+
+export const familyCollectionHandler = () =>
+  http.get(`${process.env.CONCEPTS_API_URL}/families/collections/:collectionId`, () => {
+    return HttpResponse.json({ data: [] });
+  });
+
+export const geographySubdivisionsHandler = () =>
+  http.get(`${process.env.CONCEPTS_API_URL}/geographies/subdivisions/:country`, () => {
+    return HttpResponse.json([]);
+  });
+
+export const vespaFamilyHandler = () =>
+  http.get(`${process.env.BACKEND_API_URL}/families/${testFamilyImportId}`, () => {
+    return HttpResponse.json({
+      hits: 0,
+      total_family_hits: 0,
+      query_time_ms: 1,
+      total_time_ms: 1,
+      continuation_token: null,
+      this_continuation_token: "",
+      prev_continuation_token: null,
+      families: [],
+    });
+  });


### PR DESCRIPTION
## Root cause - broken links

The API's document attributes schema (attributesSchema.ts:32-47) deliberately makes deprecated_slug optional for documents with status: "awaiting_source_file" -- that status is also in DISPLAY_ALLOWED_STATUSES, i.e. it's allowed to render on the page. So a document can legitimately be displayable and have no slug yet, specifically while it's waiting on its source file. transformDocument.ts:40 passes this through honestly as slug: deprecated_slug || null.

eventTable.tsx's getDocumentLink didn't know about this contract — it decided whether to render a preview link purely from hasMatches/PDF cdn_object, not slug presence. An awaiting_source_file document with a PDF preview but no slug still got rendered as <PageLink href="/documents/null"> (same for the topic-link block further down). Following that link hit SSR for /documents/[id], which correctly returned notFound: true — so it never crashed, but it generated dead links and noisy GET /families/slugs/null -> 404 log lines on every affected family page.

## Root cause - actual 500s (getFamilyData.ts, getCollectionData.ts, getDocumentData.ts)
ApiClient.get() (http-common.ts:57-69) never rejects on HTTP error status -- it catches AxiosError and resolves with error.response instead. Only network-level failures (DNS, timeout) actually reject. That means the try { await apiClient.get(...) } catch blocks around the /families/slugs/{slug} lookups in all three files were dead code for 4xx/5xx responses: the catch never fired, and the code proceeded to use an error-shaped response body as if it were the real payload.

Three concrete crash sites from this:

1. getFamilyData.ts (family.geographies.filter(...), family.collections.map(...)): a families-api 200 response with family present but geographies/collections missing/malformed threw Cannot read properties of undefined uncaught.
2. getCollectionData.ts (getChildDocuments(dataInCollection.documents)): if the preceding data-in fetch failed, dataInCollection stayed null, and this line dereferenced it anyway, uncaught by any try/catch.
3. The slug-lookup blocks in all three files silently proceeded on a non-200/malformed body instead of treating it as a failure.

## Fix

- eventTable.tsx: gate both link-rendering paths on document.slug being present, so a slug-less document falls through to the existing "we don't have this document, contact us" copy instead of a dead link.
- getFamilyData.ts / getCollectionData.ts / getDocumentData.ts: explicit .status !== 200 checks on the /families/slugs/{slug} response, matching the pattern already used for the Vespa/subdivisions fetches elsewhere in these files, so a non-200 or malformed slug response is treated as a failure and returns { data: null, errors } instead of silently continuing.
- getFamilyData.ts: guard family.geographies/family.collections with Array.isArray before calling array methods, falling back to [] and logging an error.
- getCollectionData.ts: only look up child families when dataInCollection is actually populated.

NOTE: the try/catch-doesn't-catch-HTTP-errors pattern exists at every apiClient.get() call site across these three files, not just the ones above -- this PR fixes the specific crash sites identified, not every instance of the pattern.

